### PR TITLE
Add flock_py: heavily-commented educational Python port of Flock

### DIFF
--- a/paper/flock_py/README.md
+++ b/paper/flock_py/README.md
@@ -26,6 +26,8 @@ python3 flock_perf.py     # wall-clock: batch proving vs K-times separate provin
 Some environments (e.g. conda) print harmless `OMP`/`numba`/`TBB` warnings to
 stderr on import; ignore them (or append `2>/dev/null`).
 
+Running `test_flock.py` doubles as a guided tour of the protocol: each section pretty-prints the actual math it verifies - field arithmetic, the eq weights, every sumcheck round's message/check/challenge, the PCS opening, and a phase-by-phase replay of the whole verifier - using worked examples small enough to redo by hand.
+
 ## What it proves
 
 - **Base circuit F** (one AND gate): `a * b = c` over F2, witness `z0 = [1, a, b, c]`.
@@ -89,3 +91,32 @@ Two classic `galois` traps, documented where they bite in the code:
 - breaking the chain (valid gates, but `out_i != x_{i+1}`) -> **glue** rejects;
 - tampering a PCS evaluation or a committed column -> **PCS** rejects;
 - tampering a sumcheck message -> **sumcheck** rejects.
+
+## Benchmark results
+
+Verbatim output of `python3 flock_perf.py` (single run on an otherwise idle machine):
+
+```text
+   K | prove batch  prove sep speedup | verify batch verify sep speedup | #proofs b/s
+--------------------------------------------------------------------------------------------
+   2 |      23.3ms     22.7ms   0.97x |      213.6ms    284.5ms   1.33x |    1/2
+   4 |      31.2ms     45.9ms   1.47x |      287.0ms    567.9ms   1.98x |    1/4
+   8 |      44.7ms     88.1ms   1.97x |      355.7ms   1106.8ms   3.11x |    1/8
+  16 |      80.7ms    168.4ms   2.09x |      456.6ms   2208.6ms   4.84x |    1/16
+  32 |     173.5ms    363.9ms   2.10x |      593.2ms   4447.3ms   7.50x |    1/32
+  64 |     463.3ms    702.5ms   1.52x |      903.3ms   8863.5ms   9.81x |    1/64
+
+note: SEPARATE cannot prove the hash-chain (out_i = x_{i+1}) - that
+cross-instance binding exists only in the BATCH witness (glue G).
+```
+
+The paper's headline survives even in unoptimized Python: one batch proof beats K separate proofs (prove up to ~2.1x, verify up to ~9.8x at K = 64), the verifier checks 1 proof instead of K, and the K separate proofs cannot express the cross-instance chain at all.
+
+**Hardware:** MacBook Pro, Apple M1 Max - 10 cores (8 performance + 2 efficiency), 64 GB RAM, macOS 15.7.4; Python 3.8.5 (conda) with `galois` 0.4.10, `numpy` 1.24.4.
+
+**Available memory at run time** (captured immediately before the run, 2026-07-02 11:33 +0800):
+
+- `memory_pressure`: system-wide memory free percentage 42% (~27 GB of the 64 GB available).
+- `vm_stat` (16 KiB pages): 3,734 pages free plus 875,469 pages inactive (~13.4 GB directly reclaimable).
+  macOS deliberately keeps raw free pages near zero and reclaims inactive/compressed memory on demand, so `memory_pressure`'s 42% is the meaningful availability figure.
+- `sysctl hw.memsize`: 68,719,476,736 bytes (64 GB) total.

--- a/paper/flock_py/README.md
+++ b/paper/flock_py/README.md
@@ -1,0 +1,92 @@
+# Flock in Python - a pedagogical end-to-end implementation
+
+A from-scratch, readable Python port of **Flock** - the protocol in
+`../flock-paper.pdf`, implemented for real in this repo's Rust crates
+(`crates/flock-core`, `crates/flock-prover`) - written as an educational
+reference in the RareSkills style: `galois` + `numpy`, heavy comments,
+correctness over performance. Read it next to the paper to understand *what*
+the protocol does; read the Rust to see *how* to make it fast.
+
+It proves a **batch of AND-gates wired into a hash-chain**, over the paper's own
+field `GF(2^128)` (GHASH polynomial `x^128 + x^7 + x^2 + x + 1`), with a **real
+hash-based polynomial commitment** (Ligero/Brakedown style, SHA-256 Merkle + Reed-
+Solomon). The only cryptographic assumption is SHA-256 - so, like Flock, it is
+transparent and post-quantum (no pairings, no trusted setup).
+
+## Running
+
+Requires Python 3 with [`galois`](https://github.com/mhostetter/galois) and `numpy`:
+
+```bash
+pip install galois numpy
+
+python3 test_flock.py     # full test suite (math, PCS, end-to-end, soundness)
+python3 flock_perf.py     # wall-clock: batch proving vs K-times separate proving
+```
+
+Some environments (e.g. conda) print harmless `OMP`/`numba`/`TBB` warnings to
+stderr on import; ignore them (or append `2>/dev/null`).
+
+## What it proves
+
+- **Base circuit F** (one AND gate): `a * b = c` over F2, witness `z0 = [1, a, b, c]`.
+- **Batch** (`K = 2^k` instances): `A = I_K (x) A0`, so `(Az) o (Bz) = Cz` holds iff
+  every instance's gate is satisfied.
+- **Glue G** (hash-chain): `out_i = x_{i+1}` for all `i`, i.e. each gate's output is
+  the next gate's input. Enforced as `Gz = 0`.
+
+## Module map (to the paper)
+
+| File | Role | Paper |
+|------|------|-------|
+| `field.py` | `GF(2^128)` via the GHASH irreducible polynomial | S4.3 |
+| `mle.py` | multilinear extension, `eq` polynomial, variable folding | S2.1 |
+| `transcript.py` | Fiat-Shamir over SHA-256 (challenges in F) | S1.1 security |
+| `sumcheck.py` | generic sumcheck prover/verifier | S2.3 |
+| `pcs.py` | hash-based multilinear PCS (Ligero: Merkle + Reed-Solomon) | S2.4, App. C |
+| `r1cs.py` | batched AND-gate R1CS (`I_K (x) A0`) + glue matrix G | S3, S4.1, S4.6 |
+| `flock.py` | end-to-end: commit -> zerocheck -> lincheck -> glue -> open | S3-S4 |
+| `flock_perf.py` | batch vs K-separate wall-clock comparison | S1, S5 |
+| `test_flock.py` | correctness + soundness test suite | - |
+
+## Protocol pipeline (`flock.py`)
+
+1. **Commit** the witness MLE `z_hat` with the PCS.
+2. **Zerocheck**: `sum_i eq(r,i) * (a[i]*b[i] - c[i]) = 0` where `a=Az, b=Bz, c=Cz`
+   - the rank-1 (Hadamard) constraint. Sumcheck of degree 3.
+3. **Lincheck**: reduce the three claims `a(r_y), b(r_y), c(r_y)` to a single claim on
+   `z_hat`, batched with a random `alpha`. Uses the block-diagonal collapse (S4.1):
+   the matrix marginal is computed on the small base matrix `A0`, not the K-times
+   larger `A`.
+4. **Glue**: prove the hash-chain `Gz = 0`, yielding another `z_hat` claim (S4.6).
+5. **Open** `z_hat` at the lincheck and glue points; the PCS values must match the
+   claims the sumchecks produced.
+
+All steps share one SHA-256 transcript, so `prove()` returns a non-interactive proof.
+
+## What is deliberately simplified
+
+This is a teaching artifact, not the optimized Rust prover. It omits the S4
+performance work whose point is CPU/cache behavior (invisible in Python):
+**univariate skip** (S4.2), **friendly challenges** (S4.3 geometric progression),
+**circuit walking** (S4.5), and the **ring-switching** dense->Boolean PCS transform
+(App. B). The glue uses a generic linear check rather than Flock's tailored shift
+argument. The protocol *structure* and soundness logic, however, are faithful.
+
+## Implementation notes (galois pitfalls)
+
+Two classic `galois` traps, documented where they bite in the code:
+
+- **In-place ops mutate shared constants.** Galois scalars are 0-d numpy arrays,
+  so `acc = ONE; acc *= y` silently corrupts the global `ONE`. Always accumulate
+  from a fresh `GF(1)` with non-in-place ops (see `field.py`, `sumcheck.py`).
+- **Field elements are not integers.** Bit tables must be lifted with `GF(...)`
+  before arithmetic, and `GF([...])` construction wants plain ints, not 0-d
+  galois scalars - hence the explicit `int(...)` round-trips (see `transcript.py`).
+
+## Soundness demonstrated (`test_flock.py`)
+
+- corrupting an AND-gate output -> **zerocheck** rejects;
+- breaking the chain (valid gates, but `out_i != x_{i+1}`) -> **glue** rejects;
+- tampering a PCS evaluation or a committed column -> **PCS** rejects;
+- tampering a sumcheck message -> **sumcheck** rejects.

--- a/paper/flock_py/README.md
+++ b/paper/flock_py/README.md
@@ -2,9 +2,8 @@
 
 A from-scratch, readable Python port of **Flock** - the protocol in
 `../flock-paper.pdf`, implemented for real in this repo's Rust crates
-(`crates/flock-core`, `crates/flock-prover`) - written as an educational
-reference in the RareSkills style: `galois` + `numpy`, heavy comments,
-correctness over performance. Read it next to the paper to understand *what*
+(`crates/flock-core`, `crates/flock-prover`) - written as a heavily-commented
+educational reference: `galois` + `numpy`, correctness over performance. Read it next to the paper to understand *what*
 the protocol does; read the Rust to see *how* to make it fast.
 
 It proves a **batch of AND-gates wired into a hash-chain**, over the paper's own

--- a/paper/flock_py/field.py
+++ b/paper/flock_py/field.py
@@ -1,0 +1,37 @@
+"""
+field.py - the binary field F = GF(2^128) that Flock computes in.
+
+The paper works over F2 (bits) for the *data* (witness, matrices) and lifts to
+the big extension field F = F_{2^128} for the verifier's random challenges, which
+is where soundness comes from (Schwartz-Zippel over a large field).
+
+galois has no Conway polynomial for degree 128, so we hand it the same
+irreducible polynomial the paper uses: the GHASH polynomial
+
+    x^128 + x^7 + x^2 + x + 1.
+
+Everything downstream imports GF from here so the whole codebase shares one field.
+"""
+
+import galois
+
+# The GHASH reduction polynomial, exactly as in the Flock paper (section 4.3).
+IRREDUCIBLE = "x^128 + x^7 + x^2 + x + 1"
+
+# verify=False: skip galois's primitivity check. We only need a *field* (the poly
+# is irreducible); we never rely on the chosen element being a multiplicative
+# generator, so primitivity is irrelevant here.
+GF = galois.GF(2**128, irreducible_poly=IRREDUCIBLE, verify=False)
+
+# Shared field constants. CAUTION (classic galois trap): galois scalars are 0-d
+# numpy arrays, so in-place operators mutate them. Never write `acc = ONE` and
+# then `acc *= y` - that silently corrupts the global ONE for the whole program.
+# Always start accumulators from a fresh GF(0)/GF(1) and use non-in-place ops
+# (`acc = acc * y`). See sumcheck._lagrange_interpolate_eval for an example.
+ZERO = GF(0)
+ONE = GF(1)
+
+
+def bit(b):
+    """Lift a Python 0/1 into the field as the subfield element 0 or 1."""
+    return ONE if b else ZERO

--- a/paper/flock_py/flock.py
+++ b/paper/flock_py/flock.py
@@ -1,0 +1,158 @@
+"""
+flock.py - the end-to-end Flock PIOP (prover + verifier), pedagogical edition.
+
+Pipeline (mirrors the paper's protocol, sections 3-4):
+
+  1. Commit   : PCS-commit the witness MLE z_hat            (section 3, step 1)
+  2. Zerocheck: sum_i eq(r,i)*(a[i]*b[i] - c[i]) = 0        (the rank-1 / Hadamard
+                where a=Az, b=Bz, c=Cz                        constraint, section 3)
+  3. Lincheck : reduce a(r_y),b(r_y),c(r_y) to ONE z-claim  (batched via alpha,
+                using the block-diagonal collapse of 4.1)      sections 3, 4.1
+  4. Glue     : prove the hash-chain Gz = 0 -> a z-claim     (section 4.6)
+  5. Open     : PCS-open z_hat at the lincheck & glue points (section 3, step 5)
+
+Everything is Fiat-Shamir'd through one shared SHA-256 transcript, so prove()
+returns a self-contained non-interactive proof that verify() checks.
+
+Sizes here are tiny for clarity; the structure is exactly the paper's.
+"""
+
+import numpy as np
+from field import GF
+from mle import eq_vector, eval_mle, num_vars
+from transcript import Transcript
+import sumcheck
+import pcs
+import r1cs
+
+
+def _combine_zerocheck(ts):
+    """Zerocheck summand eq(r,b) * (a(b)*b(b) - c(b)); each factor is multilinear,
+    so a single variable appears in at most 3 factors -> degree 3 per round."""
+    eqw, a, b, c = ts
+    return eqw * (a * b - c)              # degree 3 in the bound variable
+
+
+def _combine_product(ts):
+    """Lincheck / glue summand eta(b) * z(b): two multilinear factors -> degree 2."""
+    eta, z = ts
+    return eta * z                        # degree 2 (lincheck / glue marginal)
+
+
+def _matrix_marginals(r_y, K):
+    """
+    eq-weighted column marginals eta_M = eq_vector(r_y) @ (I_K (x) M0), computed via
+    the block-diagonal collapse: eta_M = (E @ M0).flatten with E = eq(r_y) as K x BASE.
+    Returns (etaA, etaB, etaC), each a length-2^m table. (Paper section 4.1: the
+    outer K rows contribute only a cheap eq-factor; work is on the small base M0.)
+    """
+    E = eq_vector(r_y).reshape(K, r1cs.BASE)
+    A0 = GF(r1cs.A0.astype(np.int64))
+    B0 = GF(r1cs.B0.astype(np.int64))
+    C0 = GF(r1cs.C0.astype(np.int64))
+    etaA = (E @ A0).reshape(-1)
+    etaB = (E @ B0).reshape(-1)
+    etaC = (E @ C0).reshape(-1)
+    return etaA, etaB, etaC
+
+
+def prove(z_bits, K):
+    z = GF(z_bits.astype(np.int64))
+    m = num_vars(z)
+    tr = Transcript()
+
+    # 1. commit to the witness
+    pcs_prover, cm = pcs.commit(z)
+    tr.absorb_bytes(cm.root)
+
+    # the three sides of the constraint, a=Az, b=Bz, c=Cz (block-diagonal apply)
+    a = r1cs.apply_base(r1cs.A0, z_bits, K)
+    b = r1cs.apply_base(r1cs.B0, z_bits, K)
+    c = r1cs.apply_base(r1cs.C0, z_bits, K)
+
+    # 2. zerocheck: prove a o b - c vanishes on the hypercube
+    r = tr.challenge_vec(m)
+    eqw = eq_vector(r)
+    zc_rounds, r_y, zc_final = sumcheck.prove([eqw, a, b, c], 3, _combine_zerocheck, tr)
+    _, va, vb, vc = zc_final                    # a(r_y), b(r_y), c(r_y)
+    tr.absorb_fe_list([va, vb, vc])
+
+    # 3. lincheck: batch the three claims and reduce to a single z-claim
+    alpha = tr.challenge_vec(3)
+    etaA, etaB, etaC = _matrix_marginals(r_y, K)
+    eta = alpha[0] * etaA + alpha[1] * etaB + alpha[2] * etaC
+    # (the prover never sends this claim - the verifier recomputes it from
+    # va,vb,vc itself; shown here to mirror the verify() side line for line)
+    lc_claim = alpha[0] * va + alpha[1] * vb + alpha[2] * vc
+    lc_rounds, r_x, lc_final = sumcheck.prove([eta, z], 2, _combine_product, tr)
+    _, z_rx = lc_final                           # z(r_x)
+    tr.absorb_fe(z_rx)
+
+    # 4. glue: prove the hash-chain Gz = 0 -> another z-claim
+    G = r1cs.glue_matrix(K)
+    tau = tr.challenge_vec(m)
+    etaG = eq_vector(tau) @ G
+    g_rounds, r_g, g_final = sumcheck.prove([etaG, z], 2, _combine_product, tr)
+    _, z_rg = g_final                            # z(r_g)
+    tr.absorb_fe(z_rg)
+
+    # 5. open the committed witness at both points the protocol landed on
+    open_x = pcs.open(pcs_prover, r_x, tr)
+    open_g = pcs.open(pcs_prover, r_g, tr)
+
+    return {
+        "cm": cm, "m": m, "K": K,
+        "zc_rounds": zc_rounds, "va": va, "vb": vb, "vc": vc,
+        "lc_rounds": lc_rounds, "z_rx": z_rx,
+        "g_rounds": g_rounds, "z_rg": z_rg,
+        "open_x": open_x, "open_g": open_g,
+    }
+
+
+def verify(proof):
+    cm = proof["cm"]
+    m = proof["m"]
+    K = proof["K"]
+    tr = Transcript()
+    tr.absorb_bytes(cm.root)
+
+    # 2. zerocheck (initial claim 0: the summand must vanish on the whole cube)
+    r = tr.challenge_vec(m)
+    r_y, zc_expected = sumcheck.verify(proof["zc_rounds"], 3, GF(0), tr)
+    va, vb, vc = GF(proof["va"]), GF(proof["vb"]), GF(proof["vc"])
+    tr.absorb_fe_list([va, vb, vc])
+    # final point: eq(r, r_y) * (va*vb - vc) must equal the folded sumcheck value
+    e_ry = eval_mle(eq_vector(r), r_y)
+    if e_ry * (va * vb - vc) != zc_expected:
+        raise ValueError("zerocheck: final point relation failed")
+
+    # 3. lincheck: recompute the (public) matrix marginals and check the z-claim
+    alpha = tr.challenge_vec(3)
+    etaA, etaB, etaC = _matrix_marginals(r_y, K)
+    eta = alpha[0] * etaA + alpha[1] * etaB + alpha[2] * etaC
+    lc_claim = alpha[0] * va + alpha[1] * vb + alpha[2] * vc
+    r_x, lc_expected = sumcheck.verify(proof["lc_rounds"], 2, lc_claim, tr)
+    z_rx = GF(proof["z_rx"])
+    tr.absorb_fe(z_rx)
+    if eval_mle(eta, r_x) * z_rx != lc_expected:
+        raise ValueError("lincheck: final point relation failed")
+
+    # 4. glue: recompute G's marginal at tau and check the chain z-claim
+    G = r1cs.glue_matrix(K)
+    tau = tr.challenge_vec(m)
+    etaG = eq_vector(tau) @ G
+    r_g, g_expected = sumcheck.verify(proof["g_rounds"], 2, GF(0), tr)
+    z_rg = GF(proof["z_rg"])
+    tr.absorb_fe(z_rg)
+    if eval_mle(etaG, r_g) * z_rg != g_expected:
+        raise ValueError("glue: final point relation failed")
+
+    # 5. PCS: the opened evaluations must match the z-claims the sumchecks produced
+    v_x = pcs.verify(cm, r_x, proof["open_x"], tr)
+    v_g = pcs.verify(cm, r_g, proof["open_g"], tr)
+    if v_x != z_rx:
+        raise ValueError("PCS open at r_x disagrees with lincheck z-claim")
+    if v_g != z_rg:
+        raise ValueError("PCS open at r_g disagrees with glue z-claim")
+
+    return True

--- a/paper/flock_py/flock_perf.py
+++ b/paper/flock_py/flock_perf.py
@@ -1,0 +1,78 @@
+"""
+flock_perf.py - wall-clock comparison: BATCH proving vs K-times separate proving.
+
+The paper's central pitch (section 1) is that proving a *batch* of K identical
+circuits is far cheaper than treating them independently, and the verifier's per-
+batch work stays near the cost of a single instance (block-diagonal collapse, 4.1).
+
+This script measures, for growing K:
+
+  BATCH     : one Flock proof of the whole K-instance R1CS (+ the hash-chain glue)
+  SEPARATE  : K independent Flock proofs, one per single-instance R1CS (K=1 each)
+
+and reports prove time, verify time, and the number of proofs the verifier must
+check. (SEPARATE also *cannot* enforce the cross-instance chain - that binding is
+a batch-only feature - which we note as a correctness gap, not just a speed one.)
+
+Run:  python3 flock_perf.py     (needs `galois` and `numpy`; see README.md)
+"""
+
+import time
+import numpy as np
+import r1cs
+import flock
+
+
+def _time(fn):
+    t0 = time.perf_counter()
+    out = fn()
+    return out, time.perf_counter() - t0
+
+
+def bench(K, seed=0):
+    ys = [int(x) for x in np.random.default_rng(seed).integers(0, 2, size=K)]
+    z, _ = r1cs.gen_witness(K, x0=1, ys=ys)
+
+    # ---- BATCH: a single proof over all K instances ----
+    proof, t_prove_batch = _time(lambda: flock.prove(z, K))
+    ok, t_verify_batch = _time(lambda: flock.verify(proof))
+    assert ok
+
+    # ---- SEPARATE: K proofs, one instance each ----
+    t_prove_sep = 0.0
+    t_verify_sep = 0.0
+    for i in range(K):
+        zi, _ = r1cs.gen_witness(1, x0=int(z[i * r1cs.BASE + 1]),
+                                 ys=[int(z[i * r1cs.BASE + 2])])
+        pi, dt = _time(lambda: flock.prove(zi, 1))
+        t_prove_sep += dt
+        _, dt = _time(lambda: flock.verify(pi))
+        t_verify_sep += dt
+
+    return {
+        "K": K,
+        "prove_batch": t_prove_batch, "prove_sep": t_prove_sep,
+        "verify_batch": t_verify_batch, "verify_sep": t_verify_sep,
+        "proofs_batch": 1, "proofs_sep": K,
+    }
+
+
+def main():
+    print(f"{'K':>4} | {'prove batch':>11} {'prove sep':>10} {'speedup':>7} "
+          f"| {'verify batch':>12} {'verify sep':>10} {'speedup':>7} "
+          f"| {'#proofs b/s':>11}")
+    print("-" * 92)
+    for k in range(1, 7):                 # K = 2 .. 64
+        K = 1 << k
+        r = bench(K)
+        psp = r["prove_sep"] / r["prove_batch"]
+        vsp = r["verify_sep"] / r["verify_batch"]
+        print(f"{K:>4} | {r['prove_batch']*1e3:>9.1f}ms {r['prove_sep']*1e3:>8.1f}ms "
+              f"{psp:>6.2f}x | {r['verify_batch']*1e3:>10.1f}ms {r['verify_sep']*1e3:>8.1f}ms "
+              f"{vsp:>6.2f}x | {r['proofs_batch']:>4}/{r['proofs_sep']:<5}")
+    print("\nnote: SEPARATE cannot prove the hash-chain (out_i = x_{i+1}) - that")
+    print("cross-instance binding exists only in the BATCH witness (glue G).")
+
+
+if __name__ == "__main__":
+    main()

--- a/paper/flock_py/mle.py
+++ b/paper/flock_py/mle.py
@@ -1,0 +1,64 @@
+"""
+mle.py - multilinear extensions and the eq polynomial.
+
+A function f : {0,1}^m -> F is stored simply as its table of 2^m values.
+Index convention (little-endian): the value at boolean point b = (b_0,...,b_{m-1})
+lives at integer index  i = sum_v b_v * 2^v,  i.e. variable v is bit (i >> v) & 1.
+
+The multilinear extension  f_hat(x) = sum_b f(b) * eq(b, x)  is what the whole
+protocol runs on: it turns a table of bits into a polynomial the verifier can
+probe at a random field point r in F^m.
+"""
+
+import numpy as np
+from field import GF, ONE
+
+
+def num_vars(table):
+    """m such that len(table) == 2^m."""
+    n = len(table)
+    m = n.bit_length() - 1
+    assert 1 << m == n, "table length must be a power of two"
+    return m
+
+
+def eq_vector(point):
+    """
+    Return the length-2^m vector [ eq(b, point) for b in {0,1}^m ], little-endian.
+
+    Built as a tensor product, one variable at a time:
+        eq(b, x) = prod_v ( x_v if b_v==1 else (1 - x_v) )
+    This is exactly the multilinear 'eq' from the paper - a product of the tiny
+    1-D Lagrange bases {(1-x_v), x_v} on the node set {0,1}, one per coordinate.
+    """
+    w = GF([1])
+    for xv in point:                       # append variable v as the new top bit
+        w = np.concatenate([w * (ONE - xv), w * xv])
+    return w
+
+
+def eval_mle(table, point):
+    """
+    Evaluate the multilinear extension of `table` at `point` in F^m.
+    Uses  f_hat(point) = <table, eq_vector(point)>  (O(2^m), maximally clear).
+    """
+    assert len(point) == num_vars(table)
+    if len(table) == 1:
+        return table[0]
+    return GF(np.sum(GF(table) * eq_vector(point)))
+
+
+def bind_first(table, x):
+    """
+    Bind variable 0 (the least-significant bit) to the field value x, returning a
+    table over the remaining m-1 variables (half the length).
+
+    Pairs (2j, 2j+1) share their higher bits and differ only in bit 0, so this is
+    a 1-D linear interpolation between the b_0=0 and b_0=1 slices:
+        out[j] = table[2j] * (1 - x) + table[2j+1] * x
+    This is the single fold step used in every sumcheck round.
+    """
+    t = GF(table)
+    even = t[0::2]        # b_0 = 0 slice
+    odd = t[1::2]         # b_0 = 1 slice
+    return even * (ONE - x) + odd * x

--- a/paper/flock_py/pcs.py
+++ b/paper/flock_py/pcs.py
@@ -1,0 +1,241 @@
+"""
+pcs.py - a real hash-based multilinear polynomial commitment (Ligero/Brakedown style).
+
+This plays the role of Flock's PCS (Ligerito + ring-switching in the paper). It is
+transparent and post-quantum: the ONLY cryptographic assumption is SHA-256
+(Merkle commitments + Fiat-Shamir queries). No pairings, no trusted setup.
+
+Scheme (classic Ligero tensor-query multilinear commitment):
+  - A multilinear poly is stored as its 2^m evaluation table t, reshaped to an
+    (n_rows x n_cols) matrix T, T[i][j] = t[i*n_cols + j].
+  - Each ROW is Reed-Solomon encoded (coeffs -> evaluations at n_enc points),
+    giving Enc (n_rows x n_enc). We Merkle-commit the COLUMNS of Enc; the root is
+    the commitment.
+  - The evaluation f_hat(r) factorizes through the tensor structure:
+        f_hat(r) = eq_rows^T . T . eq_cols        (eq split into high/low vars)
+    so the prover sends w = eq_rows^T . T (length n_cols) and the verifier checks
+    v == <w, eq_cols>.
+  - Soundness comes from opening a few random columns q (Fiat-Shamir): because the
+    RS code is linear, eq_rows^T . Enc[:,q] must equal Enc(w)[q], and a random
+    combination gamma^T . Enc[:,q] must equal Enc(gamma^T.T)[q]. These tie the
+    sent row w to the committed matrix at random places.
+
+This is pedagogical: conservative fixed parameters, O(N) verifier, not optimized.
+"""
+
+import hashlib
+import numpy as np
+from field import GF
+from mle import eq_vector, num_vars
+from transcript import fe_to_bytes
+
+RATE_INV = 2       # codeword length = RATE_INV * n_cols  (rate 1/2, like the paper)
+NUM_QUERIES = 24   # opened columns; soundness ~ (1/2)^Q on top of the field size
+
+
+# ----------------------------- Merkle tree -------------------------------------
+
+def _hash(data: bytes) -> bytes:
+    """Internal-node hash: SHA-256 of the two child digests concatenated."""
+    return hashlib.sha256(data).digest()
+
+
+def _leaf_hash(col_values) -> bytes:
+    """Hash one codeword column (a vector of field elements) into a leaf.
+    The b"leaf" prefix domain-separates leaves from internal nodes, blocking
+    the classic second-preimage trick of passing an internal node off as a leaf."""
+    h = hashlib.sha256(b"leaf")
+    for x in col_values:
+        h.update(fe_to_bytes(x))
+    return h.digest()
+
+
+class Merkle:
+    """Binary Merkle tree over a list of leaves (already hashed)."""
+
+    def __init__(self, leaves):
+        self.n = len(leaves)
+        assert self.n & (self.n - 1) == 0, "leaf count must be a power of two"
+        self.levels = [list(leaves)]
+        cur = leaves
+        while len(cur) > 1:
+            nxt = [_hash(cur[i] + cur[i + 1]) for i in range(0, len(cur), 2)]
+            self.levels.append(nxt)
+            cur = nxt
+        self.root = cur[0]
+
+    def path(self, idx):
+        """Authentication path for leaf `idx`: the sibling hash at every level.
+        (idx ^ 1 flips the lowest bit - left child <-> right child.)"""
+        siblings = []
+        for level in self.levels[:-1]:
+            siblings.append(level[idx ^ 1])
+            idx >>= 1
+        return siblings
+
+    @staticmethod
+    def verify(root, idx, leaf, siblings):
+        """Recompute the root from a leaf and its authentication path.
+        At each level, `idx & 1` says whether the current hash is the right or
+        left child, i.e. which side the sibling concatenates on."""
+        h = leaf
+        for sib in siblings:
+            if idx & 1:
+                h = _hash(sib + h)
+            else:
+                h = _hash(h + sib)
+            idx >>= 1
+        return h == root
+
+
+# --------------------------- Reed-Solomon encode -------------------------------
+
+def _encode_rows(mat, n_enc):
+    """
+    RS-encode each row of `mat` (n_rows x n_cols): treat the row as polynomial
+    coefficients and evaluate at the fixed points {0,1,...,n_enc-1} in F.
+    Returns an (n_rows x n_enc) galois array.
+    """
+    n_rows, n_cols = mat.shape
+    points = GF(np.arange(n_enc, dtype=np.uint64))
+    # Vandermonde: V[p, j] = points[p]^j
+    V = GF(np.ones((n_enc, n_cols), dtype=np.uint64))
+    for j in range(1, n_cols):
+        V[:, j] = V[:, j - 1] * points
+    # Enc[i, p] = sum_j mat[i,j] * points[p]^j  =>  Enc = mat @ V^T
+    return GF(mat) @ V.T
+
+
+def _encode_vec(vec, n_enc):
+    return _encode_rows(GF(vec).reshape(1, -1), n_enc)[0]
+
+
+# ------------------------------ commit / open ----------------------------------
+
+def _shape(m):
+    """Split m variables into (row vars, col vars) as balanced as possible."""
+    m2 = m // 2            # low vars -> columns
+    m1 = m - m2            # high vars -> rows
+    return m1, m2
+
+
+class Commitment:
+    """What the verifier holds: the Merkle root plus the (public) matrix shape.
+    The root binds the prover to one specific encoded matrix; the shape lets the
+    verifier recompute eq splits, re-encode rows, and reduce query indices."""
+
+    def __init__(self, root, m, n_rows, n_cols, n_enc):
+        self.root = root
+        self.m = m
+        self.n_rows, self.n_cols, self.n_enc = n_rows, n_cols, n_enc
+
+
+class _Prover:
+    """Holds the opened matrix so multiple evaluations can be proved."""
+
+    def __init__(self, table):
+        self.m = num_vars(table)
+        self.m1, self.m2 = _shape(self.m)
+        self.n_rows, self.n_cols = 1 << self.m1, 1 << self.m2
+        self.n_enc = RATE_INV * self.n_cols
+        self.T = GF(table).reshape(self.n_rows, self.n_cols)
+        self.Enc = _encode_rows(self.T, self.n_enc)                 # n_rows x n_enc
+        leaves = [_leaf_hash(self.Enc[:, q]) for q in range(self.n_enc)]
+        self.tree = Merkle(leaves)
+        self.commitment = Commitment(
+            self.tree.root, self.m, self.n_rows, self.n_cols, self.n_enc
+        )
+
+
+def commit(table):
+    """Commit to the multilinear polynomial given by `table` (its 2^m evaluations).
+    Returns (prover_state, commitment): the prover keeps the state to answer
+    open() later; only the commitment (root + shape) is sent to the verifier."""
+    p = _Prover(table)
+    return p, p.commitment
+
+
+def open(prover, point, transcript):
+    """Produce an evaluation proof that f_hat(point) = v (v returned in proof)."""
+    P = prover
+    r = GF(point)
+    eq_cols = eq_vector(r[: P.m2])
+    eq_rows = eq_vector(r[P.m2:])
+    w = eq_rows @ P.T                       # length n_cols; v = <w, eq_cols>
+    v = GF(np.sum(w * eq_cols))
+
+    transcript.absorb_bytes(P.commitment.root)
+    transcript.absorb_fe_list(r)
+    transcript.absorb_fe_list(w)
+    transcript.absorb_fe(v)
+
+    # proximity random combination over the rows
+    gamma = transcript.challenge_vec(P.n_rows)
+    r_gamma = gamma @ P.T                    # length n_cols
+
+    transcript.absorb_fe_list(r_gamma)
+
+    # query columns
+    queries = [int(transcript.challenge()) % P.n_enc for _ in range(NUM_QUERIES)]
+    openings = []
+    for q in queries:
+        col = P.Enc[:, q]
+        openings.append((q, col, P.tree.path(q)))
+
+    return {
+        "v": v, "w": w, "gamma": gamma, "r_gamma": r_gamma,
+        "queries": queries, "openings": openings,
+    }
+
+
+def verify(commitment, point, proof, transcript):
+    """Check an evaluation proof; returns the proven value v = f_hat(point) or
+    raises ValueError. Three layers of checks, mirroring the module docstring:
+    (1) the sent row w actually yields the claimed v, (2) Fiat-Shamir replay ties
+    gamma and the query set to the transcript, (3) at each queried column, the
+    Merkle path proves the column is committed, and the two linear-code identities
+    tie w (eval-consistency) and gamma^T.T (proximity) to that committed data."""
+    C = commitment
+    r = GF(point)
+    m1, m2 = _shape(C.m)
+    eq_cols = eq_vector(r[:m2])
+    eq_rows = eq_vector(r[m2:])
+    w = GF(proof["w"])
+    v = GF(proof["v"])
+
+    # 1) claimed evaluation is consistent with the sent row w
+    if GF(np.sum(w * eq_cols)) != v:
+        raise ValueError("PCS: v != <w, eq_cols>")
+
+    # replay Fiat-Shamir exactly as the prover did
+    transcript.absorb_bytes(C.root)
+    transcript.absorb_fe_list(r)
+    transcript.absorb_fe_list(w)
+    transcript.absorb_fe(v)
+    gamma = transcript.challenge_vec(C.n_rows)
+    if not np.array_equal(np.array(gamma), np.array(proof["gamma"])):
+        raise ValueError("PCS: gamma mismatch (transcript desync)")
+    r_gamma = GF(proof["r_gamma"])
+    transcript.absorb_fe_list(r_gamma)
+    queries = [int(transcript.challenge()) % C.n_enc for _ in range(NUM_QUERIES)]
+    if queries != proof["queries"]:
+        raise ValueError("PCS: query set mismatch")
+
+    enc_w = _encode_vec(w, C.n_enc)
+    enc_rg = _encode_vec(r_gamma, C.n_enc)
+
+    for (q, col, path) in proof["openings"]:
+        if q not in queries:
+            raise ValueError("PCS: opened a non-queried column")
+        # Merkle authenticity of the committed column
+        if not Merkle.verify(C.root, q, _leaf_hash(col), path):
+            raise ValueError("PCS: bad Merkle path")
+        col = GF(col)
+        # eval-consistency: eq_rows . Enc[:,q] == Enc(w)[q]
+        if GF(np.sum(eq_rows * col)) != enc_w[q]:
+            raise ValueError("PCS: eval-consistency check failed")
+        # proximity: gamma . Enc[:,q] == Enc(gamma^T T)[q]
+        if GF(np.sum(gamma * col)) != enc_rg[q]:
+            raise ValueError("PCS: proximity check failed")
+
+    return v

--- a/paper/flock_py/r1cs.py
+++ b/paper/flock_py/r1cs.py
@@ -1,0 +1,135 @@
+"""
+r1cs.py - the batched circuit Flock proves.
+
+Base circuit F (one AND gate):   out = x AND y  ==  x * y  over F2.
+Per-instance witness layout (length 2^m0 = 4, so m0 = 2), little-endian slots:
+
+    z0 = [ const1 , x , y , out ]
+    idx     0       1   2    3
+
+The single real R1CS row says  x * y = out :
+    A0 selects x (idx 1), B0 selects y (idx 2), C0 selects out (idx 3).
+Rows 1..3 are padding (0 = 0) so A0,B0,C0 are square 4x4, as the paper requires.
+
+Batching (section 4.1): K = 2^k instances stacked block-diagonally,
+    A = I_K (x) A0,  so  (A z) applies A0 to each instance independently.
+Global index convention (little-endian): variables 0..m0-1 are the WITHIN-instance
+bits i_in; variables m0..m-1 are the instance index i_out. So
+    global_index = i_out * 2^m0 + i_in,   and  z.reshape(K, 2^m0)[i_out] = instance i_out.
+
+Glue circuit G (a hash-chain): the instances form a chain
+    x_{i+1} = out_i = x_i AND y_i,
+enforced by the paper's shift argument (section 4.6). Slots used:
+    out lives at within-instance index 3 -> boolean bits S_OUT = (1,1)
+    x   lives at within-instance index 1 -> boolean bits S_IN  = (1,0)
+"""
+
+import numpy as np
+from field import GF
+
+M0 = 2                      # base variables; base dimension 2^M0 = 4
+BASE = 1 << M0             # = 4
+
+# within-instance slot bit-patterns (little-endian, length M0)
+S_CONST = (0, 0)          # idx 0
+S_IN = (1, 0)             # idx 1 (x, the chained input)
+S_AUX = (0, 1)            # idx 2 (y)
+S_OUT = (1, 1)            # idx 3 (out, the chained output)
+
+
+def _selector_row(idx):
+    """Unit row vector: as an R1CS matrix row it 'selects' witness slot `idx`."""
+    row = np.zeros(BASE, dtype=np.uint8)
+    row[idx] = 1
+    return row
+
+
+# Base matrices: only row 0 is a real constraint (x*y=out); rows 1..3 are zero.
+A0 = np.zeros((BASE, BASE), dtype=np.uint8); A0[0] = _selector_row(1)  # picks x
+B0 = np.zeros((BASE, BASE), dtype=np.uint8); B0[0] = _selector_row(2)  # picks y
+C0 = np.zeros((BASE, BASE), dtype=np.uint8); C0[0] = _selector_row(3)  # picks out
+
+
+def slot_index(slot_bits):
+    """within-instance integer index of a slot given its little-endian bits."""
+    return sum(b << v for v, b in enumerate(slot_bits))
+
+
+def gen_witness(K, x0, ys):
+    """
+    Build a satisfying batched witness for a hash-chain of K AND-gates.
+      x0  : initial input bit (0/1)
+      ys  : list of K aux bits (0/1), one per instance
+    Returns (z_bits as np.uint8 length K*BASE, info dict).
+    Chain: x_0 = x0 ; out_i = x_i AND y_i ; x_{i+1} = out_i.
+    """
+    assert len(ys) == K
+    z = np.zeros(K * BASE, dtype=np.uint8)
+    x = x0 & 1
+    xs, outs = [], []
+    for i in range(K):
+        y = ys[i] & 1
+        out = x & y
+        base = i * BASE
+        z[base + 0] = 1        # const 1
+        z[base + 1] = x        # input x_i
+        z[base + 2] = y        # aux y_i
+        z[base + 3] = out      # output out_i
+        xs.append(x); outs.append(out)
+        x = out                # chain
+    info = {"xs": xs, "ys": [y & 1 for y in ys], "outs": outs, "x_final": x}
+    return z, info
+
+
+def apply_base(M0mat, z, K):
+    """Compute (I_K (x) M0mat) @ z  by applying the small M0mat to each instance."""
+    Z = GF(z.astype(np.int64)).reshape(K, BASE)          # (K, BASE)
+    M = GF(M0mat.astype(np.int64))                       # (BASE, BASE)
+    out = (M @ Z.T).T                                    # (K, BASE)
+    return out.reshape(K * BASE)
+
+
+def transpose_apply_base(M0mat, vec, K):
+    """Compute (I_K (x) M0mat)^T @ vec = (I_K (x) M0mat^T) @ vec, blockwise."""
+    V = GF(vec).reshape(K, BASE)
+    MT = GF(M0mat.astype(np.int64)).T
+    out = (MT @ V.T).T
+    return out.reshape(K * BASE)
+
+
+def check_r1cs(z, K):
+    """Directly verify (Az) o (Bz) = Cz over F2 for the batched witness."""
+    a = apply_base(A0, z, K)
+    b = apply_base(B0, z, K)
+    c = apply_base(C0, z, K)
+    return bool(np.all(a * b == c))
+
+
+# ------------------------------- glue G ----------------------------------------
+# Hash-chain relation out_i = x_{i+1} for i = 0..K-2, as a sparse linear map G with
+# Gz = 0. This is the concrete instantiation of the paper's section 4.6 glue; Flock
+# proves it with a tailored shift argument, we prove Gz=0 with the same lincheck
+# sumcheck used for A,B,C (a "generic IO via slot-aligned regions", section 4.6).
+
+def out_index(i):
+    return i * BASE + slot_index(S_OUT)   # within-instance idx 3
+
+
+def in_index(i):
+    return i * BASE + slot_index(S_IN)    # within-instance idx 1
+
+
+def glue_matrix(K):
+    """(K*BASE x K*BASE) matrix G with row i enforcing out_i - x_{i+1} = 0 (F2)."""
+    N = K * BASE
+    G = GF(np.zeros((N, N), dtype=np.int64))
+    for i in range(K - 1):
+        G[i, out_index(i)] = 1            # out_i
+        G[i, in_index(i + 1)] = 1         # x_{i+1}   (+ == - in F2)
+    return G
+
+
+def check_glue(z, K):
+    """Directly verify the hash-chain: Gz = 0 over F2."""
+    g = glue_matrix(K) @ GF(z.astype(np.int64))
+    return bool(np.all(np.array(g) == 0))

--- a/paper/flock_py/sumcheck.py
+++ b/paper/flock_py/sumcheck.py
@@ -1,0 +1,98 @@
+"""
+sumcheck.py - a small, generic sumcheck protocol (Lund-Fortnow-Karloff-Nisan).
+
+Goal: prove   claim = sum_{b in {0,1}^m}  P( t_1[b], t_2[b], ..., t_k[b] )
+where each t_i is a multilinear table and P is a fixed low-degree combiner
+(a product / difference of its inputs). Both zerocheck and lincheck in Flock are
+instances of this with different tables and combiners.
+
+Each round binds one boolean variable, sending a univariate polynomial of degree
+`degree` (= the total degree of P in a single variable). We transmit that
+polynomial as its evaluations at x = 0, 1, ..., degree and interpolate.
+
+Design: the prover and verifier share the SAME `combine` closure. `combine` maps
+a list of (partially bound) tables to an elementwise GF array. The prover uses it
+to build each round polynomial; the verifier uses it only once, at the very end,
+to check the final point - given oracle evaluations supplied by the caller.
+"""
+
+import numpy as np
+from field import GF, ONE, ZERO
+from mle import bind_first, num_vars
+
+
+def _lagrange_interpolate_eval(xs, ys, at):
+    """Evaluate, at point `at`, the polynomial through points (xs[i], ys[i]) over F.
+    (Same Lagrange idea as the RareSkills homework, specialized to small degree.)"""
+    # NOTE: use fresh GF(0)/GF(1) and non-in-place ops. `x = ONE; x *= y` would
+    # mutate the shared global ONE in place (galois scalars are 0-d arrays).
+    total = GF(0)
+    k = len(xs)
+    for j in range(k):
+        num = GF(1)
+        den = GF(1)
+        for i in range(k):
+            if i == j:
+                continue
+            num = num * (at - xs[i])
+            den = den * (xs[j] - xs[i])
+        total = total + ys[j] * num / den
+    return total
+
+
+def prove(tables, degree, combine, transcript):
+    """
+    Run the sumcheck prover.
+
+    Returns (round_evals, challenges, final_tables) where
+      round_evals[t] = [g_t(0), ..., g_t(degree)]  (the message for round t)
+      challenges[t]  = the verifier challenge folded in after round t
+      final_tables   = each input table fully bound to `challenges` (length 1)
+    """
+    m = num_vars(tables[0])
+    xs = GF(list(range(degree + 1)))
+    cur = [GF(t) for t in tables]
+    round_evals = []
+    challenges = []
+
+    for _ in range(m):
+        # Build g(x) = sum over the remaining cube of P(tables bound with var0 := x),
+        # sampled at x = 0..degree.
+        evals = []
+        for x in xs:
+            bound = [bind_first(t, x) for t in cur]
+            evals.append(GF(np.sum(combine(bound))))
+        evals = GF(evals)
+        round_evals.append(evals)
+
+        transcript.absorb_fe_list(evals)
+        ch = transcript.challenge()
+        challenges.append(ch)
+
+        cur = [bind_first(t, ch) for t in cur]
+
+    return round_evals, GF(challenges), [t[0] for t in cur]
+
+
+def verify(round_evals, degree, claim, transcript):
+    """
+    Verify the sumcheck rounds against `claim`. Does NOT check the final point
+    (the caller does that using externally obtained oracle evaluations, e.g. from
+    the PCS). Returns (challenges, final_expected) where final_expected is the
+    value P(...) must equal at the random point r = challenges.
+    """
+    xs = GF(list(range(degree + 1)))
+    challenges = []
+    cur_claim = claim
+
+    for evals in round_evals:
+        evals = GF(evals)
+        # fundamental sumcheck check: g(0) + g(1) == running claim
+        if GF(evals[0]) + GF(evals[1]) != cur_claim:
+            raise ValueError("sumcheck: round consistency g(0)+g(1) != claim failed")
+        transcript.absorb_fe_list(evals)
+        ch = transcript.challenge()
+        challenges.append(ch)
+        cur_claim = _lagrange_interpolate_eval(xs, evals, ch)
+
+    return GF(challenges), cur_claim

--- a/paper/flock_py/sumcheck.py
+++ b/paper/flock_py/sumcheck.py
@@ -23,7 +23,7 @@ from mle import bind_first, num_vars
 
 def _lagrange_interpolate_eval(xs, ys, at):
     """Evaluate, at point `at`, the polynomial through points (xs[i], ys[i]) over F.
-    (Same Lagrange idea as the RareSkills homework, specialized to small degree.)"""
+    (Standard Lagrange interpolation, specialized to small degree.)"""
     # NOTE: use fresh GF(0)/GF(1) and non-in-place ops. `x = ONE; x *= y` would
     # mutate the shared global ONE in place (galois scalars are 0-d arrays).
     total = GF(0)

--- a/paper/flock_py/test_flock.py
+++ b/paper/flock_py/test_flock.py
@@ -10,6 +10,15 @@ Two kinds of tests, deliberately paired:
   - SOUNDNESS: each tampering is caught by the specific sub-protocol whose job
     it is to catch it (zerocheck for a bad gate, glue for a broken chain, the
     PCS for forged evaluations/columns, sumcheck for altered round messages).
+
+The suite doubles as a WORKED EXAMPLE of the protocol math: each section
+pretty-prints the actual values flowing through the operation it tests -
+inputs, intermediate steps, and the checks - so you can follow the algebra on
+screen next to the paper. Nothing printed is mocked: every number comes out of
+the same code paths the assertions exercise, and the demos deliberately use
+operands small enough (single hex digits) that you can redo the arithmetic by
+hand. Genuinely random 128-bit elements are abbreviated as 0xHEAD..TAIL purely
+for layout; the code always computes on the full value.
 """
 
 import numpy as np
@@ -26,7 +35,7 @@ PASS = []
 
 def ok(name):
     PASS.append(name)
-    print(f"  ok  {name}")
+    print(f"\n  ok  {name}")
 
 
 def fail(name, e):
@@ -34,16 +43,195 @@ def fail(name, e):
     raise SystemExit(1)
 
 
+# ------------------------- pretty-printing helpers -----------------------------
+# Everything in this block is formatting only - none of it participates in the
+# checks. The one exception is replay_sumcheck(), which deliberately re-runs the
+# verifier's math (with asserts) so that what it prints CANNOT drift from what
+# sumcheck.verify actually accepts.
+
+WIDTH = 78
+
+
+def banner(title):
+    """Section header - one per protocol building block."""
+    print("\n" + "=" * WIDTH)
+    print(f"  {title}")
+    print("=" * WIDTH)
+
+
+def step(label, text):
+    """A numbered step (or phase, or attack) inside a section."""
+    print(f"\n  [{label}] {text}")
+
+
+def note(text, indent=6):
+    """One indented line of worked math."""
+    print(" " * indent + text)
+
+
+def fe(x):
+    """Format a field element for display. Small values (the hand-checkable
+    demos) print in full; big ones (128-bit challenges, sumcheck messages)
+    abbreviate to 0xHEAD..TAIL so lines stay readable. Display only - the
+    underlying 128-bit value is always what the code computes with."""
+    v = int(x)
+    if v < (1 << 32):
+        return f"0x{v:x}"
+    h = f"{v:032x}"
+    return f"0x{h[:4]}..{h[-4:]}"
+
+
+def fe_poly(x):
+    """Format a small field element as a polynomial in x over F2. Bit i of the
+    integer representation is the coefficient of x^i - this makes the carry-less
+    arithmetic in the field demo legible as plain polynomial algebra."""
+    v = int(x)
+    if v == 0:
+        return "0"
+    terms = []
+    for i in range(v.bit_length() - 1, -1, -1):
+        if (v >> i) & 1:
+            terms.append("1" if i == 0 else ("x" if i == 1 else f"x^{i}"))
+    return " + ".join(terms)
+
+
+def vec(xs, limit=8):
+    """Format a vector of field elements, truncating very long ones."""
+    xs = list(xs)
+    body = ", ".join(fe(x) for x in xs[:limit])
+    if len(xs) > limit:
+        body += f", ... ({len(xs)} elements)"
+    return f"[{body}]"
+
+
+def bits(v, group=r1cs.BASE):
+    """Format a 0/1 vector as bit blocks, one block per circuit instance -
+    the natural way to read a batched witness z = [1,x,y,out | 1,x,y,out | ...]."""
+    s = "".join(str(int(x)) for x in np.array(v))
+    return " ".join(s[i:i + group] for i in range(0, len(s), group))
+
+
+def replay_sumcheck(round_evals, degree, claim, tr, indent=6):
+    """Print-and-check replay of sumcheck.verify(): identical transcript absorbs
+    in the identical order, hence identical challenges, and the same two facts
+    re-checked (with asserts) every round:
+      (1) g_t(0) + g_t(1) must equal the running claim - the sum over the
+          remaining cube, split by the value of the variable being bound;
+      (2) the next running claim becomes g_t(r_t), Lagrange-interpolated from
+          the degree+1 samples the prover sent.
+    Returns (challenges, final_expected) exactly like sumcheck.verify, so the
+    caller can assert the replay agrees with the real verifier."""
+    xs = GF(list(range(degree + 1)))
+    challenges = []
+    cur = claim
+    for t, evals in enumerate(round_evals):
+        evals = GF(evals)
+        g01 = GF(evals[0]) + GF(evals[1])
+        assert g01 == cur, "replay diverged from sumcheck.verify"
+        note(f"round {t}: prover sends g{t}, sampled at x = 0..{degree}: {vec(evals)}", indent)
+        note(f"         g{t}(0) + g{t}(1) = {fe(g01)}  == running claim  ok", indent)
+        tr.absorb_fe_list(evals)
+        ch = tr.challenge()
+        challenges.append(ch)
+        cur = sumcheck._lagrange_interpolate_eval(xs, evals, ch)
+        note(f"         challenge r{t} = {fe(ch)}  ->  new claim g{t}(r{t}) = {fe(cur)}", indent)
+    return GF(challenges), cur
+
+
+# ------------------------------- field demo -------------------------------------
+
+def demo_field():
+    """Not a counted test - a worked tour of GF(2^128) arithmetic (field.py),
+    with operands small enough to redo by hand. The asserts pin every printed
+    identity to what galois actually computes."""
+    banner("FIELD  GF(2^128), irreducible p(x) = x^128 + x^7 + x^2 + x + 1 (field.py)")
+    print("  An element is a 128-bit integer whose bit i is the coefficient of x^i.")
+    print("  Witness DATA lives in the {0,1} subfield; verifier CHALLENGES range over")
+    print("  the whole field - that gap is where Schwartz-Zippel soundness comes from.")
+
+    step(1, "addition is coefficientwise XOR (characteristic 2, so 1 + 1 = 0)")
+    a, b = GF(0b1010), GF(0b0011)              # x^3 + x   and   x + 1
+    s = a + b
+    note(f"a     = {int(a):#06b} = {fe_poly(a)}")
+    note(f"b     = {int(b):#06b} = {fe_poly(b)}")
+    note(f"a + b = {int(s):#06b} = {fe_poly(s)}    (the two x terms cancelled)")
+    assert int(s) == int(a) ^ int(b)
+    note(f"a + a = {fe(a + a)}    (every element is its own negative, so + and - coincide)")
+    assert a + a == GF(0)
+
+    step(2, "multiplication is carry-less polynomial product, then reduce mod p(x)")
+    small = GF(3) * GF(3)
+    note("no reduction needed while degrees stay below 128:")
+    note(f"    (x+1)*(x+1) = x^2 + 2x + 1 = x^2 + 1 (the 2x vanishes):  GF(3)*GF(3) = GF({int(small)})")
+    assert int(small) == 0b101
+    hi = GF(1 << 127) * GF(2)
+    note("crossing degree 128 triggers the reduction x^128 = x^7 + x^2 + x + 1 (mod p):")
+    note(f"    x^127 * x = x^128  ->  GF(2^127)*GF(2) = {int(hi):#b} = {fe_poly(hi)}")
+    assert int(hi) == 0b10000111
+
+    step(3, "inverses exist (F is a FIELD), so division is well-defined")
+    c = GF(0x0123456789abcdef0123456789abcdef)     # an arbitrary big element
+    ci = GF(1) / c
+    note(f"c        = {fe(c)}")
+    note(f"c^-1     = {fe(ci)}")
+    note(f"c * c^-1 = {fe(c * ci)}")
+    assert c * ci == GF(1)
+
+
 # ------------------------------- MLE -------------------------------------------
 
 def test_mle_agrees_on_cube():
     """Defining property of the multilinear extension: f_hat interpolates f,
     i.e. evaluating at every boolean corner returns the original table entry."""
+    banner("MLE  f_hat(x) = sum_b f(b) * eq(b, x) - table -> polynomial (mle.py)")
+
+    # Worked example small enough to follow by hand: m = 2 variables (a 4-entry
+    # table) evaluated at the deliberately tiny point r = (2, 3), so every eq
+    # weight is a one-hex-digit carry-less product. Remember: in this field
+    # subtraction IS addition (XOR), so 1 - 2 = 1 + 2 = 3.
+    t = GF([3, 1, 4, 1])
+    r = GF([2, 3])
+    print("  worked example: m = 2, table f = [3, 1, 4, 1], point r = (2, 3)")
+    print("  (little-endian corners: f(b0,b1) lives at index b0 + 2*b1)")
+
+    step(1, "the eq weights: eq(b, r) = prod_v (r_v if b_v = 1 else 1 - r_v)")
+    eqw = eq_vector(r)
+    for i in range(4):
+        b0, b1 = i & 1, (i >> 1) & 1
+        f0 = r[0] if b0 else GF(1) - r[0]
+        f1 = r[1] if b1 else GF(1) - r[1]
+        s0 = " r0 " if b0 else "1-r0"
+        s1 = " r1 " if b1 else "1-r1"
+        note(f"b=({b0},{b1}):  ({s0})*({s1}) = {fe(f0)} * {fe(f1)} = {fe(f0 * f1)}")
+        assert f0 * f1 == eqw[i]
+    total = GF(np.sum(eqw))
+    note(f"sum of the four weights = {fe(total)}    (partition of unity: always exactly 1)")
+    assert total == GF(1)
+
+    step(2, "evaluate: f_hat(r) = <f, eq> - one weighted sum over the table")
+    v = eval_mle(t, r)
+    note("f_hat(2,3) = " + " + ".join(f"{int(t[i])}*{fe(eqw[i])}" for i in range(4)))
+    note("           = " + " + ".join(fe(GF(t[i]) * eqw[i]) for i in range(4))
+         + f" = {fe(v)}    (+ is XOR)")
+    assert GF(np.sum(GF(t) * eqw)) == v
+
+    step(3, "interpolation: at boolean corners the MLE reproduces the table")
+    corners = []
+    for i in range(4):
+        pt = GF([(i >> vbit) & 1 for vbit in range(2)])
+        cv = eval_mle(t, pt)
+        assert cv == t[i]
+        corners.append(f"f_hat({int(pt[0])},{int(pt[1])}) = {int(cv)}")
+    note("   ".join(corners))
+    note("which is exactly the table f = [3, 1, 4, 1] again  ok")
+
+    # The counted test: the same property on a random m = 4 table, all 16 corners.
     m = 4
     t = GF.Random(1 << m)
     for i in range(1 << m):
         pt = GF([(i >> v) & 1 for v in range(m)])
         assert eval_mle(t, pt) == t[i]
+    note("(re-checked quietly on a random m = 4 table: all 16 corners agree)", 2)
     ok("MLE agrees with table on all 2^m corners")
 
 
@@ -53,6 +241,7 @@ def test_sumcheck_roundtrip_and_soundness():
     """Honest sumcheck verifies: challenges match, the verifier's final expected
     value equals P at the bound point, and the bound tables really are the MLEs
     at the challenge point. Then: flipping one round message must be rejected."""
+    banner("SUMCHECK  reduce a sum over {0,1}^m to one random point (sumcheck.py)")
     m = 4
     a, b, c = GF.Random(1 << m), GF.Random(1 << m), GF.Random(1 << m)
     r = GF.Random(m)
@@ -63,19 +252,39 @@ def test_sumcheck_roundtrip_and_soundness():
         return e * (a * b - c)
 
     claim = GF(np.sum(combine([eqw, a, b, c])))
+    print(f"  statement: claim = sum over b in {{0,1}}^{m} of  eq(w,b)*(a(b)*b(b) - c(b))")
+    print(f"  with random tables a, b, c (so the values below are full 128-bit elements).")
+    print(f"  Degree 3 per variable -> each round message is 4 samples of a univariate g.")
+    note(f"claimed sum = {fe(claim)}", 2)
+
     rounds, ch, final = sumcheck.prove([eqw, a, b, c], 3, combine, Transcript())
     chv, expected = sumcheck.verify(rounds, 3, claim, Transcript())
     assert np.array_equal(np.array(ch), np.array(chv))
     assert combine([GF([x]) for x in final])[0] == expected
     assert final[1] == eval_mle(a, ch)
+
+    step(1, f"the {m} rounds, replayed with the verifier's own two checks per round")
+    rch, rfinal = replay_sumcheck(rounds, 3, claim, Transcript())
+    # the replay must agree with the real verifier on everything it derived
+    assert np.array_equal(np.array(rch), np.array(chv))
+    assert rfinal == expected
+
+    step(2, "final point: after m rounds the sum has shrunk to ONE point r = (r0..r3)")
+    e_, a_, b_, c_ = final
+    note(f"prover's fully-bound tables:  eq = {fe(e_)}, a = {fe(a_)}, b = {fe(b_)}, c = {fe(c_)}")
+    note(f"P at the point = eq*(a*b - c) = {fe(e_ * (a_ * b_ - c_))}  == final claim {fe(expected)}  ok")
+    note(f"cross-check: binding table a to the challenges equals the MLE a(r): {fe(eval_mle(a, ch))}  ok")
     ok("sumcheck prove/verify + final-point consistency")
 
     bad = [x.copy() for x in rounds]
     bad[0] = bad[0].copy(); bad[0][0] = bad[0][0] + GF(1)
+    step(3, "soundness: add 1 to g0(0) and hand the verifier the altered messages")
+    note(f"g0(0): {fe(rounds[0][0])}  ->  {fe(bad[0][0])}   (now g0(0)+g0(1) != claim)")
     try:
         sumcheck.verify(bad, 3, claim, Transcript())
         fail("sumcheck soundness", "tamper not caught")
-    except ValueError:
+    except ValueError as e:
+        note(f"verifier raises: {e}")
         ok("tampered sumcheck rejected")
 
 
@@ -85,6 +294,64 @@ def test_pcs_roundtrip_and_soundness():
     """PCS round-trip on several sizes (odd/even m exercise both row/col splits),
     then two forgeries: a wrong claimed value v, and a tampered committed column
     (which must fail the Merkle check or a code-consistency check)."""
+    banner("PCS  hash-based commitment: Merkle + Reed-Solomon, Ligero-style (pcs.py)")
+
+    # Worked example: commit to the SAME 4-entry table used in the MLE section and
+    # prove its evaluation at the same point r = (2,3) - so the value proven here
+    # is the one computed by hand there. m = 2 -> a 2x2 matrix; rate-1/2 code ->
+    # each 2-entry row becomes a 4-entry codeword.
+    t = GF([3, 1, 4, 1])
+    r = GF([2, 3])
+    print("  worked example: commit f = [3, 1, 4, 1], then prove the MLE section's")
+    print("  claim f_hat(2,3) against that commitment.")
+    prover, cm = pcs.commit(t)
+
+    step(1, "shape the table into a matrix and Reed-Solomon-encode each row")
+    note(f"T = f reshaped to {prover.n_rows}x{prover.n_cols} (row i = t[{prover.n_cols}i .. {prover.n_cols}i+{prover.n_cols - 1}]):")
+    for row in prover.T:
+        note(f"    {vec(row)}")
+    note(f"each row's entries are coefficients of a polynomial, evaluated at x = 0..{prover.n_enc - 1}:")
+    for i, row in enumerate(prover.Enc):
+        note(f"    Enc row {i}: {vec(row)}")
+    note("(check row 0 by hand: p(x) = 3 + 1*x gives p(0)=3, p(1)=3+1=2, p(2)=3+2=1,")
+    note(" p(3)=3+3=0 - additions are XOR. Redundancy is what makes spot-checks bite.)")
+
+    step(2, "Merkle-commit the encoded COLUMNS; the root alone is the commitment")
+    note(f"leaf q = SHA-256('leaf' || Enc[:,q]), {cm.n_enc} leaves  ->  root = {cm.root.hex()[:16]}..")
+
+    step(3, "open at r = (2,3): the tensor split f_hat(r) = eq_rows^T . T . eq_cols")
+    proof = pcs.open(prover, r, Transcript())
+    eq_cols = eq_vector(r[:prover.m2])
+    eq_rows = eq_vector(r[prover.m2:])
+    note(f"r splits: col var -> eq_cols = {vec(eq_cols)},  row var -> eq_rows = {vec(eq_rows)}")
+    note(f"prover sends the folded row  w = eq_rows^T . T = {vec(proof['w'])}")
+    note(f"claimed value v = <w, eq_cols> = {fe(proof['v'])}   (the MLE section's f_hat(2,3))")
+    assert proof["v"] == eval_mle(t, r)
+
+    step(4, "verify: spot-check random columns against the root and the code")
+    qs = proof["queries"]
+    note(f"{len(qs)} Fiat-Shamir column queries -> columns {sorted(set(qs))}")
+    note("(this demo code has only 4 columns, so the 24 queries repeat; real")
+    note(" parameters make each query an independent binomial trial)")
+    q, col, path = proof["openings"][0]
+    note(f"take query q = {q}: opened column Enc[:,{q}] = {vec(col)}")
+    assert pcs.Merkle.verify(cm.root, q, pcs._leaf_hash(col), path)
+    note(f"Merkle: {len(path)} sibling hashes recompute the committed root  ok")
+    enc_w = pcs._encode_vec(GF(proof["w"]), cm.n_enc)
+    lhs = GF(np.sum(eq_rows * GF(col)))
+    note(f"eval-consistency (the code is LINEAR, so encoding commutes with eq_rows):")
+    note(f"    <eq_rows, Enc[:,{q}]> = {fe(lhs)}  ==  Enc(w)[{q}] = {fe(enc_w[q])}  ok")
+    assert lhs == enc_w[q]
+    enc_rg = pcs._encode_vec(GF(proof["r_gamma"]), cm.n_enc)
+    plhs = GF(np.sum(GF(proof["gamma"]) * GF(col)))
+    note(f"proximity (random combo gamma of the rows, same linearity trick):")
+    note(f"    <gamma, Enc[:,{q}]> = {fe(plhs)}  ==  Enc(gamma^T T)[{q}] = {fe(enc_rg[q])}  ok")
+    assert plhs == enc_rg[q]
+    v = pcs.verify(cm, r, proof, Transcript())
+    note(f"pcs.verify accepts and returns v = {fe(v)}")
+    assert v == eval_mle(t, r)
+
+    step(5, "the counted round-trip: m = 2, 3, 5, 6 (both row/col split parities)")
     for m in [2, 3, 5, 6]:
         t = GF.Random(1 << m)
         prover, cm = pcs.commit(t)
@@ -94,52 +361,185 @@ def test_pcs_roundtrip_and_soundness():
         assert v == eval_mle(t, r)
     ok("PCS commit/open/verify matches MLE (m=2,3,5,6)")
 
+    step(6, "soundness: two forgeries against a fresh m = 4 commitment")
     t = GF.Random(1 << 4)
     prover, cm = pcs.commit(t)
     r = GF.Random(4)
     proof = pcs.open(prover, r, Transcript())
     proof["v"] = proof["v"] + GF(1)
+    note(f"forgery 1: claim v + 1 = {fe(proof['v'])} instead of the true evaluation")
     try:
         pcs.verify(cm, r, proof, Transcript())
         fail("PCS soundness (value)", "tampered value accepted")
-    except ValueError:
+    except ValueError as e:
+        note(f"verifier raises: {e}")
         ok("PCS rejects tampered evaluation value")
 
     proof = pcs.open(prover, r, Transcript())
     q, col, path = proof["openings"][0]
     col2 = col.copy(); col2[0] = col2[0] + GF(1)
     proof["openings"][0] = (q, col2, path)
+    note(f"forgery 2: flip one entry of opened column {q}; its leaf hash changes,")
+    note("so the untouched authentication path can no longer reach the root")
     try:
         pcs.verify(cm, r, proof, Transcript())
         fail("PCS soundness (column)", "tampered column accepted")
-    except ValueError:
+    except ValueError as e:
+        note(f"verifier raises: {e}")
         ok("PCS rejects tampered committed column")
+
+
+# ------------------------------- R1CS demo --------------------------------------
+
+def demo_r1cs():
+    """Not a counted test - a worked example of the STATEMENT being proven
+    (r1cs.py): the batched AND-gate R1CS and the hash-chain glue, checked
+    directly over F2. These are the very equations the zerocheck, lincheck and
+    glue sumchecks will re-assert algebraically in the end-to-end section."""
+    banner("R1CS  batched AND-gates + hash-chain glue (r1cs.py)")
+    print("  base gate: out = x AND y = x*y over F2. One instance's witness block is")
+    print("  z0 = [1, x, y, out] (slots 0..3), and only R1CS row 0 is real:")
+    print("  (A0 z0) * (B0 z0) = (C0 z0) row-wise says  x * y = out.")
+
+    step(1, "the base selector matrices (rows 1..3 are 0 = 0 padding)")
+    for name, M, what in [("A0", r1cs.A0, "slot 1 = x"),
+                          ("B0", r1cs.B0, "slot 2 = y"),
+                          ("C0", r1cs.C0, "slot 3 = out")]:
+        rows = " ".join("[" + "".join(str(int(x)) for x in row) + "]" for row in M)
+        note(f"{name} = {rows}    row 0 selects {what}")
+
+    step(2, "a K = 4 hash-chain witness: x_(i+1) = out_i = x_i AND y_i")
+    K, x0, ys = 4, 1, [1, 1, 0, 1]
+    z, info = r1cs.gen_witness(K, x0, ys)
+    note("i | x_i y_i | out_i = x_i AND y_i")
+    for i in range(K):
+        chain = f"-> chains into x_{i + 1}" if i < K - 1 else "(chain output)"
+        note(f"{i} |  {info['xs'][i]}   {info['ys'][i]}  |    {info['outs'][i]}    {chain}")
+    note(f"z = {bits(z)}    (one [1,x,y,out] block per instance)")
+
+    step(3, "batched R1CS: A = I_K (x) A0, so Az just applies A0 to every block")
+    a = r1cs.apply_base(r1cs.A0, z, K)
+    b = r1cs.apply_base(r1cs.B0, z, K)
+    c = r1cs.apply_base(r1cs.C0, z, K)
+    note(f"Az        = {bits(a)}    (block i row 0 = x_i)")
+    note(f"Bz        = {bits(b)}    (block i row 0 = y_i)")
+    note(f"Cz        = {bits(c)}    (block i row 0 = out_i)")
+    note(f"(Az)o(Bz) = {bits(a * b)}    elementwise == Cz  ok   (the Hadamard constraint)")
+    assert r1cs.check_r1cs(z, K)
+
+    step(4, "glue: Gz = 0 encodes the chain, one row per link (over F2, + is -)")
+    for i in range(K - 1):
+        note(f"G row {i}: z[{r1cs.out_index(i)}] (out_{i}) + z[{r1cs.in_index(i + 1)}] (x_{i + 1})  = 0")
+    g = r1cs.glue_matrix(K) @ GF(z.astype(np.int64))
+    note(f"G z = {bits(g)}  = 0  ok   (the cross-instance fact no single gate can see)")
+    assert r1cs.check_glue(z, K)
 
 
 # ------------------------------ end-to-end -------------------------------------
 
+def show_flock_proof(proof):
+    """Replay flock.verify() phase by phase, printing the verifier's math. The
+    transcript operations are IDENTICAL to verify()'s (same absorbs, same order),
+    so the challenges shown are the real ones, and every printed check is also
+    asserted - the narration cannot drift from what verify() actually accepts."""
+    cm, m, K = proof["cm"], proof["m"], proof["K"]
+    tr = Transcript()
+    tr.absorb_bytes(cm.root)
+
+    step("phase 1/5", "COMMIT - the witness MLE z_hat, held only as a PCS root")
+    note(f"K = {K} instances x {r1cs.BASE} slots = 2^{m} witness entries; root = {cm.root.hex()[:16]}..")
+
+    step("phase 2/5", "ZEROCHECK - 0 = sum_b eq(r,b) * (Az(b)*Bz(b) - Cz(b))")
+    r = tr.challenge_vec(m)
+    note(f"verifier randomness r = {vec(r)}; the claim starts at literally 0")
+    r_y, zc_expected = replay_sumcheck(proof["zc_rounds"], 3, GF(0), tr)
+    va, vb, vc = GF(proof["va"]), GF(proof["vb"]), GF(proof["vc"])
+    tr.absorb_fe_list([va, vb, vc])
+    e_ry = eval_mle(eq_vector(r), r_y)
+    lhs = e_ry * (va * vb - vc)
+    note(f"prover claims a(r_y) = {fe(va)}, b(r_y) = {fe(vb)}, c(r_y) = {fe(vc)}")
+    note(f"final point: eq(r,r_y)*(va*vb - vc) = {fe(lhs)}  == folded claim {fe(zc_expected)}  ok")
+    assert lhs == zc_expected
+    note("(va, vb, vc are so far only CLAIMS about Az, Bz, Cz - the lincheck earns them)")
+
+    step("phase 3/5", "LINCHECK - reduce the three matrix claims to ONE claim about z")
+    alpha = tr.challenge_vec(3)
+    etaA, etaB, etaC = flock._matrix_marginals(r_y, K)
+    eta = alpha[0] * etaA + alpha[1] * etaB + alpha[2] * etaC
+    lc_claim = alpha[0] * va + alpha[1] * vb + alpha[2] * vc
+    note(f"batching randomness alpha = {vec(alpha)}")
+    note(f"claim = alpha0*va + alpha1*vb + alpha2*vc = {fe(lc_claim)}")
+    note("eta = the same alpha-mix of the PUBLIC matrix marginals eq(r_y)^T M, which")
+    note("the verifier computes itself on the small base matrices (the 4.1 collapse)")
+    r_x, lc_expected = replay_sumcheck(proof["lc_rounds"], 2, lc_claim, tr)
+    z_rx = GF(proof["z_rx"])
+    tr.absorb_fe(z_rx)
+    lhs = eval_mle(eta, r_x) * z_rx
+    note(f"final point: eta(r_x) * z(r_x) = {fe(lhs)}  == folded claim {fe(lc_expected)}  ok")
+    assert lhs == lc_expected
+    note(f"-> surviving claim #1: z_hat(r_x) = {fe(z_rx)}   (the PCS settles it in phase 5)")
+
+    step("phase 4/5", "GLUE - the hash-chain: 0 = sum_b (eq(tau)^T G)(b) * z(b)")
+    tau = tr.challenge_vec(m)
+    etaG = eq_vector(tau) @ r1cs.glue_matrix(K)
+    note(f"tau = {vec(tau)};  etaG = eq(tau)^T G is public (built from the K-1 chain rows)")
+    r_g, g_expected = replay_sumcheck(proof["g_rounds"], 2, GF(0), tr)
+    z_rg = GF(proof["z_rg"])
+    tr.absorb_fe(z_rg)
+    lhs = eval_mle(etaG, r_g) * z_rg
+    note(f"final point: etaG(r_g) * z(r_g) = {fe(lhs)}  == folded claim {fe(g_expected)}  ok")
+    assert lhs == g_expected
+    note(f"-> surviving claim #2: z_hat(r_g) = {fe(z_rg)}")
+
+    step("phase 5/5", "OPEN - the PCS ties both surviving claims to the commitment")
+    v_x = pcs.verify(cm, r_x, proof["open_x"], tr)
+    note(f"open z_hat at r_x: v = {fe(v_x)}  == lincheck claim {fe(z_rx)}  ok")
+    assert v_x == z_rx
+    v_g = pcs.verify(cm, r_g, proof["open_g"], tr)
+    note(f"open z_hat at r_g: v = {fe(v_g)}  == glue claim {fe(z_rg)}  ok")
+    assert v_g == z_rg
+    note("verifier accepts: the COMMITTED witness satisfies the gates AND the chain.")
+
+
 def test_end_to_end():
     """Full pipeline (commit -> zerocheck -> lincheck -> glue -> open) accepts an
     honest hash-chain witness for batch sizes K = 2, 4, 8, 16."""
+    banner("END-TO-END  commit -> zerocheck -> lincheck -> glue -> open (flock.py)")
+    print("  Proving the SAME K = 4 chain witness from the R1CS section. Below is the")
+    print("  verifier's complete view, replayed check by check from the actual proof.")
+    z, _ = r1cs.gen_witness(4, 1, [1, 1, 0, 1])
+    proof = flock.prove(z, 4)
+    show_flock_proof(proof)
+    assert flock.verify(proof)
+
+    # The counted test: several batch sizes with (seeded-)random chains, quietly.
     for k in [1, 2, 3, 4]:
         K = 1 << k
         ys = [int(x) for x in np.random.default_rng(k).integers(0, 2, size=K)]
         z, _ = r1cs.gen_witness(K, x0=1, ys=ys)
         assert r1cs.check_r1cs(z, K) and r1cs.check_glue(z, K)
         assert flock.verify(flock.prove(z, K))
+    note("(re-run quietly for K = 2, 4, 8, 16 with random chains: all accepted)", 2)
     ok("end-to-end prove/verify for K=2,4,8,16")
 
 
 def test_soundness_bad_gate():
     """Flip one gate's output bit so x*y != out for instance 0. This violates the
     Hadamard constraint (Az) o (Bz) = Cz, so the ZEROCHECK must reject."""
+    banner("SOUNDNESS  each attack is caught by the sub-protocol built to catch it")
     K = 4
     z, _ = r1cs.gen_witness(K, 1, [1, 1, 0, 1])
+    step("attack 1", "corrupt ONE gate: flip out_0, so instance 0 claims 1 AND 1 = 0")
+    note(f"z before: {bits(z)}")
     z[0 * r1cs.BASE + 3] ^= 1                 # corrupt out_0
+    note(f"z after:  {bits(z)}    (block 0's out bit flipped)")
+    note("now (Az)o(Bz) != Cz at instance 0, so the zerocheck's true sum is NOT 0;")
+    note("its very first round message must satisfy g0(0)+g0(1) = 0 and cannot.")
     try:
         flock.verify(flock.prove(z, K))
         fail("bad-gate soundness", "accepted invalid witness")
-    except ValueError:
+    except ValueError as e:
+        note(f"flock.verify raises: {e}")
         ok("corrupt AND-gate rejected (zerocheck)")
 
 
@@ -149,21 +549,31 @@ def test_soundness_broken_chain():
     check Gz = 0 - the batch-only cross-instance binding - can catch this."""
     K = 4
     z, _ = r1cs.gen_witness(K, 1, [1, 1, 0, 1])
+    step("attack 2", "break the CHAIN: rewrite instance 1 as the perfectly valid gate 0 AND 1 = 0")
+    note(f"z before: {bits(z)}")
     base = 1 * r1cs.BASE                        # instance 1: valid gate, wrong input
     z[base + 1], z[base + 2], z[base + 3] = 0, 1, 0
     assert (z[base + 1] & z[base + 2]) == z[base + 3]   # gate still valid
+    note(f"z after:  {bits(z)}    (instance 1 fine in isolation, but x_1 = 0 != out_0 = 1)")
+    note("every gate satisfies x*y = out, so the zerocheck sees NOTHING wrong;")
+    note("but Gz != 0, so the glue sumcheck's claim of 0 is false and must fail.")
     try:
         flock.verify(flock.prove(z, K))
         fail("broken-chain soundness", "accepted broken chain")
-    except ValueError:
+    except ValueError as e:
+        note(f"flock.verify raises: {e}")
         ok("broken hash-chain rejected (glue)")
 
 
 if __name__ == "__main__":
-    print("Flock (pedagogical) test suite\n")
+    print("Flock (pedagogical) test suite")
+    print("Each section prints the REAL math its test verifies: worked examples use")
+    print("hand-checkable values; random 128-bit elements display as 0xHEAD..TAIL.")
+    demo_field()
     test_mle_agrees_on_cube()
     test_sumcheck_roundtrip_and_soundness()
     test_pcs_roundtrip_and_soundness()
+    demo_r1cs()
     test_end_to_end()
     test_soundness_bad_gate()
     test_soundness_broken_chain()

--- a/paper/flock_py/test_flock.py
+++ b/paper/flock_py/test_flock.py
@@ -1,0 +1,170 @@
+"""
+test_flock.py - self-contained test suite for the pedagogical Flock.
+
+Run:  python3 test_flock.py     (needs `galois` and `numpy`; see README.md)
+Exits non-zero on the first failure; prints a summary otherwise.
+
+Two kinds of tests, deliberately paired:
+  - COMPLETENESS: honest prover + honest verifier accept (MLE identities,
+    sumcheck round-trip, PCS round-trip, end-to-end for several batch sizes).
+  - SOUNDNESS: each tampering is caught by the specific sub-protocol whose job
+    it is to catch it (zerocheck for a bad gate, glue for a broken chain, the
+    PCS for forged evaluations/columns, sumcheck for altered round messages).
+"""
+
+import numpy as np
+from field import GF
+from mle import eval_mle, eq_vector
+from transcript import Transcript
+import sumcheck
+import pcs
+import r1cs
+import flock
+
+PASS = []
+
+
+def ok(name):
+    PASS.append(name)
+    print(f"  ok  {name}")
+
+
+def fail(name, e):
+    print(f" FAIL {name}: {e}")
+    raise SystemExit(1)
+
+
+# ------------------------------- MLE -------------------------------------------
+
+def test_mle_agrees_on_cube():
+    """Defining property of the multilinear extension: f_hat interpolates f,
+    i.e. evaluating at every boolean corner returns the original table entry."""
+    m = 4
+    t = GF.Random(1 << m)
+    for i in range(1 << m):
+        pt = GF([(i >> v) & 1 for v in range(m)])
+        assert eval_mle(t, pt) == t[i]
+    ok("MLE agrees with table on all 2^m corners")
+
+
+# ----------------------------- sumcheck ----------------------------------------
+
+def test_sumcheck_roundtrip_and_soundness():
+    """Honest sumcheck verifies: challenges match, the verifier's final expected
+    value equals P at the bound point, and the bound tables really are the MLEs
+    at the challenge point. Then: flipping one round message must be rejected."""
+    m = 4
+    a, b, c = GF.Random(1 << m), GF.Random(1 << m), GF.Random(1 << m)
+    r = GF.Random(m)
+    eqw = eq_vector(r)
+
+    def combine(ts):
+        e, a, b, c = ts
+        return e * (a * b - c)
+
+    claim = GF(np.sum(combine([eqw, a, b, c])))
+    rounds, ch, final = sumcheck.prove([eqw, a, b, c], 3, combine, Transcript())
+    chv, expected = sumcheck.verify(rounds, 3, claim, Transcript())
+    assert np.array_equal(np.array(ch), np.array(chv))
+    assert combine([GF([x]) for x in final])[0] == expected
+    assert final[1] == eval_mle(a, ch)
+    ok("sumcheck prove/verify + final-point consistency")
+
+    bad = [x.copy() for x in rounds]
+    bad[0] = bad[0].copy(); bad[0][0] = bad[0][0] + GF(1)
+    try:
+        sumcheck.verify(bad, 3, claim, Transcript())
+        fail("sumcheck soundness", "tamper not caught")
+    except ValueError:
+        ok("tampered sumcheck rejected")
+
+
+# -------------------------------- PCS ------------------------------------------
+
+def test_pcs_roundtrip_and_soundness():
+    """PCS round-trip on several sizes (odd/even m exercise both row/col splits),
+    then two forgeries: a wrong claimed value v, and a tampered committed column
+    (which must fail the Merkle check or a code-consistency check)."""
+    for m in [2, 3, 5, 6]:
+        t = GF.Random(1 << m)
+        prover, cm = pcs.commit(t)
+        r = GF.Random(m)
+        proof = pcs.open(prover, r, Transcript())
+        v = pcs.verify(cm, r, proof, Transcript())
+        assert v == eval_mle(t, r)
+    ok("PCS commit/open/verify matches MLE (m=2,3,5,6)")
+
+    t = GF.Random(1 << 4)
+    prover, cm = pcs.commit(t)
+    r = GF.Random(4)
+    proof = pcs.open(prover, r, Transcript())
+    proof["v"] = proof["v"] + GF(1)
+    try:
+        pcs.verify(cm, r, proof, Transcript())
+        fail("PCS soundness (value)", "tampered value accepted")
+    except ValueError:
+        ok("PCS rejects tampered evaluation value")
+
+    proof = pcs.open(prover, r, Transcript())
+    q, col, path = proof["openings"][0]
+    col2 = col.copy(); col2[0] = col2[0] + GF(1)
+    proof["openings"][0] = (q, col2, path)
+    try:
+        pcs.verify(cm, r, proof, Transcript())
+        fail("PCS soundness (column)", "tampered column accepted")
+    except ValueError:
+        ok("PCS rejects tampered committed column")
+
+
+# ------------------------------ end-to-end -------------------------------------
+
+def test_end_to_end():
+    """Full pipeline (commit -> zerocheck -> lincheck -> glue -> open) accepts an
+    honest hash-chain witness for batch sizes K = 2, 4, 8, 16."""
+    for k in [1, 2, 3, 4]:
+        K = 1 << k
+        ys = [int(x) for x in np.random.default_rng(k).integers(0, 2, size=K)]
+        z, _ = r1cs.gen_witness(K, x0=1, ys=ys)
+        assert r1cs.check_r1cs(z, K) and r1cs.check_glue(z, K)
+        assert flock.verify(flock.prove(z, K))
+    ok("end-to-end prove/verify for K=2,4,8,16")
+
+
+def test_soundness_bad_gate():
+    """Flip one gate's output bit so x*y != out for instance 0. This violates the
+    Hadamard constraint (Az) o (Bz) = Cz, so the ZEROCHECK must reject."""
+    K = 4
+    z, _ = r1cs.gen_witness(K, 1, [1, 1, 0, 1])
+    z[0 * r1cs.BASE + 3] ^= 1                 # corrupt out_0
+    try:
+        flock.verify(flock.prove(z, K))
+        fail("bad-gate soundness", "accepted invalid witness")
+    except ValueError:
+        ok("corrupt AND-gate rejected (zerocheck)")
+
+
+def test_soundness_broken_chain():
+    """The subtler attack: every gate is individually valid (so the zerocheck
+    passes) but instance 1's input is not instance 0's output. Only the GLUE
+    check Gz = 0 - the batch-only cross-instance binding - can catch this."""
+    K = 4
+    z, _ = r1cs.gen_witness(K, 1, [1, 1, 0, 1])
+    base = 1 * r1cs.BASE                        # instance 1: valid gate, wrong input
+    z[base + 1], z[base + 2], z[base + 3] = 0, 1, 0
+    assert (z[base + 1] & z[base + 2]) == z[base + 3]   # gate still valid
+    try:
+        flock.verify(flock.prove(z, K))
+        fail("broken-chain soundness", "accepted broken chain")
+    except ValueError:
+        ok("broken hash-chain rejected (glue)")
+
+
+if __name__ == "__main__":
+    print("Flock (pedagogical) test suite\n")
+    test_mle_agrees_on_cube()
+    test_sumcheck_roundtrip_and_soundness()
+    test_pcs_roundtrip_and_soundness()
+    test_end_to_end()
+    test_soundness_bad_gate()
+    test_soundness_broken_chain()
+    print(f"\nAll {len(PASS)} checks passed.")

--- a/paper/flock_py/transcript.py
+++ b/paper/flock_py/transcript.py
@@ -1,0 +1,75 @@
+"""
+transcript.py - Fiat-Shamir transcript backed by SHA-256.
+
+This is the *only* cryptographic assumption in the whole system (exactly as the
+paper states: "the remaining soundness assumption is the security of SHA-256,
+used internally for both Merkle commitments and Fiat-Shamir"). We hash the
+running protocol transcript and squeeze out verifier challenges in F = GF(2^128),
+turning the interactive protocol into a non-interactive one.
+"""
+
+import hashlib
+from field import GF
+
+FE_BYTES = 16  # 128 bits per field element
+
+
+def fe_to_bytes(x):
+    """Serialize a single GF(2^128) element to 16 big-endian bytes."""
+    return int(x).to_bytes(FE_BYTES, "big")
+
+
+class Transcript:
+    """
+    A running SHA-256 hash of every message exchanged so far.
+
+    The prover ABSORBS each protocol message before squeezing the CHALLENGE that
+    would have been the verifier's reply; the verifier replays the exact same
+    absorb/challenge sequence, so both sides derive identical challenges iff they
+    saw identical messages. Any tampering desynchronizes the challenges and some
+    later check fails. Prover and verifier must therefore call these methods in
+    EXACTLY the same order - compare prove() and verify() in flock.py line by line.
+    """
+
+    def __init__(self, label=b"flock"):
+        # Domain-separation label: proofs for different protocols (or protocol
+        # versions) hash differently even on identical messages.
+        self.h = hashlib.sha256()
+        self.h.update(label)
+
+    def absorb_bytes(self, data: bytes):
+        """Mix raw bytes (e.g. a Merkle root) into the transcript."""
+        # length-prefixed so distinct messages can't be ambiguously concatenated
+        # (absorb(b"ab"); absorb(b"c") must differ from absorb(b"a"); absorb(b"bc"))
+        self.h.update(len(data).to_bytes(8, "big"))
+        self.h.update(data)
+        return self
+
+    def absorb_fe(self, x):
+        """Mix one GF(2^128) element into the transcript."""
+        return self.absorb_bytes(fe_to_bytes(x))
+
+    def absorb_fe_list(self, xs):
+        """Mix a sequence of field elements, in order."""
+        for x in xs:
+            self.absorb_fe(x)
+        return self
+
+    def challenge(self):
+        """Squeeze one field element; also re-key so the next challenge differs."""
+        digest = self.h.digest()               # 32 bytes
+        # fold the 256-bit digest to 128 bits (XOR halves); any 128-bit string is
+        # a valid field element, so no modular bias to worry about
+        val = int.from_bytes(digest[:FE_BYTES], "big") ^ int.from_bytes(
+            digest[FE_BYTES:], "big"
+        )
+        self.h.update(b"squeeze")              # ratchet the state
+        return GF(val % (2**128))
+
+    def challenge_vec(self, n):
+        """Squeeze n field elements as one galois array (e.g. a random point in F^n).
+
+        Note the int() round-trip: GF([...]) wants integers, not 0-d galois
+        scalars - another instance of the field-element-vs-integer distinction
+        that galois makes you handle explicitly."""
+        return GF([int(self.challenge()) for _ in range(n)])


### PR DESCRIPTION
## What this is

A faithful, heavily-commented **educational Python port of Flock** (the protocol in `paper/flock-paper.pdf`), added under `paper/flock_py/`.
It is built on `galois` + `numpy`, with one concept per module, every non-trivial function explaining the math or protocol step it performs, and each module docstring tying the code back to its paper section.
The intent is a companion to the Rust crates: read the Python next to the paper to understand *what* the protocol does, then read the Rust to see *how* to make it fast.

Nothing outside `paper/flock_py/` is touched.

## What it implements

The full end-to-end pipeline, over the paper's own field GF(2^128) with the GHASH polynomial `x^128 + x^7 + x^2 + x + 1`:

| Module | Role | Paper |
|---|---|---|
| `field.py` | GF(2^128) via the GHASH irreducible | §4.3 |
| `mle.py` | multilinear extension, `eq`, variable folding | §2.1 |
| `transcript.py` | Fiat-Shamir over SHA-256 | §1.1 |
| `sumcheck.py` | generic sumcheck prover/verifier | §2.3 |
| `pcs.py` | real hash-based multilinear PCS (Ligero: SHA-256 Merkle + Reed-Solomon) | §2.4, App. C |
| `r1cs.py` | batched AND-gate R1CS (`I_K ⊗ A0`) + hash-chain glue matrix | §3, §4.1, §4.6 |
| `flock.py` | commit → zerocheck → lincheck → glue → open | §3-§4 |
| `flock_perf.py` | batch vs K-times-separate wall-clock benchmark | §1, §5 |
| `test_flock.py` | completeness + soundness test suite, printed as a worked example | - |

The demo statement is a batch of K AND-gates wired into a hash-chain (`out_i = x_{i+1}`), so the glue check has real work to do: the broken-chain test passes every individual gate but is rejected by the glue sumcheck alone.

## The test suite is also a guided tour

Running `test_flock.py` pretty-prints the actual math each test verifies, stage by stage: GF(2^128) arithmetic with hand-checkable operands (XOR addition, the `x^128 = x^7+x^2+x+1` reduction), the eq weights and their partition-of-unity, every sumcheck round's message / `g(0)+g(1)` check / challenge / folded claim, the PCS matrix, its Reed-Solomon codewords, the Merkle root and both column spot-checks, the batched R1CS witness as bit blocks, and a phase-by-phase replay of the entire verifier (commit → zerocheck → lincheck → glue → open) for a K = 4 chain.
Nothing printed is mocked: the narration re-runs the verifier's own transcript operations and asserts every identity it prints, and the soundness tests show the exact tampered bits and the exact error the verifier raises.

## Faithful vs deliberately simplified

**Faithful:** the protocol structure and all soundness logic - the zerocheck/lincheck decomposition, the §4.1 block-diagonal collapse (matrix marginals computed on the small base matrix, never the K-times-larger batched matrix), one shared Fiat-Shamir transcript, a transparent hash-based PCS whose only cryptographic assumption is SHA-256 (no pairings, no trusted setup), and PCS openings bound to the sumcheck claims.

**Deliberately simplified (documented in the README):** the §4 performance techniques whose point is CPU/cache behavior and which are invisible in Python - univariate skip (§4.2), friendly challenges (§4.3), circuit walking (§4.5), and the ring-switching dense→Boolean PCS transform (App. B).
The glue is proven with the same generic lincheck used for A, B, C rather than the tailored shift argument.
Parameters are tiny and conservative for readability.

## Testing

All 9 tests pass (`python3 test_flock.py`, needs `pip install galois numpy`):

```
ok  MLE agrees with table on all 2^m corners
ok  sumcheck prove/verify + final-point consistency
ok  tampered sumcheck rejected
ok  PCS commit/open/verify matches MLE (m=2,3,5,6)
ok  PCS rejects tampered evaluation value
ok  PCS rejects tampered committed column
ok  end-to-end prove/verify for K=2,4,8,16
ok  corrupt AND-gate rejected (zerocheck)
ok  broken hash-chain rejected (glue)
```

## Benchmark results

`flock_perf.py` reproduces the paper's headline in miniature: one batch proof beats K separate proofs, and the separate proofs cannot express the cross-instance chain at all.
Measured single-run output (now recorded verbatim in the README):

```
   K | prove batch  prove sep speedup | verify batch verify sep speedup | #proofs b/s
--------------------------------------------------------------------------------------------
   2 |      23.3ms     22.7ms   0.97x |      213.6ms    284.5ms   1.33x |    1/2
   4 |      31.2ms     45.9ms   1.47x |      287.0ms    567.9ms   1.98x |    1/4
   8 |      44.7ms     88.1ms   1.97x |      355.7ms   1106.8ms   3.11x |    1/8
  16 |      80.7ms    168.4ms   2.09x |      456.6ms   2208.6ms   4.84x |    1/16
  32 |     173.5ms    363.9ms   2.10x |      593.2ms   4447.3ms   7.50x |    1/32
  64 |     463.3ms    702.5ms   1.52x |      903.3ms   8863.5ms   9.81x |    1/64
```

Prove speedup peaks at ~2.1x and verify reaches ~9.8x at K = 64, with the verifier checking 1 proof instead of K.

**Hardware:** MacBook Pro, Apple M1 Max - 10 cores (8 performance + 2 efficiency), 64 GB RAM, macOS 15.7.4; Python 3.8.5 (conda) with `galois` 0.4.10, `numpy` 1.24.4.
**Available memory at run time** (captured immediately before the run): `memory_pressure` reported 42% system-wide free (~27 GB of 64 GB); `vm_stat` showed 3,734 pages free + 875,469 pages inactive (16 KiB pages, ~13.4 GB directly reclaimable).
