### PR TITLE
pcs: batch sparse-PD round-0 recompute — O(n_pd·2^L) → O(Σ support + 2^L)

### DIFF
--- a/crates/flock-core/src/pcs.rs
+++ b/crates/flock-core/src/pcs.rs
@@ -647,24 +647,33 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
             }
         }
     }
+    // Scatter every sparse PD claim into b_combined first, then recompute round0
+    // ONCE. The per-claim round0 assignment is an overwrite (not an accumulate),
+    // so only a single reduction over the fully-scattered b_combined is needed —
+    // replacing O(n_pd · 2^L) full sweeps (the prove bottleneck) with O(Σ support
+    // + 2^L). Result is bit-identical (F128 addition is commutative).
+    let mut any_sparse_pd = false;
     for (pd, g) in packed_direct.iter().zip(gammas_pd.iter()) {
         if let DirectEqInd::Sparse(eq) = &pd.eq_ind {
             sparse_scatter_add_parallel(&mut b_combined, eq, *g);
-            let (u0_fix, u2_fix) = b_combined
-                .par_chunks(2)
-                .enumerate()
-                .map(|(i, chunk)| {
-                    let a0 = packed_witness[2 * i];
-                    let a1 = packed_witness[2 * i + 1];
-                    (a0 * chunk[0], (a0 + a1) * (chunk[0] + chunk[1]))
-                })
-                .reduce(
-                    || (F128::ZERO, F128::ZERO),
-                    |(x0, x2), (y0, y2)| (x0 + y0, x2 + y2),
-                );
-            round0_u0 = u0_fix;
-            round0_u2 = u2_fix;
+            any_sparse_pd = true;
         }
+    }
+    if any_sparse_pd {
+        let (u0_fix, u2_fix) = b_combined
+            .par_chunks(2)
+            .enumerate()
+            .map(|(i, chunk)| {
+                let a0 = packed_witness[2 * i];
+                let a1 = packed_witness[2 * i + 1];
+                (a0 * chunk[0], (a0 + a1) * (chunk[0] + chunk[1]))
+            })
+            .reduce(
+                || (F128::ZERO, F128::ZERO),
+                |(x0, x2), (y0, y2)| (x0 + y0, x2 + y2),
+            );
+        round0_u0 = u0_fix;
+        round0_u2 = u2_fix;
     }
     if trace {
         eprintln!(


### PR DESCRIPTION
## What

`compute_combined_basis_and_target` re-swept the full `2^L` `b_combined` array to recompute the round-0 correction after **each** sparse `PackedDirectClaim` was scattered. The per-claim assignment overwrites `round0_u0`/`round0_u2` rather than accumulating, so every sweep except the last one was dead work — with `n_pd` sparse claims the loop cost `O(n_pd · 2^L)` while only the final sweep's result survived.

This PR scatters all sparse claims first, then does the round-0 reduction **once**.

## Why it is safe

Bit-identical output: F128 addition is commutative (the scatter order doesn't matter), and the overwritten intermediate `round0_*` values were never observable. Workloads with zero or one sparse PD claim produce identical bytes and identical work.

## Measured

Found while profiling a batched SHA-256 Merkle-path workload (MHOT multiproof on our fork) that opens ~9k per-block sparse PD claims at L=23:

- PCS open: **29.5 s → 0.43 s** (68×)
- end-to-end prove: **34.8 s → 2.0 s**

Proof bytes identical before/after.

## Tests

All flock-core tests pass (255). No behavior change, so no new tests added.