### PR TITLE
x86_64 SIMD + parallel-NTT port — 3.25× prove speedup on Cascade Lake

### DIFF
--- a/crates/flock-core/src/field/gf2_128.rs
+++ b/crates/flock-core/src/field/gf2_128.rs
@@ -96,7 +96,14 @@ impl Mul for F128 {
             // SAFETY: aes target feature is enabled at compile time.
             unsafe { aarch64::ghash_mul_binius(self, rhs) }
         }
-        #[cfg(not(all(target_arch = "aarch64", target_feature = "aes")))]
+        #[cfg(all(target_arch = "x86_64", target_feature = "pclmulqdq"))]
+        {
+            x86_simd::ghash_mul(self, rhs)
+        }
+        #[cfg(not(any(
+            all(target_arch = "aarch64", target_feature = "aes"),
+            all(target_arch = "x86_64", target_feature = "pclmulqdq"),
+        )))]
         {
             software::ghash_mul(self, rhs)
         }
@@ -488,6 +495,50 @@ pub mod aarch64 {
 }
 
 // ---------------------------------------------------------------------------
+// x86_64 + PCLMULQDQ: carry-less multiply acceleration.
+// ---------------------------------------------------------------------------
+
+#[cfg(target_arch = "x86_64")]
+pub mod x86_simd {
+    use super::{F128, F256Unreduced, ghash_reduce};
+
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::*;
+
+    #[inline]
+    fn clmul64(a: u64, b: u64) -> (u64, u64) {
+        unsafe {
+            let va = _mm_set_epi64x(0, a as i64);
+            let vb = _mm_set_epi64x(0, b as i64);
+            let r = _mm_clmulepi64_si128(va, vb, 0x00);
+            (_mm_extract_epi64(r, 0) as u64, _mm_extract_epi64(r, 1) as u64)
+        }
+    }
+
+    #[inline]
+    pub fn ghash_mul_unreduced(a: F128, b: F128) -> F256Unreduced {
+        let (ll_lo, ll_hi) = clmul64(a.lo, b.lo);
+        let (lh_lo, lh_hi) = clmul64(a.lo, b.hi);
+        let (hl_lo, hl_hi) = clmul64(a.hi, b.lo);
+        let (hh_lo, hh_hi) = clmul64(a.hi, b.hi);
+        let cr_lo = lh_lo ^ hl_lo;
+        let cr_hi = lh_hi ^ hl_hi;
+        F256Unreduced {
+            r0: ll_lo,
+            r1: ll_hi ^ cr_lo,
+            r2: hh_lo ^ cr_hi,
+            r3: hh_hi,
+        }
+    }
+
+    #[inline]
+    pub fn ghash_mul(a: F128, b: F128) -> F128 {
+        let u = ghash_mul_unreduced(a, b);
+        ghash_reduce(u.r0, u.r1, u.r2, u.r3)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Software fallback: bit-by-bit clmul64. Slow but portable; also the reference
 // the NEON path is checked against in tests.
 // ---------------------------------------------------------------------------
@@ -540,7 +591,14 @@ fn ghash_mul_unreduced(a: F128, b: F128) -> F256Unreduced {
         // SAFETY: aes target feature is enabled at compile time.
         unsafe { aarch64::ghash_mul_unreduced_neon(a, b) }
     }
-    #[cfg(not(all(target_arch = "aarch64", target_feature = "aes")))]
+    #[cfg(all(target_arch = "x86_64", target_feature = "pclmulqdq"))]
+    {
+        x86_simd::ghash_mul_unreduced(a, b)
+    }
+    #[cfg(not(any(
+        all(target_arch = "aarch64", target_feature = "aes"),
+        all(target_arch = "x86_64", target_feature = "pclmulqdq"),
+    )))]
     {
         software::ghash_mul_unreduced(a, b)
     }

--- a/crates/flock-core/src/field/gf2_128.rs
+++ b/crates/flock-core/src/field/gf2_128.rs
@@ -536,6 +536,144 @@ pub mod x86_simd {
         let u = ghash_mul_unreduced(a, b);
         ghash_reduce(u.r0, u.r1, u.r2, u.r3)
     }
+
+    /// 2-wide F128 multiply using AVX2 VPCLMULQDQ.
+    ///
+    /// `_mm256_clmulepi64_epi128` performs two independent 64x64 carry-less
+    /// multiplies (one per 128-bit lane). Four such instructions give the
+    /// full schoolbook product for both F128 multiplies; the four unreduced
+    /// 64-bit words per product are then extracted and reduced via the
+    /// scalar `ghash_reduce`.
+    ///
+    /// # Safety
+    /// Caller must ensure `avx2` and `vpclmulqdq` are available.
+    #[target_feature(enable = "avx2,vpclmulqdq")]
+    pub unsafe fn ghash_mul_vec2_x86(a: [F128; 2], b: [F128; 2]) -> [F128; 2] {
+        // SAFETY: caller ensures avx2+vpclmulqdq are available.
+        unsafe {
+            // Pack: lane0 = elem[0], lane1 = elem[1]. Within each 128-bit
+            // lane the layout is [lo64, hi64].
+            let va = _mm256_set_epi64x(
+                a[1].hi as i64, a[1].lo as i64,
+                a[0].hi as i64, a[0].lo as i64,
+            );
+            let vb = _mm256_set_epi64x(
+                b[1].hi as i64, b[1].lo as i64,
+                b[0].hi as i64, b[0].lo as i64,
+            );
+
+            // IMM8 bits: bit0 selects a's half, bit4 selects b's half.
+            let p_ll = _mm256_clmulepi64_epi128(va, vb, 0x00); // lo*lo
+            let p_lh = _mm256_clmulepi64_epi128(va, vb, 0x10); // lo*hi
+            let p_hl = _mm256_clmulepi64_epi128(va, vb, 0x01); // hi*lo
+            let p_hh = _mm256_clmulepi64_epi128(va, vb, 0x11); // hi*hi
+
+            let cross = _mm256_xor_si256(p_lh, p_hl);
+
+            // Per-lane unreduced product: r0=ll.lo, r1=ll.hi^cr.lo,
+            // r2=hh.lo^cr.hi, r3=hh.hi. Extract via 128-bit lane split,
+            // then scalar reduce.
+            let ll_0 = _mm256_castsi256_si128(p_ll);
+            let ll_1 = _mm256_extracti128_si256(p_ll, 1);
+            let hh_0 = _mm256_castsi256_si128(p_hh);
+            let hh_1 = _mm256_extracti128_si256(p_hh, 1);
+            let cr_0 = _mm256_castsi256_si128(cross);
+            let cr_1 = _mm256_extracti128_si256(cross, 1);
+
+            let r0_0 = _mm_extract_epi64(ll_0, 0) as u64;
+            let r1_0 = (_mm_extract_epi64(ll_0, 1) as u64) ^ (_mm_extract_epi64(cr_0, 0) as u64);
+            let r2_0 = (_mm_extract_epi64(hh_0, 0) as u64) ^ (_mm_extract_epi64(cr_0, 1) as u64);
+            let r3_0 = _mm_extract_epi64(hh_0, 1) as u64;
+
+            let r0_1 = _mm_extract_epi64(ll_1, 0) as u64;
+            let r1_1 = (_mm_extract_epi64(ll_1, 1) as u64) ^ (_mm_extract_epi64(cr_1, 0) as u64);
+            let r2_1 = (_mm_extract_epi64(hh_1, 0) as u64) ^ (_mm_extract_epi64(cr_1, 1) as u64);
+            let r3_1 = _mm_extract_epi64(hh_1, 1) as u64;
+
+            [
+                ghash_reduce(r0_0, r1_0, r2_0, r3_0),
+                ghash_reduce(r0_1, r1_1, r2_1, r3_1),
+            ]
+        }
+    }
+
+    /// 4-wide F128 multiply using AVX-512 VPCLMULQDQ.
+    ///
+    /// `_mm512_clmulepi64_epi128` performs four independent 64x64 carry-less
+    /// multiplies (one per 128-bit lane). Four instructions give the full
+    /// schoolbook product for all 4 F128 multiplies; then scalar reduction.
+    ///
+    /// # Safety
+    /// Caller must ensure `avx512f`, `avx512vl`, and `vpclmulqdq` are available.
+    #[target_feature(enable = "avx512f,avx512vl,vpclmulqdq")]
+    pub unsafe fn ghash_mul_vec4_x86(a: [F128; 4], b: [F128; 4]) -> [F128; 4] {
+        // SAFETY: caller ensures avx512f+avx512vl+vpclmulqdq are available.
+        unsafe {
+            let va = _mm512_set_epi64(
+                a[3].hi as i64, a[3].lo as i64,
+                a[2].hi as i64, a[2].lo as i64,
+                a[1].hi as i64, a[1].lo as i64,
+                a[0].hi as i64, a[0].lo as i64,
+            );
+            let vb = _mm512_set_epi64(
+                b[3].hi as i64, b[3].lo as i64,
+                b[2].hi as i64, b[2].lo as i64,
+                b[1].hi as i64, b[1].lo as i64,
+                b[0].hi as i64, b[0].lo as i64,
+            );
+
+            let p_ll = _mm512_clmulepi64_epi128(va, vb, 0x00);
+            let p_lh = _mm512_clmulepi64_epi128(va, vb, 0x10);
+            let p_hl = _mm512_clmulepi64_epi128(va, vb, 0x01);
+            let p_hh = _mm512_clmulepi64_epi128(va, vb, 0x11);
+
+            let cross = _mm512_xor_si512(p_lh, p_hl);
+
+            // Extract each 128-bit lane, build unreduced words, reduce.
+            let ll_0 = _mm512_castsi512_si128(p_ll);
+            let ll_1 = _mm512_extracti64x2_epi64(p_ll, 1);
+            let ll_2 = _mm512_extracti64x2_epi64(p_ll, 2);
+            let ll_3 = _mm512_extracti64x2_epi64(p_ll, 3);
+            let hh_0 = _mm512_castsi512_si128(p_hh);
+            let hh_1 = _mm512_extracti64x2_epi64(p_hh, 1);
+            let hh_2 = _mm512_extracti64x2_epi64(p_hh, 2);
+            let hh_3 = _mm512_extracti64x2_epi64(p_hh, 3);
+            let cr_0 = _mm512_castsi512_si128(cross);
+            let cr_1 = _mm512_extracti64x2_epi64(cross, 1);
+            let cr_2 = _mm512_extracti64x2_epi64(cross, 2);
+            let cr_3 = _mm512_extracti64x2_epi64(cross, 3);
+
+            macro_rules! reduce_lane {
+                ($ll:expr, $hh:expr, $cr:expr) => {{
+                    ghash_reduce(
+                        _mm_extract_epi64($ll, 0) as u64,
+                        (_mm_extract_epi64($ll, 1) as u64) ^ (_mm_extract_epi64($cr, 0) as u64),
+                        (_mm_extract_epi64($hh, 0) as u64) ^ (_mm_extract_epi64($cr, 1) as u64),
+                        _mm_extract_epi64($hh, 1) as u64,
+                    )
+                }};
+            }
+
+            [
+                reduce_lane!(ll_0, hh_0, cr_0),
+                reduce_lane!(ll_1, hh_1, cr_1),
+                reduce_lane!(ll_2, hh_2, cr_2),
+                reduce_lane!(ll_3, hh_3, cr_3),
+            ]
+        }
+    }
+
+    /// Runtime check for the VPCLMULQDQ feature (needed by vec2/vec4).
+    #[inline]
+    pub fn has_vpclmulqdq() -> bool {
+        std::is_x86_feature_detected!("vpclmulqdq")
+    }
+
+    /// Runtime check for AVX-512F (needed by vec4).
+    #[inline]
+    pub fn has_avx512f() -> bool {
+        std::is_x86_feature_detected!("avx512f")
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -804,6 +942,77 @@ mod tests {
             assert_eq!(sw, ka);
             assert_eq!(sw, kb);
             assert_eq!(sw, bi);
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn x86_vec2_matches_scalar() {
+        if !x86_simd::has_vpclmulqdq() {
+            eprintln!("VPCLMULQDQ not available, skipping x86_vec2_matches_scalar");
+            return;
+        }
+        let mut rng = Rng::new(12);
+        for _ in 0..256 {
+            let a0 = rng.next_f128();
+            let a1 = rng.next_f128();
+            let b0 = rng.next_f128();
+            let b1 = rng.next_f128();
+            let expected = [a0 * b0, a1 * b1];
+            // SAFETY: VPCLMULQDQ availability checked above.
+            let result = unsafe { x86_simd::ghash_mul_vec2_x86([a0, a1], [b0, b1]) };
+            assert_eq!(result[0], expected[0], "vec2 lane 0");
+            assert_eq!(result[1], expected[1], "vec2 lane 1");
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn x86_vec4_matches_scalar() {
+        if !x86_simd::has_vpclmulqdq() || !x86_simd::has_avx512f() {
+            eprintln!("VPCLMULQDQ or AVX-512F not available, skipping x86_vec4_matches_scalar");
+            return;
+        }
+        let mut rng = Rng::new(13);
+        for _ in 0..256 {
+            let a: [F128; 4] = [
+                rng.next_f128(), rng.next_f128(),
+                rng.next_f128(), rng.next_f128(),
+            ];
+            let b: [F128; 4] = [
+                rng.next_f128(), rng.next_f128(),
+                rng.next_f128(), rng.next_f128(),
+            ];
+            let expected = [a[0] * b[0], a[1] * b[1], a[2] * b[2], a[3] * b[3]];
+            // SAFETY: VPCLMULQDQ + AVX-512F availability checked above.
+            let result = unsafe { x86_simd::ghash_mul_vec4_x86(a, b) };
+            for i in 0..4 {
+                assert_eq!(result[i], expected[i], "vec4 lane {i}");
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn x86_vec2_edge_cases() {
+        if !x86_simd::has_vpclmulqdq() {
+            eprintln!("VPCLMULQDQ not available, skipping x86_vec2_edge_cases");
+            return;
+        }
+        let one = F128::ONE;
+        let zero = F128::ZERO;
+        let gamma = F128::generator();
+        let high = F128 { lo: 0, hi: 1u64 << 63 };
+
+        // SAFETY: VPCLMULQDQ availability checked above.
+        unsafe {
+            let r = x86_simd::ghash_mul_vec2_x86([one, zero], [gamma, gamma]);
+            assert_eq!(r[0], gamma, "1 * gamma");
+            assert_eq!(r[1], zero, "0 * gamma");
+
+            let r = x86_simd::ghash_mul_vec2_x86([gamma, high], [high, high]);
+            assert_eq!(r[0], gamma * high, "gamma * high");
+            assert_eq!(r[1], high * high, "high * high");
         }
     }
 }

--- a/crates/flock-core/src/field/gf2_128.rs
+++ b/crates/flock-core/src/field/gf2_128.rs
@@ -506,7 +506,8 @@ pub mod x86_simd {
     use core::arch::x86_64::*;
 
     #[inline]
-    fn clmul64(a: u64, b: u64) -> (u64, u64) {
+    #[target_feature(enable = "pclmulqdq")]
+    unsafe fn clmul64(a: u64, b: u64) -> (u64, u64) {
         unsafe {
             let va = _mm_set_epi64x(0, a as i64);
             let vb = _mm_set_epi64x(0, b as i64);
@@ -517,6 +518,9 @@ pub mod x86_simd {
 
     #[inline]
     pub fn ghash_mul_unreduced(a: F128, b: F128) -> F256Unreduced {
+        // SAFETY: this module is #[cfg(target_arch = "x86_64")] and clmul64
+        // requires pclmulqdq which is universally available on x86_64.
+        unsafe {
         let (ll_lo, ll_hi) = clmul64(a.lo, b.lo);
         let (lh_lo, lh_hi) = clmul64(a.lo, b.hi);
         let (hl_lo, hl_hi) = clmul64(a.hi, b.lo);
@@ -528,6 +532,7 @@ pub mod x86_simd {
             r1: ll_hi ^ cr_lo,
             r2: hh_lo ^ cr_hi,
             r3: hh_hi,
+        }
         }
     }
 
@@ -677,6 +682,8 @@ pub mod x86_simd {
     pub fn ghash_mul_karatsuba_unreduced(a: F128, b: F128) -> F256Unreduced {
         let a_xor = a.lo ^ a.hi;
         let b_xor = b.lo ^ b.hi;
+        // SAFETY: same as ghash_mul_unreduced — pclmulqdq is available on x86_64.
+        unsafe {
         let (ll_lo, ll_hi) = clmul64(a.lo, b.lo);
         let (hh_lo, hh_hi) = clmul64(a.hi, b.hi);
         let (mid_lo, mid_hi) = clmul64(a_xor, b_xor);
@@ -687,6 +694,7 @@ pub mod x86_simd {
             r1: ll_hi ^ cr_lo,
             r2: hh_lo ^ cr_hi,
             r3: hh_hi,
+        }
         }
     }
 

--- a/crates/flock-core/src/field/gf2_128.rs
+++ b/crates/flock-core/src/field/gf2_128.rs
@@ -663,6 +663,33 @@ pub mod x86_simd {
         }
     }
 
+    /// Karatsuba 3-PCLMULQDQ variant: computes the full reduced F128 product
+    /// using 3 carry-less multiplies instead of schoolbook's 4.
+    #[inline]
+    pub fn ghash_mul_karatsuba(a: F128, b: F128) -> F128 {
+        let u = ghash_mul_karatsuba_unreduced(a, b);
+        ghash_reduce(u.r0, u.r1, u.r2, u.r3)
+    }
+
+    /// Karatsuba 3-PCLMULQDQ unreduced: returns the 256-bit product
+    /// without mod-p reduction.
+    #[inline]
+    pub fn ghash_mul_karatsuba_unreduced(a: F128, b: F128) -> F256Unreduced {
+        let a_xor = a.lo ^ a.hi;
+        let b_xor = b.lo ^ b.hi;
+        let (ll_lo, ll_hi) = clmul64(a.lo, b.lo);
+        let (hh_lo, hh_hi) = clmul64(a.hi, b.hi);
+        let (mid_lo, mid_hi) = clmul64(a_xor, b_xor);
+        let cr_lo = mid_lo ^ ll_lo ^ hh_lo;
+        let cr_hi = mid_hi ^ ll_hi ^ hh_hi;
+        F256Unreduced {
+            r0: ll_lo,
+            r1: ll_hi ^ cr_lo,
+            r2: hh_lo ^ cr_hi,
+            r3: hh_hi,
+        }
+    }
+
     /// Runtime check for the VPCLMULQDQ feature (needed by vec2/vec4).
     #[inline]
     pub fn has_vpclmulqdq() -> bool {
@@ -1014,5 +1041,81 @@ mod tests {
             assert_eq!(r[0], gamma * high, "gamma * high");
             assert_eq!(r[1], high * high, "high * high");
         }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn karatsuba_matches_schoolbook() {
+        let mut rng = Rng::new(42);
+        for _ in 0..1000 {
+            let a = rng.next_f128();
+            let b = rng.next_f128();
+            let schoolbook = x86_simd::ghash_mul(a, b);
+            let karatsuba = x86_simd::ghash_mul_karatsuba(a, b);
+            assert_eq!(schoolbook, karatsuba, "mismatch for a={a:?}, b={b:?}");
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn karatsuba_unreduced_matches_schoolbook_unreduced() {
+        let mut rng = Rng::new(43);
+        for _ in 0..1000 {
+            let a = rng.next_f128();
+            let b = rng.next_f128();
+            let sb = x86_simd::ghash_mul_unreduced(a, b);
+            let ka = x86_simd::ghash_mul_karatsuba_unreduced(a, b);
+            assert_eq!(sb, ka, "unreduced mismatch for a={a:?}, b={b:?}");
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn karatsuba_edge_cases() {
+        let one = F128::ONE;
+        let zero = F128::ZERO;
+        let gamma = F128::generator();
+        let high = F128 { lo: 0, hi: 1u64 << 63 };
+        let max = F128 { lo: u64::MAX, hi: u64::MAX };
+
+        assert_eq!(x86_simd::ghash_mul_karatsuba(one, gamma), gamma);
+        assert_eq!(x86_simd::ghash_mul_karatsuba(zero, gamma), zero);
+        assert_eq!(x86_simd::ghash_mul_karatsuba(high, high), high * high);
+        assert_eq!(x86_simd::ghash_mul_karatsuba(max, max), max * max);
+        assert_eq!(x86_simd::ghash_mul_karatsuba(gamma, high), gamma * high);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn karatsuba_microbench() {
+        let mut rng = Rng::new(99);
+        let n = 10_000_000usize;
+        let pairs: Vec<(F128, F128)> = (0..64).map(|_| (rng.next_f128(), rng.next_f128())).collect();
+
+        // Schoolbook
+        let start = std::time::Instant::now();
+        let mut acc_sb = F128::ZERO;
+        for i in 0..n {
+            let (a, b) = pairs[i & 63];
+            acc_sb += x86_simd::ghash_mul(a, b);
+        }
+        let sb_elapsed = start.elapsed();
+
+        // Karatsuba
+        let start = std::time::Instant::now();
+        let mut acc_ka = F128::ZERO;
+        for i in 0..n {
+            let (a, b) = pairs[i & 63];
+            acc_ka += x86_simd::ghash_mul_karatsuba(a, b);
+        }
+        let ka_elapsed = start.elapsed();
+
+        assert_eq!(acc_sb, acc_ka, "accumulators must match");
+        let sb_ns = sb_elapsed.as_nanos() as f64 / n as f64;
+        let ka_ns = ka_elapsed.as_nanos() as f64 / n as f64;
+        eprintln!("F128 mul x86 microbench ({n} muls):");
+        eprintln!("  schoolbook (4 PCLMUL): {sb_ns:.2} ns/mul");
+        eprintln!("  karatsuba  (3 PCLMUL): {ka_ns:.2} ns/mul");
+        eprintln!("  ratio (sb/ka):         {:.3}x", sb_ns / ka_ns);
     }
 }

--- a/crates/flock-core/src/field/gf2_8.rs
+++ b/crates/flock-core/src/field/gf2_8.rs
@@ -218,6 +218,220 @@ pub mod neon {
     }
 }
 
+// ---------------------------------------------------------------------------
+// x86_64 AVX2 helpers: 32-lane GF(2^8) operations.
+//
+// Two functions:
+//   gf8_mul_vec32_x86  — scalar × vector (VPSHUFB split-nibble lookup)
+//   gf8_mul_vec32_x86_ew — element-wise vector × vector (bitsliced schoolbook)
+//
+// Both require AVX2. The split-nibble lookup (scalar×vector) uses two
+// precomputed 16-entry tables T_lo[i] = a*i mod p, T_hi[i] = a*(i<<4) mod p,
+// then VPSHUFB does 32 parallel lookups per table.
+//
+// The element-wise multiply decomposes each lane's multiply into the
+// schoolbook form: accumulate (bit_j(a) AND b) << j, with inline modular
+// reduction (xtime) at each step to keep the intermediate in 8 bits.
+// ---------------------------------------------------------------------------
+
+#[cfg(target_arch = "x86_64")]
+pub mod x86 {
+    use super::{F8, gf8_reduce};
+
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::*;
+
+    /// Scalar-by-vector GF(2^8) multiply: compute `a_scalar * b[i]` for 32 lanes.
+    ///
+    /// Uses VPSHUFB split-nibble lookup: decompose each b[i] into low/high nibbles,
+    /// look up `a * nibble_val` from precomputed tables, XOR the halves.
+    ///
+    /// # Safety
+    /// Requires AVX2.
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn gf8_mul_vec32_x86(a_scalar: u8, b: &[u8; 32]) -> [u8; 32] {
+        unsafe {
+            // Build the two 16-entry lookup tables.
+            let mut tbl_lo = [0u8; 16];
+            let mut tbl_hi = [0u8; 16];
+            for i in 0u8..16 {
+                tbl_lo[i as usize] = (F8(a_scalar) * F8(i)).0;
+                tbl_hi[i as usize] = (F8(a_scalar) * F8(i << 4)).0;
+            }
+
+            // Broadcast each 16-byte table into both 128-bit lanes of a __m256i.
+            // VPSHUFB operates independently on each 128-bit lane, so both lanes
+            // need identical table contents.
+            let tlo = _mm256_broadcastsi128_si256(_mm_loadu_si128(tbl_lo.as_ptr() as *const _));
+            let thi = _mm256_broadcastsi128_si256(_mm_loadu_si128(tbl_hi.as_ptr() as *const _));
+
+            let bv = _mm256_loadu_si256(b.as_ptr() as *const _);
+            let nibble_mask = _mm256_set1_epi8(0x0F);
+
+            let b_lo = _mm256_and_si256(bv, nibble_mask);
+            let b_hi = _mm256_and_si256(_mm256_srli_epi16(bv, 4), nibble_mask);
+
+            let r_lo = _mm256_shuffle_epi8(tlo, b_lo);
+            let r_hi = _mm256_shuffle_epi8(thi, b_hi);
+
+            let result = _mm256_xor_si256(r_lo, r_hi);
+            let mut out = [0u8; 32];
+            _mm256_storeu_si256(out.as_mut_ptr() as *mut _, result);
+            out
+        }
+    }
+
+    /// Element-wise GF(2^8) multiply: compute `a[i] * b[i]` for 32 lanes.
+    ///
+    /// Uses bitsliced schoolbook multiplication with inline xtime reduction.
+    /// At each step j (0..7), if bit j of a[i] is set, XOR the running product
+    /// of b into the accumulator. Then apply xtime (multiply b by x, reducing
+    /// mod the AES polynomial x^8+x^4+x^3+x+1).
+    ///
+    /// This avoids the need for wide (16-bit) intermediates by reducing after
+    /// every shift.
+    ///
+    /// # Safety
+    /// Requires AVX2.
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn gf8_mul_vec32_x86_ew(a: &[u8; 32], b: &[u8; 32]) -> [u8; 32] {
+        unsafe {
+            let av = _mm256_loadu_si256(a.as_ptr() as *const _);
+            let bv = _mm256_loadu_si256(b.as_ptr() as *const _);
+
+            let poly = _mm256_set1_epi8(0x1Bu8 as i8); // x^4+x^3+x+1
+            let zero = _mm256_setzero_si256();
+            let one_bit = _mm256_set1_epi8(1);
+
+            let mut acc = zero;
+            let mut shifted_b = bv; // b * x^j at step j
+
+            // Bit 0: if a[i] & 1, XOR b into acc.
+            let mask0 = _mm256_cmpeq_epi8(
+                _mm256_and_si256(av, one_bit),
+                one_bit,
+            );
+            acc = _mm256_xor_si256(acc, _mm256_and_si256(mask0, shifted_b));
+
+            // Bits 1..7: xtime shifted_b, then conditionally XOR.
+            macro_rules! do_bit {
+                ($bit:expr) => {{
+                    // xtime: shifted_b = (shifted_b << 1) ^ (0x1B if high bit was set)
+                    let high_bits = _mm256_cmpgt_epi8(zero, shifted_b); // -1 if byte >= 0x80
+                    let sb_shifted = _mm256_add_epi8(shifted_b, shifted_b); // << 1 (mod 256)
+                    let reduce = _mm256_and_si256(high_bits, poly);
+                    shifted_b = _mm256_xor_si256(sb_shifted, reduce);
+
+                    // Extract bit $bit of each a[i]: shift right, mask, compare.
+                    let a_bit = _mm256_and_si256(
+                        _mm256_srli_epi16(av, $bit),
+                        one_bit,
+                    );
+                    let mask = _mm256_cmpeq_epi8(a_bit, one_bit);
+                    acc = _mm256_xor_si256(acc, _mm256_and_si256(mask, shifted_b));
+                }};
+            }
+            do_bit!(1);
+            do_bit!(2);
+            do_bit!(3);
+            do_bit!(4);
+            do_bit!(5);
+            do_bit!(6);
+            do_bit!(7);
+
+            let mut out = [0u8; 32];
+            _mm256_storeu_si256(out.as_mut_ptr() as *mut _, acc);
+            out
+        }
+    }
+
+    /// 32-lane GF(2^8) modular reduction: reduce 32 u16 values (stored as
+    /// interleaved low/high byte vectors) modulo x^8+x^4+x^3+x+1.
+    ///
+    /// Input: `lo` contains the low bytes, `hi` contains the high bytes of the
+    /// 15-bit carry-less products. Output: 32 reduced GF(2^8) bytes.
+    ///
+    /// Uses VPSHUFB split-nibble lookup for the reduction polynomial multiply.
+    ///
+    /// # Safety
+    /// Requires AVX2.
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn gf8_reduce_vec32(lo: __m256i, hi: __m256i) -> __m256i {
+        unsafe {
+            // h folds back as: h ^ (h<<1) ^ (h<<3) ^ (h<<4)
+            // This can overflow into bits 8..11, needing a second fold.
+            // Use VPSHUFB: build a 16-entry table for the fold of each nibble of h.
+
+            // Stage 1: fold h (7 bits max) into lo.
+            // For each possible h (0..127), fold(h) = h ^ (h<<1) ^ (h<<3) ^ (h<<4).
+            // The result is at most 12 bits. We keep the low byte and the carry.
+            // But h is at most 7 bits (degree 14 product → 7 high bits), so h in 0..127.
+            // fold(h) fits in 12 bits; the low 8 bits XOR into lo, bits 8..11 need second fold.
+
+            // Build tables: for nibble values 0..15, compute the fold contribution.
+            // T_lo_nib[i] = fold(i) & 0xFF, T_hi_nib[i] = fold(i<<4) & 0xFFFF split into lo/hi bytes.
+            // But fold(h) = h ^ (h<<1) ^ (h<<3) ^ (h<<4) where h is 7-bit.
+            // We split h into h_lo (bits 0..3) and h_hi (bits 4..6).
+            // fold is linear in GF(2), so fold(h) = fold(h_lo) ^ fold(h_hi << 4).
+
+            let mut tbl_lo_lo = [0u8; 16]; // fold(i) low byte, for i = low nibble of h
+            let mut tbl_lo_hi = [0u8; 16]; // fold(i) high byte
+            let mut tbl_hi_lo = [0u8; 16]; // fold(i<<4) low byte
+            let mut tbl_hi_hi = [0u8; 16]; // fold(i<<4) high byte
+
+            for i in 0u16..16 {
+                let f1 = i ^ (i << 1) ^ (i << 3) ^ (i << 4);
+                tbl_lo_lo[i as usize] = (f1 & 0xFF) as u8;
+                tbl_lo_hi[i as usize] = ((f1 >> 8) & 0xFF) as u8;
+
+                let ih = i << 4;
+                let f2 = ih ^ (ih << 1) ^ (ih << 3) ^ (ih << 4);
+                tbl_hi_lo[i as usize] = (f2 & 0xFF) as u8;
+                tbl_hi_hi[i as usize] = ((f2 >> 8) & 0xFF) as u8;
+            }
+
+            let t_lo_lo = _mm256_broadcastsi128_si256(_mm_loadu_si128(tbl_lo_lo.as_ptr() as *const _));
+            let t_lo_hi = _mm256_broadcastsi128_si256(_mm_loadu_si128(tbl_lo_hi.as_ptr() as *const _));
+            let t_hi_lo = _mm256_broadcastsi128_si256(_mm_loadu_si128(tbl_hi_lo.as_ptr() as *const _));
+            let t_hi_hi = _mm256_broadcastsi128_si256(_mm_loadu_si128(tbl_hi_hi.as_ptr() as *const _));
+
+            let nibble_mask = _mm256_set1_epi8(0x0F);
+            let h_lo_nib = _mm256_and_si256(hi, nibble_mask);
+            let h_hi_nib = _mm256_and_si256(_mm256_srli_epi16(hi, 4), nibble_mask);
+
+            // Stage-1 fold: 16-bit result split into lo/hi parts.
+            let fold_lo = _mm256_xor_si256(
+                _mm256_shuffle_epi8(t_lo_lo, h_lo_nib),
+                _mm256_shuffle_epi8(t_hi_lo, h_hi_nib),
+            );
+            let fold_hi = _mm256_xor_si256(
+                _mm256_shuffle_epi8(t_lo_hi, h_lo_nib),
+                _mm256_shuffle_epi8(t_hi_hi, h_hi_nib),
+            );
+
+            // XOR fold low byte into lo to get stage-1 result low byte.
+            let s1_lo = _mm256_xor_si256(lo, fold_lo);
+
+            // Stage 2: fold_hi has bits 8..11 (at most 4 bits). Apply same reduction.
+            // For 4-bit h2, fold(h2) is at most 12 bits, but since h2 < 16, the
+            // high bits after fold are at most 4 more bits. For h2 in 0..15:
+            // fold(h2) = h2 ^ (h2<<1) ^ (h2<<3) ^ (h2<<4), max 8 bits for h2<8.
+            // Actually h2 can be up to 0x0F. fold(0x0F) = 0x0F ^ 0x1E ^ 0x78 ^ 0xF0 = 0x81.
+            // So stage-2 result fits in 8 bits.
+            let mut tbl_s2 = [0u8; 16];
+            for i in 0u16..16 {
+                let f = i ^ (i << 1) ^ (i << 3) ^ (i << 4);
+                tbl_s2[i as usize] = (f & 0xFF) as u8;
+                // Verify no overflow: assert f < 256
+            }
+            let t_s2 = _mm256_broadcastsi128_si256(_mm_loadu_si128(tbl_s2.as_ptr() as *const _));
+            let s2_fold = _mm256_shuffle_epi8(t_s2, fold_hi);
+
+            _mm256_xor_si256(s1_lo, s2_fold)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -355,6 +569,140 @@ mod tests {
             };
             let result: [u8; 16] = unsafe { transmute(result_vec) };
             assert_eq!(result, expected, "a={:02x?}, b={:02x?}", a_arr, b_arr);
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn gf8_vpshufb_matches_scalar() {
+        // Exhaustive: for all 256 × 256 input pairs, VPSHUFB scalar×vector
+        // must match the scalar reference.
+        for a_val in 0u16..=255 {
+            let a = a_val as u8;
+            // Process b in batches of 32.
+            let mut b_arr = [0u8; 32];
+            for b_base in (0u16..=255).step_by(32) {
+                for j in 0..32u16 {
+                    let bv = b_base + j;
+                    b_arr[j as usize] = if bv <= 255 { bv as u8 } else { 0 };
+                }
+                let result = unsafe { super::x86::gf8_mul_vec32_x86(a, &b_arr) };
+                for j in 0..32u16 {
+                    let bv = b_base + j;
+                    if bv <= 255 {
+                        let expected = (F8(a) * F8(bv as u8)).0;
+                        assert_eq!(
+                            result[j as usize], expected,
+                            "gf8_mul_vec32_x86 mismatch: a=0x{a:02x}, b=0x{:02x}",
+                            bv as u8
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn gf8_mul_vec32_x86_matches_scalar() {
+        // 32 random pairs, batch multiply, check each matches scalar.
+        let mut rng = Rng::new(0xABCD1234);
+        for _ in 0..512 {
+            let a_scalar = (rng.next_u64() & 0xff) as u8;
+            let mut b_arr = [0u8; 32];
+            for j in 0..32 {
+                b_arr[j] = (rng.next_u64() & 0xff) as u8;
+            }
+            let result = unsafe { super::x86::gf8_mul_vec32_x86(a_scalar, &b_arr) };
+            for j in 0..32 {
+                let expected = (F8(a_scalar) * F8(b_arr[j])).0;
+                assert_eq!(
+                    result[j], expected,
+                    "scalar×vec mismatch: a=0x{a_scalar:02x}, b[{j}]=0x{:02x}",
+                    b_arr[j]
+                );
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn gf8_mul_vec32_ew_x86_matches_scalar() {
+        // Element-wise: 32 random pairs, verify against scalar F8 mul.
+        let mut rng = Rng::new(0xF00DCAFE);
+        for _ in 0..512 {
+            let mut a_arr = [0u8; 32];
+            let mut b_arr = [0u8; 32];
+            for j in 0..32 {
+                a_arr[j] = (rng.next_u64() & 0xff) as u8;
+                b_arr[j] = (rng.next_u64() & 0xff) as u8;
+            }
+            let result = unsafe { super::x86::gf8_mul_vec32_x86_ew(&a_arr, &b_arr) };
+            for j in 0..32 {
+                let expected = (F8(a_arr[j]) * F8(b_arr[j])).0;
+                assert_eq!(
+                    result[j], expected,
+                    "ew mismatch at lane {j}: a=0x{:02x}, b=0x{:02x}",
+                    a_arr[j], b_arr[j]
+                );
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn gf8_mul_vec32_ew_x86_exhaustive_sample() {
+        // Sample 256 a-values × 32 random b-values each for broader coverage.
+        let mut rng = Rng::new(0xBEEFBEEF);
+        for a_val in 0u8..=255 {
+            let mut a_arr = [a_val; 32];
+            let mut b_arr = [0u8; 32];
+            for j in 0..32 {
+                b_arr[j] = (rng.next_u64() & 0xff) as u8;
+                a_arr[j] = a_val; // keep constant for this row
+            }
+            let result = unsafe { super::x86::gf8_mul_vec32_x86_ew(&a_arr, &b_arr) };
+            for j in 0..32 {
+                let expected = (F8(a_val) * F8(b_arr[j])).0;
+                assert_eq!(
+                    result[j], expected,
+                    "ew-exhaust mismatch: a=0x{a_val:02x}, b=0x{:02x}",
+                    b_arr[j]
+                );
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn gf8_reduce_vec32_matches_scalar() {
+        // Verify vectorized reduction against the scalar gf8_reduce.
+        let mut rng = Rng::new(0xDEAD5678);
+        for _ in 0..1024 {
+            let mut lo_arr = [0u8; 32];
+            let mut hi_arr = [0u8; 32];
+            for j in 0..32 {
+                let val = (rng.next_u64() & 0x7FFF) as u16; // 15-bit product
+                lo_arr[j] = (val & 0xFF) as u8;
+                hi_arr[j] = ((val >> 8) & 0xFF) as u8;
+            }
+            let result = unsafe {
+                use core::arch::x86_64::*;
+                let lo = _mm256_loadu_si256(lo_arr.as_ptr() as *const _);
+                let hi = _mm256_loadu_si256(hi_arr.as_ptr() as *const _);
+                let r = super::x86::gf8_reduce_vec32(lo, hi);
+                let mut out = [0u8; 32];
+                _mm256_storeu_si256(out.as_mut_ptr() as *mut _, r);
+                out
+            };
+            for j in 0..32 {
+                let val = (lo_arr[j] as u16) | ((hi_arr[j] as u16) << 8);
+                let expected = gf8_reduce(val);
+                assert_eq!(
+                    result[j], expected,
+                    "reduce mismatch at lane {j}: val=0x{val:04x}"
+                );
+            }
         }
     }
 

--- a/crates/flock-core/src/lincheck.rs
+++ b/crates/flock-core/src/lincheck.rs
@@ -117,7 +117,7 @@
 //!   per byte.
 
 use crate::challenger::Challenger;
-use crate::field::F128;
+use crate::field::{F128, F256Unreduced};
 use crate::r1cs::SparseBinaryMatrix;
 use crate::zerocheck::multilinear::lagrange_weights_naive;
 use serde::{Deserialize, Serialize};
@@ -313,6 +313,173 @@ impl LincheckCircuit for CscCircuit {
             let mut sb = F128::ZERO;
             for &r in &self.b_rows[self.b_col_ptr[c] as usize..self.b_col_ptr[c + 1] as usize] {
                 sb += eq_inner[r as usize];
+            }
+            alpha * sa + sb
+        };
+        if self.n_cols < SUMCHECK_PAR_THRESHOLD {
+            return (0..self.n_cols).map(one_col).collect();
+        }
+        let mut out = vec![F128::ZERO; self.n_cols];
+        out.par_iter_mut()
+            .enumerate()
+            .for_each(|(c, slot)| *slot = one_col(c));
+        out
+    }
+}
+
+/// Row-compacted CSC circuit: remaps row indices to a dense `[0, n_unique_rows)`
+/// range during construction so that `fold_alpha_batched_compact` can use a
+/// compact eq_inner table that fits in L1 cache. For MHOT route (2838 unique
+/// rows out of 32768), the compact table is ~44 KiB instead of ~512 KiB.
+///
+/// Use [`build_quirky_eq_table_sparse`] to build the compact eq_inner, then
+/// pass it to [`CompactCscCircuit::fold_alpha_batched_compact`].
+///
+/// Also implements [`LincheckCircuit`] so it can be used as a drop-in
+/// replacement in the standard lincheck prover (accepting full-length
+/// eq_inner). The compact path is available via the dedicated method.
+#[derive(Clone)]
+pub struct CompactCscCircuit {
+    n_cols: usize,
+    n_orig_rows: usize,
+    a_col_ptr: Vec<u32>,
+    a_rows_compact: Vec<u32>,
+    b_col_ptr: Vec<u32>,
+    b_rows_compact: Vec<u32>,
+    /// Sorted original row indices that have at least one nonzero in A or B.
+    pub referenced_rows: Vec<u32>,
+    const_pin: Option<usize>,
+}
+
+impl std::fmt::Debug for CompactCscCircuit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompactCscCircuit")
+            .field("n_cols", &self.n_cols)
+            .field("n_orig_rows", &self.n_orig_rows)
+            .field("n_unique_rows", &self.referenced_rows.len())
+            .field("nnz_a", &self.a_rows_compact.len())
+            .field("nnz_b", &self.b_rows_compact.len())
+            .finish()
+    }
+}
+
+impl CompactCscCircuit {
+    pub fn from_matrices(a_0: &SparseBinaryMatrix, b_0: &SparseBinaryMatrix) -> Self {
+        assert_eq!(a_0.num_rows, b_0.num_rows);
+        assert_eq!(a_0.num_cols, b_0.num_cols);
+
+        let (a_col_ptr, a_rows_orig) = csc_from_rows(a_0);
+        let (b_col_ptr, b_rows_orig) = csc_from_rows(b_0);
+
+        let mut row_set = std::collections::BTreeSet::new();
+        for &r in &a_rows_orig {
+            row_set.insert(r);
+        }
+        for &r in &b_rows_orig {
+            row_set.insert(r);
+        }
+        let referenced_rows: Vec<u32> = row_set.iter().copied().collect();
+
+        let mut orig_to_compact = vec![u32::MAX; a_0.num_rows];
+        for (compact_idx, &orig) in referenced_rows.iter().enumerate() {
+            orig_to_compact[orig as usize] = compact_idx as u32;
+        }
+
+        let a_rows_compact: Vec<u32> = a_rows_orig
+            .iter()
+            .map(|&r| orig_to_compact[r as usize])
+            .collect();
+        let b_rows_compact: Vec<u32> = b_rows_orig
+            .iter()
+            .map(|&r| orig_to_compact[r as usize])
+            .collect();
+
+        Self {
+            n_cols: a_0.num_cols,
+            n_orig_rows: a_0.num_rows,
+            a_col_ptr,
+            a_rows_compact,
+            b_col_ptr,
+            b_rows_compact,
+            referenced_rows,
+            const_pin: None,
+        }
+    }
+
+    pub fn with_const_pin(mut self, const_pin: Option<usize>) -> Self {
+        self.const_pin = const_pin;
+        self
+    }
+
+    /// Number of unique rows referenced by any nonzero in A or B.
+    pub fn n_unique_rows(&self) -> usize {
+        self.referenced_rows.len()
+    }
+
+    /// Fold using a compact eq_inner table (length = `n_unique_rows()`).
+    /// The compact table must be indexed by the remapped row indices.
+    /// Returns a full-length `n_cols` comb_vec.
+    pub fn fold_alpha_batched_compact(
+        &self,
+        alpha: F128,
+        eq_inner_compact: &[F128],
+    ) -> Vec<F128> {
+        use rayon::prelude::*;
+        assert_eq!(
+            eq_inner_compact.len(),
+            self.referenced_rows.len(),
+            "compact eq_inner length must match n_unique_rows"
+        );
+        let one_col = |c: usize| {
+            let mut sa = F128::ZERO;
+            for &r in &self.a_rows_compact
+                [self.a_col_ptr[c] as usize..self.a_col_ptr[c + 1] as usize]
+            {
+                sa += eq_inner_compact[r as usize];
+            }
+            let mut sb = F128::ZERO;
+            for &r in &self.b_rows_compact
+                [self.b_col_ptr[c] as usize..self.b_col_ptr[c + 1] as usize]
+            {
+                sb += eq_inner_compact[r as usize];
+            }
+            alpha * sa + sb
+        };
+        if self.n_cols < SUMCHECK_PAR_THRESHOLD {
+            return (0..self.n_cols).map(one_col).collect();
+        }
+        let mut out = vec![F128::ZERO; self.n_cols];
+        out.par_iter_mut()
+            .enumerate()
+            .for_each(|(c, slot)| *slot = one_col(c));
+        out
+    }
+}
+
+impl LincheckCircuit for CompactCscCircuit {
+    fn n_cols(&self) -> usize {
+        self.n_cols
+    }
+    fn const_pin_col(&self) -> Option<usize> {
+        self.const_pin
+    }
+    fn fold_alpha_batched(&self, alpha: F128, eq_inner_full: &[F128]) -> Vec<F128> {
+        use rayon::prelude::*;
+        assert_eq!(eq_inner_full.len(), self.n_cols);
+        let one_col = |c: usize| {
+            let mut sa = F128::ZERO;
+            for &r in &self.a_rows_compact
+                [self.a_col_ptr[c] as usize..self.a_col_ptr[c + 1] as usize]
+            {
+                // Gather from the full table using the ORIGINAL row index
+                // (referenced_rows maps compact -> original).
+                sa += eq_inner_full[self.referenced_rows[r as usize] as usize];
+            }
+            let mut sb = F128::ZERO;
+            for &r in &self.b_rows_compact
+                [self.b_col_ptr[c] as usize..self.b_col_ptr[c + 1] as usize]
+            {
+                sb += eq_inner_full[self.referenced_rows[r as usize] as usize];
             }
             alpha * sa + sb
         };
@@ -1107,6 +1274,36 @@ pub fn build_quirky_eq_table(z_skip: F128, x_inner_rest: &[F128], k_skip: usize)
     out
 }
 
+/// Build a **sparse** quirky eq table containing only the entries at the given
+/// `row_indices`. Output has `row_indices.len()` entries, where `out[i]` is the
+/// value that `build_quirky_eq_table` would produce at index `row_indices[i]`.
+///
+/// Each entry is computed directly as `lambda_skip[r % ell_skip] * eq_rest[r >> k_skip]`.
+/// The `eq_rest` table (length `2^(k_log - k_skip)`) is built in full via the
+/// standard doubling construction; only the outer-product gather is sparse.
+///
+/// For MHOT route (2838 referenced rows, k_log=15, k_skip=6): builds
+/// 512 eq_rest + 64 lagrange + 2838 muls ≈ 3414 F128 ops
+/// vs dense: 512 + 64 + 32768 = 33344 ops.
+pub fn build_quirky_eq_table_sparse(
+    z_skip: F128,
+    x_inner_rest: &[F128],
+    k_skip: usize,
+    row_indices: &[u32],
+) -> Vec<F128> {
+    let ell_skip = 1usize << k_skip;
+    let lambda_skip = lagrange_weights_naive(k_skip, z_skip);
+    let eq_rest = build_eq_table(x_inner_rest);
+    let mut out = Vec::with_capacity(row_indices.len());
+    for &r in row_indices {
+        let r = r as usize;
+        let i_skip = r & (ell_skip - 1);
+        let i_rest = r >> k_skip;
+        out.push(lambda_skip[i_skip] * eq_rest[i_rest]);
+    }
+    out
+}
+
 /// Dot product of two equal-length F128 slices.
 fn inner_product(a: &[F128], b: &[F128]) -> F128 {
     assert_eq!(a.len(), b.len());
@@ -1341,6 +1538,124 @@ fn sumcheck_bind_both_and_eval_next(
 }
 
 // ---------------------------------------------------------------------------
+// Deferred-reduction variants: accumulate F256Unreduced products, reduce once.
+// ---------------------------------------------------------------------------
+
+/// Deferred-reduction variant of [`sumcheck_round_eval_par`]. Accumulates
+/// unreduced 256-bit products via XOR, then reduces once at the end. Saves
+/// `(half − 1)` ghash_reduce calls per accumulator (2 accumulators total).
+fn sumcheck_round_eval_par_deferred(c: &[F128], z: &[F128]) -> (F128, F128) {
+    use rayon::prelude::*;
+    let half = c.len() / 2;
+    debug_assert_eq!(z.len(), c.len());
+    let (clo, chi) = c.split_at(half);
+    let (zlo, zhi) = z.split_at(half);
+    if half < SUMCHECK_PAR_THRESHOLD {
+        let mut e1_acc = F256Unreduced::ZERO;
+        let mut einf_acc = F256Unreduced::ZERO;
+        for i in 0..half {
+            e1_acc ^= chi[i].mul_unreduced(zhi[i]);
+            einf_acc ^= (chi[i] + clo[i]).mul_unreduced(zhi[i] + zlo[i]);
+        }
+        return (e1_acc.reduce(), einf_acc.reduce());
+    }
+    (0..half)
+        .into_par_iter()
+        .map(|i| {
+            let e1_i = chi[i].mul_unreduced(zhi[i]);
+            let einf_i = (chi[i] + clo[i]).mul_unreduced(zhi[i] + zlo[i]);
+            (e1_i, einf_i)
+        })
+        .reduce(
+            || (F256Unreduced::ZERO, F256Unreduced::ZERO),
+            |a, b| (a.0 ^ b.0, a.1 ^ b.1),
+        )
+        .into_reduced()
+}
+
+/// Deferred-reduction variant of [`sumcheck_bind_both_and_eval_next`].
+/// The bind step (per-element writes) still uses eager F128 multiply because
+/// each result is stored, not accumulated. Only the two accumulation sums
+/// `e1` and `einf` benefit from deferred reduction.
+fn sumcheck_bind_both_and_eval_next_deferred(
+    comb: &mut Vec<F128>,
+    z: &mut Vec<F128>,
+    r: F128,
+) -> (F128, F128) {
+    use rayon::prelude::*;
+    let len = comb.len();
+    debug_assert_eq!(z.len(), len);
+    let half = len / 2;
+    let half2 = half / 2;
+    debug_assert!(half2 >= 1, "fused step needs a well-defined next round");
+
+    let (c_lo, c_hi) = comb.split_at_mut(half);
+    let (cq0, cq1) = c_lo.split_at_mut(half2);
+    let (cq2, cq3) = c_hi.split_at(half2);
+    let (z_lo, z_hi) = z.split_at_mut(half);
+    let (zq0, zq1) = z_lo.split_at_mut(half2);
+    let (zq2, zq3) = z_hi.split_at(half2);
+
+    let (e1, einf) = if half2 < SUMCHECK_PAR_THRESHOLD {
+        let mut e1_acc = F256Unreduced::ZERO;
+        let mut einf_acc = F256Unreduced::ZERO;
+        for i in 0..half2 {
+            let lo = cq0[i] + r * (cq2[i] + cq0[i]);
+            let hi = cq1[i] + r * (cq3[i] + cq1[i]);
+            let zlo = zq0[i] + r * (zq2[i] + zq0[i]);
+            let zhi = zq1[i] + r * (zq3[i] + zq1[i]);
+            cq0[i] = lo;
+            cq1[i] = hi;
+            zq0[i] = zlo;
+            zq1[i] = zhi;
+            e1_acc ^= hi.mul_unreduced(zhi);
+            einf_acc ^= (hi + lo).mul_unreduced(zhi + zlo);
+        }
+        (e1_acc.reduce(), einf_acc.reduce())
+    } else {
+        cq0.par_iter_mut()
+            .zip(cq1.par_iter_mut())
+            .zip(cq2.par_iter())
+            .zip(cq3.par_iter())
+            .zip(zq0.par_iter_mut())
+            .zip(zq1.par_iter_mut())
+            .zip(zq2.par_iter())
+            .zip(zq3.par_iter())
+            .map(|(((((((c0, c1), c2), c3), z0), z1), z2), z3)| {
+                let lo = *c0 + r * (*c2 + *c0);
+                let hi = *c1 + r * (*c3 + *c1);
+                let zlo = *z0 + r * (*z2 + *z0);
+                let zhi = *z1 + r * (*z3 + *z1);
+                *c0 = lo;
+                *c1 = hi;
+                *z0 = zlo;
+                *z1 = zhi;
+                (hi.mul_unreduced(zhi), (hi + lo).mul_unreduced(zhi + zlo))
+            })
+            .reduce(
+                || (F256Unreduced::ZERO, F256Unreduced::ZERO),
+                |a, b| (a.0 ^ b.0, a.1 ^ b.1),
+            )
+            .into_reduced()
+    };
+
+    comb.truncate(half);
+    z.truncate(half);
+    (e1, einf)
+}
+
+trait IntoReduced {
+    fn into_reduced(self) -> (F128, F128);
+}
+
+impl IntoReduced for (F256Unreduced, F256Unreduced) {
+    #[inline]
+    fn into_reduced(self) -> (F128, F128) {
+        (self.0.reduce(), self.1.reduce())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // API
 // ---------------------------------------------------------------------------
 
@@ -1552,7 +1867,7 @@ fn prove_padded_inner<Ch: Challenger>(
         // Round 0's message is the only standalone evaluation pass; every later
         // round's message falls out of binding the previous round (fold +
         // next-eval fused into one pass — see `sumcheck_bind_both_and_eval_next`).
-        let (mut e1, mut einf) = sumcheck_round_eval_par(&comb_vec, &z_vec);
+        let (mut e1, mut einf) = sumcheck_round_eval_par_deferred(&comb_vec, &z_vec);
         for t in 0..inner_rest_len {
             challenger.observe_f128(e1);
             challenger.observe_f128(einf);
@@ -1561,7 +1876,7 @@ fn prove_padded_inner<Ch: Challenger>(
             r_rounds.push(r);
             if t + 1 < inner_rest_len {
                 // Fused: bind both tables at r AND compute round (t+1)'s message.
-                let (ne1, neinf) = sumcheck_bind_both_and_eval_next(&mut comb_vec, &mut z_vec, r);
+                let (ne1, neinf) = sumcheck_bind_both_and_eval_next_deferred(&mut comb_vec, &mut z_vec, r);
                 e1 = ne1;
                 einf = neinf;
             } else {
@@ -2389,5 +2704,388 @@ mod tests {
             ),
             Err(VerifyError::KSkipExceedsKLog { .. })
         ));
+    }
+
+    // ---- Deferred-reduction correctness ----
+
+    /// The deferred-reduction `sumcheck_round_eval_par_deferred` must produce
+    /// bit-identical output to the eager `sumcheck_round_eval_par` for all
+    /// table sizes (both sequential and parallel branches).
+    #[test]
+    fn deferred_round_eval_matches_eager() {
+        for &half_log in &[2usize, 4, 8, 13] {
+            let half = 1usize << half_log;
+            let len = half * 2;
+            let mut rng = Rng::new(9000 + half_log as u64);
+            let c = rng.f128_vec(len);
+            let z = rng.f128_vec(len);
+
+            let (e1_eager, einf_eager) = sumcheck_round_eval_par(&c, &z);
+            let (e1_def, einf_def) = sumcheck_round_eval_par_deferred(&c, &z);
+
+            assert_eq!(
+                e1_eager, e1_def,
+                "e1 mismatch at half_log={half_log}"
+            );
+            assert_eq!(
+                einf_eager, einf_def,
+                "einf mismatch at half_log={half_log}"
+            );
+        }
+    }
+
+    /// The deferred-reduction `sumcheck_bind_both_and_eval_next_deferred` must
+    /// produce bit-identical output AND identical side-effects (table mutations)
+    /// to the eager variant.
+    #[test]
+    fn deferred_bind_eval_next_matches_eager() {
+        for &half2_log in &[1usize, 3, 6, 13] {
+            let half2 = 1usize << half2_log;
+            let len = half2 * 4;
+            let mut rng = Rng::new(9100 + half2_log as u64);
+            let comb_orig = rng.f128_vec(len);
+            let z_orig = rng.f128_vec(len);
+            let r = rng.f128();
+
+            let mut comb_eager = comb_orig.clone();
+            let mut z_eager = z_orig.clone();
+            let (e1_eager, einf_eager) =
+                sumcheck_bind_both_and_eval_next(&mut comb_eager, &mut z_eager, r);
+
+            let mut comb_def = comb_orig.clone();
+            let mut z_def = z_orig.clone();
+            let (e1_def, einf_def) =
+                sumcheck_bind_both_and_eval_next_deferred(&mut comb_def, &mut z_def, r);
+
+            assert_eq!(e1_eager, e1_def, "e1 mismatch at half2_log={half2_log}");
+            assert_eq!(
+                einf_eager, einf_def,
+                "einf mismatch at half2_log={half2_log}"
+            );
+            assert_eq!(
+                comb_eager, comb_def,
+                "comb side-effect mismatch at half2_log={half2_log}"
+            );
+            assert_eq!(
+                z_eager, z_def,
+                "z side-effect mismatch at half2_log={half2_log}"
+            );
+        }
+    }
+
+    /// Full lincheck prove/verify roundtrip using the deferred-reduction path
+    /// (which is now the default in `prove_padded_inner`). This re-runs the
+    /// same cases as `prove_verify_roundtrip_honest` to confirm transcript
+    /// compatibility.
+    #[test]
+    fn deferred_reduction_lincheck_matches_eager() {
+        for &(m, k_log, k_skip) in &[
+            (10usize, 4, 0),
+            (10, 4, 2),
+            (10, 4, 4),
+            (12, 5, 3),
+            (14, 7, 6),
+            (14, 7, 0),
+        ] {
+            let k = 1usize << k_log;
+            let mut rng = Rng::new(55 + (m * 100 + k_log * 10 + k_skip) as u64);
+
+            let nnz_per_mat = k * 2;
+            let a_0 = random_sparse_matrix(k, nnz_per_mat, &mut rng);
+            let b_0 = random_sparse_matrix(k, nnz_per_mat, &mut rng);
+
+            let z = rng.bits(1 << m);
+            let a = apply_block_diag(&a_0, &z, k_log);
+            let b = apply_block_diag(&b_0, &z, k_log);
+            let z_packed = pack_z_lincheck(&z, m, k_log);
+
+            let x_ab = random_quirky_point(m, k_log, k_skip, &mut rng);
+            let v_a = mle_eval_bool_quirky(&a, m, k_log, k_skip, &x_ab);
+            let v_b = mle_eval_bool_quirky(&b, m, k_log, k_skip, &x_ab);
+
+            let circuit = SparseMatrixCircuit::new(&a_0, &b_0);
+            let mut ch_p = FsChallenger::new(b"flock-test-v0");
+            let (proof, claim_p) =
+                prove(&z_packed, m, k_log, k_skip, &circuit, &x_ab, &mut ch_p);
+
+            let mut ch_v = FsChallenger::new(b"flock-test-v0");
+            let claim_v = verify(
+                m, k_log, k_skip, &circuit, &x_ab, v_a, v_b, &proof, &mut ch_v,
+            )
+            .unwrap_or_else(|e| {
+                panic!(
+                    "deferred verify rejected honest proof at m={m},k_log={k_log},k_skip={k_skip}: {e:?}"
+                )
+            });
+
+            assert_eq!(
+                claim_p, claim_v,
+                "claim mismatch at m={m}, k_log={k_log}, k_skip={k_skip}"
+            );
+
+            let pt = QuirkyPoint {
+                z_skip: claim_v.r_inner_skip,
+                x_inner_rest: claim_v.r_inner_rest.clone(),
+                x_outer: x_ab.x_outer.clone(),
+            };
+            assert_eq!(
+                claim_v.w,
+                mle_eval_bool_quirky(&z, m, k_log, k_skip, &pt),
+                "w wrong at m={m}, k_log={k_log}, k_skip={k_skip}"
+            );
+        }
+    }
+
+    // ---- Sparse eq_inner correctness ----
+
+    #[test]
+    fn sparse_eq_inner_matches_dense() {
+        for &(k_log, k_skip) in &[
+            (4usize, 0),
+            (4, 2),
+            (6, 3),
+            (8, 4),
+            (10, 6),
+            (15, 6),
+        ] {
+            let k = 1usize << k_log;
+            let mut rng = Rng::new(7700 + k_log as u64 * 100 + k_skip as u64);
+            let x_inner_rest = rng.f128_vec(k_log - k_skip);
+            let z_skip = rng.f128();
+
+            let dense = build_quirky_eq_table(z_skip, &x_inner_rest, k_skip);
+            assert_eq!(dense.len(), k);
+
+            let useful = k / 4;
+            let nnz_per_mat = useful * 2;
+            let a_0 = random_sparse_matrix_in_range(k, useful, nnz_per_mat, &mut rng);
+            let b_0 = random_sparse_matrix_in_range(k, useful, nnz_per_mat, &mut rng);
+
+            let compact = CompactCscCircuit::from_matrices(&a_0, &b_0);
+            let sparse = build_quirky_eq_table_sparse(
+                z_skip,
+                &x_inner_rest,
+                k_skip,
+                &compact.referenced_rows,
+            );
+            assert_eq!(sparse.len(), compact.n_unique_rows());
+
+            for (compact_idx, &orig_row) in compact.referenced_rows.iter().enumerate() {
+                assert_eq!(
+                    sparse[compact_idx], dense[orig_row as usize],
+                    "mismatch at orig_row={orig_row}, k_log={k_log}, k_skip={k_skip}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn compact_csc_fold_matches_dense_csc() {
+        for &(k_log, k_skip) in &[
+            (4usize, 0),
+            (4, 2),
+            (6, 3),
+            (8, 4),
+            (10, 6),
+        ] {
+            let k = 1usize << k_log;
+            let mut rng = Rng::new(8800 + k_log as u64 * 100 + k_skip as u64);
+            let x_inner_rest = rng.f128_vec(k_log - k_skip);
+            let z_skip = rng.f128();
+            let alpha = rng.f128();
+
+            let useful = k / 4;
+            let nnz_per_mat = useful * 2;
+            let a_0 = random_sparse_matrix_in_range(k, useful, nnz_per_mat, &mut rng);
+            let b_0 = random_sparse_matrix_in_range(k, useful, nnz_per_mat, &mut rng);
+
+            let dense_csc = CscCircuit::from_matrices(&a_0, &b_0);
+            let compact = CompactCscCircuit::from_matrices(&a_0, &b_0);
+
+            let eq_inner_dense = build_quirky_eq_table(z_skip, &x_inner_rest, k_skip);
+            let eq_inner_sparse = build_quirky_eq_table_sparse(
+                z_skip,
+                &x_inner_rest,
+                k_skip,
+                &compact.referenced_rows,
+            );
+
+            let comb_dense = dense_csc.fold_alpha_batched(alpha, &eq_inner_dense);
+            let comb_compact = compact.fold_alpha_batched_compact(alpha, &eq_inner_sparse);
+
+            assert_eq!(
+                comb_dense, comb_compact,
+                "fold mismatch at k_log={k_log}, k_skip={k_skip}"
+            );
+        }
+    }
+
+    #[test]
+    fn compact_csc_trait_fold_matches_dense() {
+        for &(k_log, k_skip) in &[(4usize, 2), (6, 3), (8, 4)] {
+            let k = 1usize << k_log;
+            let mut rng = Rng::new(9900 + k_log as u64 * 100 + k_skip as u64);
+            let x_inner_rest = rng.f128_vec(k_log - k_skip);
+            let z_skip = rng.f128();
+            let alpha = rng.f128();
+
+            let useful = k / 4;
+            let nnz_per_mat = useful * 2;
+            let a_0 = random_sparse_matrix_in_range(k, useful, nnz_per_mat, &mut rng);
+            let b_0 = random_sparse_matrix_in_range(k, useful, nnz_per_mat, &mut rng);
+
+            let dense_csc = CscCircuit::from_matrices(&a_0, &b_0);
+            let compact = CompactCscCircuit::from_matrices(&a_0, &b_0);
+
+            let eq_inner = build_quirky_eq_table(z_skip, &x_inner_rest, k_skip);
+
+            let comb_dense = dense_csc.fold_alpha_batched(alpha, &eq_inner);
+            let comb_trait = compact.fold_alpha_batched(alpha, &eq_inner);
+
+            assert_eq!(
+                comb_dense, comb_trait,
+                "trait-fold mismatch at k_log={k_log}, k_skip={k_skip}"
+            );
+        }
+    }
+
+    #[test]
+    fn compact_csc_prove_verify_roundtrip() {
+        for &(m, k_log, k_skip) in &[
+            (10usize, 4, 2),
+            (12, 5, 3),
+            (14, 7, 6),
+        ] {
+            let k = 1usize << k_log;
+            let mut rng = Rng::new(10100 + (m * 100 + k_log * 10 + k_skip) as u64);
+
+            let useful = k / 3;
+            let nnz_per_mat = useful * 2;
+            let a_0 = random_sparse_matrix_in_range(k, useful, nnz_per_mat, &mut rng);
+            let b_0 = random_sparse_matrix_in_range(k, useful, nnz_per_mat, &mut rng);
+
+            let z = rng.bits(1 << m);
+            let a = apply_block_diag(&a_0, &z, k_log);
+            let b = apply_block_diag(&b_0, &z, k_log);
+            let z_packed = pack_z_lincheck(&z, m, k_log);
+
+            let x_ab = random_quirky_point(m, k_log, k_skip, &mut rng);
+            let v_a = mle_eval_bool_quirky(&a, m, k_log, k_skip, &x_ab);
+            let v_b = mle_eval_bool_quirky(&b, m, k_log, k_skip, &x_ab);
+
+            let compact = CompactCscCircuit::from_matrices(&a_0, &b_0);
+            let mut ch_p = FsChallenger::new(b"flock-test-v0");
+            let (proof, claim_p) =
+                prove(&z_packed, m, k_log, k_skip, &compact, &x_ab, &mut ch_p);
+
+            let mut ch_v = FsChallenger::new(b"flock-test-v0");
+            let claim_v = verify(
+                m, k_log, k_skip, &compact, &x_ab, v_a, v_b, &proof, &mut ch_v,
+            )
+            .unwrap_or_else(|e| {
+                panic!("compact verify rejected at m={m},k_log={k_log},k_skip={k_skip}: {e:?}")
+            });
+
+            assert_eq!(
+                claim_p, claim_v,
+                "claim mismatch at m={m}, k_log={k_log}, k_skip={k_skip}"
+            );
+        }
+    }
+
+    #[test]
+    fn sparse_eq_inner_speedup_measurement() {
+        let k_log = 15usize;
+        let k_skip = 6usize;
+        let k = 1usize << k_log;
+        let useful = 3094;
+        let mut rng = Rng::new(5555);
+        let x_inner_rest = rng.f128_vec(k_log - k_skip);
+        let z_skip = rng.f128();
+        let alpha = rng.f128();
+
+        let nnz_per_mat = useful * 3;
+        let a_0 = random_sparse_matrix_in_range(k, useful, nnz_per_mat, &mut rng);
+        let b_0 = random_sparse_matrix_in_range(k, useful, nnz_per_mat, &mut rng);
+
+        let dense_csc = CscCircuit::from_matrices(&a_0, &b_0);
+        let compact = CompactCscCircuit::from_matrices(&a_0, &b_0);
+
+        eprintln!(
+            "K={k}, useful_rows={useful}, n_unique_rows={}, a_nnz={}, b_nnz={}",
+            compact.n_unique_rows(),
+            compact.a_rows_compact.len(),
+            compact.b_rows_compact.len(),
+        );
+
+        let n_iter = 50;
+
+        let mut dense_times = Vec::with_capacity(n_iter);
+        for _ in 0..n_iter {
+            let t = std::time::Instant::now();
+            let eq = build_quirky_eq_table(z_skip, &x_inner_rest, k_skip);
+            let _comb = dense_csc.fold_alpha_batched(alpha, &eq);
+            dense_times.push(t.elapsed());
+        }
+
+        let mut sparse_times = Vec::with_capacity(n_iter);
+        for _ in 0..n_iter {
+            let t = std::time::Instant::now();
+            let eq = build_quirky_eq_table_sparse(
+                z_skip,
+                &x_inner_rest,
+                k_skip,
+                &compact.referenced_rows,
+            );
+            let _comb = compact.fold_alpha_batched_compact(alpha, &eq);
+            sparse_times.push(t.elapsed());
+        }
+
+        dense_times.sort();
+        sparse_times.sort();
+
+        let dense_median = dense_times[n_iter / 2].as_secs_f64() * 1e3;
+        let sparse_median = sparse_times[n_iter / 2].as_secs_f64() * 1e3;
+        let speedup = dense_median / sparse_median;
+
+        eprintln!(
+            "  dense  (build_quirky_eq + fold): median {dense_median:.3} ms"
+        );
+        eprintln!(
+            "  sparse (build_sparse + fold_compact): median {sparse_median:.3} ms"
+        );
+        eprintln!("  speedup: {speedup:.2}x");
+        eprintln!(
+            "  savings: {:.3} ms ({:.1}%)",
+            dense_median - sparse_median,
+            (1.0 - sparse_median / dense_median) * 100.0
+        );
+    }
+
+    fn random_sparse_matrix_in_range(
+        k: usize,
+        useful_rows: usize,
+        nnz: usize,
+        rng: &mut Rng,
+    ) -> SparseBinaryMatrix {
+        let mut rows: Vec<Vec<usize>> = vec![Vec::new(); k];
+        let mut seen = std::collections::HashSet::new();
+        let mut count = 0;
+        while count < nnz {
+            let r = (rng.next_u64() as usize) % useful_rows;
+            let c = (rng.next_u64() as usize) % k;
+            if seen.insert((r, c)) {
+                rows[r].push(c);
+                count += 1;
+            }
+        }
+        for row in &mut rows {
+            row.sort();
+        }
+        SparseBinaryMatrix {
+            num_rows: k,
+            num_cols: k,
+            rows,
+        }
     }
 }

--- a/crates/flock-core/src/ntt/additive_ntt_f128.rs
+++ b/crates/flock-core/src/ntt/additive_ntt_f128.rs
@@ -146,7 +146,18 @@ impl AdditiveNttF128 {
         {
             self.forward_transform_batched(data);
         }
-        #[cfg(not(all(target_arch = "aarch64", target_feature = "aes")))]
+        #[cfg(all(target_arch = "x86_64", not(all(target_arch = "aarch64", target_feature = "aes"))))]
+        {
+            if crate::field::gf2_128::x86_simd::has_vpclmulqdq() {
+                self.forward_transform_x86(data);
+            } else {
+                self.forward_transform_scalar(data);
+            }
+        }
+        #[cfg(not(any(
+            all(target_arch = "aarch64", target_feature = "aes"),
+            target_arch = "x86_64",
+        )))]
         {
             self.forward_transform_scalar(data);
         }
@@ -444,6 +455,50 @@ impl AdditiveNttF128 {
                         block += 2;
                     }
                     // Scalar tail (num_blocks odd — only when num_blocks = 1).
+                    while block < num_blocks {
+                        let twiddle = self.twiddle(layer, block);
+                        let idx0 = block * 2;
+                        let idx1 = idx0 + 1;
+                        let v = data[idx1];
+                        let new_u = data[idx0] + v * twiddle;
+                        data[idx0] = new_u;
+                        data[idx1] = v + new_u;
+                        block += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Single-threaded x86 forward transform (uses `ghash_mul_vec2_x86` to
+    /// batch 2 butterflies per VPCLMULQDQ pair).
+    #[cfg(target_arch = "x86_64")]
+    pub fn forward_transform_x86(&self, data: &mut [F128]) {
+        let log_d = log2_pow2(data.len());
+        assert!(log_d <= self.log_domain_size());
+
+        for layer in 0..log_d {
+            let num_blocks = 1usize << layer;
+            let block_size = 1usize << (log_d - layer);
+            let block_size_half = block_size >> 1;
+            // SAFETY: caller verifies VPCLMULQDQ at runtime before calling.
+            unsafe {
+                if block_size_half >= 2 {
+                    for block in 0..num_blocks {
+                        let twiddle = self.twiddle(layer, block);
+                        let block_start = block * block_size;
+                        let chunk = &mut data[block_start..block_start + block_size];
+                        butterfly_block_x86(chunk, twiddle, block_size_half);
+                    }
+                } else {
+                    debug_assert_eq!(block_size_half, 1);
+                    let mut block = 0;
+                    while block + 1 < num_blocks {
+                        let t_a = self.twiddle(layer, block);
+                        let t_b = self.twiddle(layer, block + 1);
+                        butterfly_across_blocks_x86(data, block * 2, t_a, t_b);
+                        block += 2;
+                    }
                     while block < num_blocks {
                         let twiddle = self.twiddle(layer, block);
                         let idx0 = block * 2;
@@ -910,6 +965,109 @@ unsafe fn butterfly_across_blocks_neon_in_chunk(chunk: &mut [F128], t_a: F128, t
     chunk[3] = new_v_b;
 }
 
+// ---------------------------------------------------------------------------
+// x86 butterfly helpers — batch 2 F128 butterflies per ghash_mul_vec2_x86.
+// ---------------------------------------------------------------------------
+
+/// Two butterflies within a single block (shared twiddle), using AVX2
+/// VPCLMULQDQ. Mirrors [`butterfly_block_neon`]: processes pairs in steps
+/// of 2, sharing the twiddle across the vec2 call.
+///
+/// # Safety
+/// Caller must ensure `avx2` and `vpclmulqdq` are available.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+#[target_feature(enable = "avx2,vpclmulqdq")]
+unsafe fn butterfly_block_x86(chunk: &mut [F128], twiddle: F128, half: usize) {
+    use crate::field::gf2_128::x86_simd::ghash_mul_vec2_x86;
+    debug_assert!(half >= 2);
+    debug_assert_eq!(chunk.len(), 2 * half);
+    let mut idx0 = 0;
+    while idx0 < half {
+        let idx1 = idx0 + half;
+        let u_a = chunk[idx0];
+        let v_a = chunk[idx1];
+        let u_b = chunk[idx0 + 1];
+        let v_b = chunk[idx1 + 1];
+
+        // SAFETY: avx2+vpclmulqdq enabled by target_feature on this function.
+        let prod = unsafe { ghash_mul_vec2_x86([twiddle, twiddle], [v_a, v_b]) };
+
+        let new_u_a = F128 {
+            lo: u_a.lo ^ prod[0].lo,
+            hi: u_a.hi ^ prod[0].hi,
+        };
+        let new_u_b = F128 {
+            lo: u_b.lo ^ prod[1].lo,
+            hi: u_b.hi ^ prod[1].hi,
+        };
+        let new_v_a = F128 {
+            lo: v_a.lo ^ new_u_a.lo,
+            hi: v_a.hi ^ new_u_a.hi,
+        };
+        let new_v_b = F128 {
+            lo: v_b.lo ^ new_u_b.lo,
+            hi: v_b.hi ^ new_u_b.hi,
+        };
+
+        chunk[idx0] = new_u_a;
+        chunk[idx1] = new_v_a;
+        chunk[idx0 + 1] = new_u_b;
+        chunk[idx1 + 1] = new_v_b;
+        idx0 += 2;
+    }
+}
+
+/// Two butterflies across 2 adjacent blocks (deepest layer, different
+/// twiddles), using AVX2 VPCLMULQDQ.
+///
+/// # Safety
+/// Caller must ensure `avx2` and `vpclmulqdq` are available.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+#[target_feature(enable = "avx2,vpclmulqdq")]
+unsafe fn butterfly_across_blocks_x86(data: &mut [F128], base: usize, t_a: F128, t_b: F128) {
+    // SAFETY: caller's target-feature guarantees cover this call.
+    unsafe { butterfly_across_blocks_x86_in_chunk(&mut data[base..base + 4], t_a, t_b) };
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+#[target_feature(enable = "avx2,vpclmulqdq")]
+unsafe fn butterfly_across_blocks_x86_in_chunk(chunk: &mut [F128], t_a: F128, t_b: F128) {
+    use crate::field::gf2_128::x86_simd::ghash_mul_vec2_x86;
+    debug_assert_eq!(chunk.len(), 4);
+    let u_a = chunk[0];
+    let v_a = chunk[1];
+    let u_b = chunk[2];
+    let v_b = chunk[3];
+
+    // SAFETY: avx2+vpclmulqdq enabled by target_feature on this function.
+    let prod = unsafe { ghash_mul_vec2_x86([t_a, t_b], [v_a, v_b]) };
+
+    let new_u_a = F128 {
+        lo: u_a.lo ^ prod[0].lo,
+        hi: u_a.hi ^ prod[0].hi,
+    };
+    let new_u_b = F128 {
+        lo: u_b.lo ^ prod[1].lo,
+        hi: u_b.hi ^ prod[1].hi,
+    };
+    let new_v_a = F128 {
+        lo: v_a.lo ^ new_u_a.lo,
+        hi: v_a.hi ^ new_u_a.hi,
+    };
+    let new_v_b = F128 {
+        lo: v_b.lo ^ new_u_b.lo,
+        hi: v_b.hi ^ new_u_b.hi,
+    };
+
+    chunk[0] = new_u_a;
+    chunk[1] = new_v_a;
+    chunk[2] = new_u_b;
+    chunk[3] = new_v_b;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1133,6 +1291,28 @@ mod tests {
         // At layer log_d - 1 = 3, there are 2^3 = 8 blocks. twiddle(3, b) for b ∈ 0..8.
         for b in 0..8 {
             let _t = ntt.twiddle(log_d - 1, b);
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn x86_ntt_matches_scalar() {
+        if !crate::field::gf2_128::x86_simd::has_vpclmulqdq() {
+            eprintln!("VPCLMULQDQ not available, skipping x86_ntt_matches_scalar");
+            return;
+        }
+        let mut rng = Rng::new(0xBB5);
+        for log_d in 1..=10 {
+            let ntt = AdditiveNttF128::standard(log_d);
+            let original = rand_vec(&mut rng, 1 << log_d);
+            let mut v_scalar = original.clone();
+            ntt.forward_transform_scalar(&mut v_scalar);
+            let mut v_x86 = original.clone();
+            ntt.forward_transform_x86(&mut v_x86);
+            assert_eq!(
+                v_x86, v_scalar,
+                "x86 disagrees with scalar at log_d={log_d}"
+            );
         }
     }
 }

--- a/crates/flock-core/src/ntt/additive_ntt_f128.rs
+++ b/crates/flock-core/src/ntt/additive_ntt_f128.rs
@@ -205,16 +205,7 @@ impl AdditiveNttF128 {
         assert!(log_d <= self.log_domain_size());
         assert!(start_layer <= log_d);
 
-        // Scalar; SIMD/parallel variants below dispatch from `forward_transform_interleaved`
-        // on supported targets.
-        #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
-        {
-            self.forward_transform_interleaved_parallel_from_layer(data, num_ntts, start_layer);
-        }
-        #[cfg(not(all(target_arch = "aarch64", target_feature = "aes")))]
-        {
-            self.forward_transform_interleaved_scalar_from_layer(data, num_ntts, start_layer);
-        }
+        self.forward_transform_interleaved_parallel_from_layer(data, num_ntts, start_layer);
     }
 
     /// Scalar reference for the interleaved forward NTT.
@@ -265,14 +256,12 @@ impl AdditiveNttF128 {
     /// inputs to avoid rayon overhead; for large inputs it uses an in-place
     /// scalar butterfly per lane (per-lane vectorization is future work — the
     /// big win at large `m` is cache locality + thread parallelism).
-    #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
     pub fn forward_transform_interleaved_parallel(&self, data: &mut [F128], num_ntts: usize) {
         self.forward_transform_interleaved_parallel_from_layer(data, num_ntts, 0);
     }
 
     /// Parallel interleaved forward NTT from `start_layer` (see
     /// [`Self::forward_transform_interleaved_from_layer`]).
-    #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
     pub fn forward_transform_interleaved_parallel_from_layer(
         &self,
         data: &mut [F128],

--- a/crates/flock-core/src/ntt/inv_table.rs
+++ b/crates/flock-core/src/ntt/inv_table.rs
@@ -114,6 +114,13 @@ impl InvNttTableByteSingleGf8 {
             unsafe { self.apply_neon_unchecked(bytes, out) };
             return;
         }
+        #[cfg(target_arch = "x86_64")]
+        if self.ell >= 16 {
+            // SAFETY: SSE2 is baseline on x86_64; ell ≥ 16 ⇒ at least one
+            // 128-bit chunk; method validates slice lengths.
+            unsafe { self.apply_sse2(bytes, out) };
+            return;
+        }
         self.apply_scalar(bytes, out);
     }
 
@@ -181,6 +188,56 @@ impl InvNttTableByteSingleGf8 {
                         let v = vld1q_u8(row_b.add(sc * 16));
                         let dst = out_ptr.add(c * 16);
                         vst1q_u8(dst, veorq_u8(vld1q_u8(dst), v));
+                    }
+                }
+            }
+        }
+    }
+
+    /// SSE2 variant of `apply` — same algorithm as `apply_neon_unchecked`,
+    /// using SSE2 128-bit load/store/XOR. The 8-byte half-swap (NEON
+    /// `vextq_u8::<8>`) is implemented via `_mm_shuffle_epi32` with imm 0x4E
+    /// (swap the two 64-bit halves).
+    ///
+    /// # Safety
+    /// SSE2 is baseline on x86_64 — always available. The method validates
+    /// slice lengths.
+    #[cfg(target_arch = "x86_64")]
+    unsafe fn apply_sse2(&self, bytes: &[u8], out: &mut [F8]) {
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::*;
+
+        assert_eq!(bytes.len(), self.n_chunks);
+        assert_eq!(out.len(), self.ell);
+        let n128 = self.ell / 16;
+        let base = self.data.as_ptr() as *const u8;
+        let out_ptr = out.as_mut_ptr() as *mut u8;
+
+        unsafe {
+            let row0 = base.add(bytes[0] as usize * self.ell);
+            for c in 0..n128 {
+                let v = _mm_loadu_si128(row0.add(c * 16) as *const __m128i);
+                _mm_storeu_si128(out_ptr.add(c * 16) as *mut __m128i, v);
+            }
+
+            for b in 1..self.n_chunks {
+                let b_high = b >> 1;
+                let b_odd = (b & 1) != 0;
+                let row_b = base.add(bytes[b] as usize * self.ell);
+                if b_odd {
+                    for c in 0..n128 {
+                        let sc = c ^ b_high;
+                        let v = _mm_loadu_si128(row_b.add(sc * 16) as *const __m128i);
+                        let v_swapped = _mm_shuffle_epi32(v, 0x4E);
+                        let dst = out_ptr.add(c * 16) as *mut __m128i;
+                        _mm_storeu_si128(dst, _mm_xor_si128(_mm_loadu_si128(dst), v_swapped));
+                    }
+                } else {
+                    for c in 0..n128 {
+                        let sc = c ^ b_high;
+                        let v = _mm_loadu_si128(row_b.add(sc * 16) as *const __m128i);
+                        let dst = out_ptr.add(c * 16) as *mut __m128i;
+                        _mm_storeu_si128(dst, _mm_xor_si128(_mm_loadu_si128(dst), v));
                     }
                 }
             }

--- a/crates/flock-core/src/ntt/inv_table_deg4.rs
+++ b/crates/flock-core/src/ntt/inv_table_deg4.rs
@@ -158,16 +158,59 @@ impl InvNttTableSToV8Gf8 {
         }
     }
 
-    /// Dispatch helper — uses NEON when available, scalar otherwise.
+    /// Dispatch helper — uses NEON/SSE2 when available, scalar otherwise.
     #[inline]
     pub fn apply(&self, bytes: &[u8], out: &mut [F8]) {
         #[cfg(target_arch = "aarch64")]
         if self.ell_out >= 16 {
-            // SAFETY: aarch64 statically guarantees NEON; the method validates lengths.
             unsafe { self.apply_neon_unchecked(bytes, out) };
             return;
         }
+        #[cfg(target_arch = "x86_64")]
+        if self.ell_out >= 16 {
+            unsafe { self.apply_sse2(bytes, out) };
+            return;
+        }
         self.apply_scalar(bytes, out);
+    }
+
+    /// SSE2 variant — same algorithm as NEON, 128-bit load/store/XOR.
+    #[cfg(target_arch = "x86_64")]
+    unsafe fn apply_sse2(&self, bytes: &[u8], out: &mut [F8]) {
+        use core::arch::x86_64::*;
+        assert_eq!(bytes.len(), self.n_chunks);
+        assert_eq!(out.len(), self.ell_out);
+        let n128 = self.ell_out / 16;
+        let base = self.data.as_ptr() as *const u8;
+        let out_ptr = out.as_mut_ptr() as *mut u8;
+        unsafe {
+            let row0 = base.add(bytes[0] as usize * self.ell_out);
+            for c in 0..n128 {
+                let v = _mm_loadu_si128(row0.add(c * 16) as *const __m128i);
+                _mm_storeu_si128(out_ptr.add(c * 16) as *mut __m128i, v);
+            }
+            for b in 1..self.n_chunks {
+                let b_high = b >> 1;
+                let b_odd = (b & 1) != 0;
+                let row_b = base.add(bytes[b] as usize * self.ell_out);
+                if b_odd {
+                    for c in 0..n128 {
+                        let sc = c ^ b_high;
+                        let v = _mm_loadu_si128(row_b.add(sc * 16) as *const __m128i);
+                        let v_swapped = _mm_shuffle_epi32(v, 0x4E);
+                        let dst = out_ptr.add(c * 16) as *mut __m128i;
+                        _mm_storeu_si128(dst, _mm_xor_si128(_mm_loadu_si128(dst), v_swapped));
+                    }
+                } else {
+                    for c in 0..n128 {
+                        let sc = c ^ b_high;
+                        let v = _mm_loadu_si128(row_b.add(sc * 16) as *const __m128i);
+                        let dst = out_ptr.add(c * 16) as *mut __m128i;
+                        _mm_storeu_si128(dst, _mm_xor_si128(_mm_loadu_si128(dst), v));
+                    }
+                }
+            }
+        }
     }
 
     /// NEON variant of `apply` — operates in 16-byte chunks. Mirrors the

--- a/crates/flock-core/src/ntt/parallel_f128.rs
+++ b/crates/flock-core/src/ntt/parallel_f128.rs
@@ -136,13 +136,87 @@ fn butterfly_par(data: &mut [F128], lambda: F128, num_ntts: usize) {
         .for_each(|(t, b)| butterfly_row_pair_neon(t, b, lambda));
 }
 
+#[cfg(target_arch = "x86_64")]
+#[inline]
+#[target_feature(enable = "avx2,vpclmulqdq")]
+unsafe fn butterfly_row_pair_x86(top_row: &mut [F128], bot_row: &mut [F128], lambda: F128) {
+    use crate::field::gf2_128::x86_simd::ghash_mul_vec2_x86;
+
+    debug_assert_eq!(top_row.len(), bot_row.len());
+    let num_ntts = top_row.len();
+    // SAFETY: avx2+vpclmulqdq enabled by target_feature on this function.
+    unsafe {
+        let mut lane = 0usize;
+        while lane < num_ntts {
+            let t0 = top_row[lane];
+            let t1 = top_row[lane + 1];
+            let b0 = bot_row[lane];
+            let b1 = bot_row[lane + 1];
+
+            let prod = ghash_mul_vec2_x86([lambda, lambda], [b0, b1]);
+
+            let new_t0 = F128 {
+                lo: t0.lo ^ prod[0].lo,
+                hi: t0.hi ^ prod[0].hi,
+            };
+            let new_t1 = F128 {
+                lo: t1.lo ^ prod[1].lo,
+                hi: t1.hi ^ prod[1].hi,
+            };
+            let new_b0 = F128 {
+                lo: b0.lo ^ new_t0.lo,
+                hi: b0.hi ^ new_t0.hi,
+            };
+            let new_b1 = F128 {
+                lo: b1.lo ^ new_t1.lo,
+                hi: b1.hi ^ new_t1.hi,
+            };
+
+            top_row[lane] = new_t0;
+            top_row[lane + 1] = new_t1;
+            bot_row[lane] = new_b0;
+            bot_row[lane + 1] = new_b1;
+
+            lane += 2;
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn butterfly_x86(data: &mut [F128], lambda: F128, num_ntts: usize) {
+    let rows = data.len() / num_ntts;
+    let half = rows >> 1;
+    let half_offset = half * num_ntts;
+    let (top, bot) = data.split_at_mut(half_offset);
+    for row in 0..half {
+        let off = row * num_ntts;
+        let top_row = &mut top[off..off + num_ntts];
+        let bot_row = &mut bot[off..off + num_ntts];
+        // SAFETY: caller checks VPCLMULQDQ availability before entering the
+        // x86 path (see `butterfly` dispatch below).
+        unsafe { butterfly_row_pair_x86(top_row, bot_row, lambda) };
+    }
+}
+
 #[inline]
 fn butterfly(data: &mut [F128], lambda: F128, num_ntts: usize) {
     #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
     {
         butterfly_neon(data, lambda, num_ntts);
     }
-    #[cfg(not(all(target_arch = "aarch64", target_feature = "aes")))]
+    #[cfg(all(target_arch = "x86_64", not(all(target_arch = "aarch64", target_feature = "aes"))))]
+    {
+        if crate::field::gf2_128::x86_simd::has_vpclmulqdq() {
+            butterfly_x86(data, lambda, num_ntts);
+        } else {
+            butterfly_scalar(data, lambda, num_ntts);
+        }
+    }
+    #[cfg(not(any(
+        all(target_arch = "aarch64", target_feature = "aes"),
+        target_arch = "x86_64",
+    )))]
     {
         butterfly_scalar(data, lambda, num_ntts);
     }

--- a/crates/flock-core/src/zerocheck/univariate_skip_optimized.rs
+++ b/crates/flock-core/src/zerocheck/univariate_skip_optimized.rs
@@ -676,7 +676,118 @@ fn shift_reduce_inner_ab_fused_neon(
     }
 }
 
-/// Dispatch helper — picks the fused NEON kernel when available, otherwise scalar.
+/// x86_64 AVX2 version of shift_reduce_inner_ab.
+///
+/// Same algorithm as the scalar version, but uses AVX2 element-wise GF(2^8)
+/// multiply (bitsliced schoolbook) for the 64 lane-wise products, and AVX2
+/// 16-bit shift-accumulate + vectorized reduction. The 8 k-iterations are
+/// macro-unrolled because `_mm256_slli_epi16` requires a compile-time constant.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn shift_reduce_inner_ab_avx2(
+    a_packed: &[u8],
+    b_packed: &[u8],
+    inv_table: &InvNttTableByteSingleGf8,
+    chunk_byte_base: usize,
+    b_med: usize,
+    out: &mut [u8; 64],
+    a_col: &mut [F8],
+    b_col: &mut [F8],
+) {
+    use core::arch::x86_64::*;
+    use crate::field::gf2_8::x86::gf8_mul_vec32_x86_ew;
+
+    unsafe {
+        let mut acc0 = _mm256_setzero_si256(); // lanes 0..15 (16 x u16)
+        let mut acc1 = _mm256_setzero_si256(); // lanes 16..31
+        let mut acc2 = _mm256_setzero_si256(); // lanes 32..47
+        let mut acc3 = _mm256_setzero_si256(); // lanes 48..63
+
+        let byte_base_b = chunk_byte_base + b_med * N_CHUNKS * 8;
+
+        macro_rules! do_k {
+            ($k:literal) => {{
+                let chunk_off = byte_base_b + $k * N_CHUNKS;
+                inv_table.apply(&a_packed[chunk_off..chunk_off + N_CHUNKS], a_col);
+                inv_table.apply(&b_packed[chunk_off..chunk_off + N_CHUNKS], b_col);
+
+                let a_ptr = a_col.as_ptr() as *const u8;
+                let b_ptr = b_col.as_ptr() as *const u8;
+
+                let a_lo: [u8; 32] = *(a_ptr as *const [u8; 32]);
+                let b_lo: [u8; 32] = *(b_ptr as *const [u8; 32]);
+                let a_hi: [u8; 32] = *(a_ptr.add(32) as *const [u8; 32]);
+                let b_hi: [u8; 32] = *(b_ptr.add(32) as *const [u8; 32]);
+
+                let y_lo = gf8_mul_vec32_x86_ew(&a_lo, &b_lo);
+                let y_hi = gf8_mul_vec32_x86_ew(&a_hi, &b_hi);
+
+                let y0 = _mm256_loadu_si256(y_lo.as_ptr() as *const _);
+                let y1 = _mm256_loadu_si256(y_hi.as_ptr() as *const _);
+
+                let y0_lo128 = _mm256_castsi256_si128(y0);
+                let y0_hi128 = _mm256_extracti128_si256(y0, 1);
+                let y1_lo128 = _mm256_castsi256_si128(y1);
+                let y1_hi128 = _mm256_extracti128_si256(y1, 1);
+
+                let y0_lo_u16 = _mm256_cvtepu8_epi16(y0_lo128);
+                let y0_hi_u16 = _mm256_cvtepu8_epi16(y0_hi128);
+                let y1_lo_u16 = _mm256_cvtepu8_epi16(y1_lo128);
+                let y1_hi_u16 = _mm256_cvtepu8_epi16(y1_hi128);
+
+                acc0 = _mm256_xor_si256(acc0, _mm256_slli_epi16(y0_lo_u16, $k));
+                acc1 = _mm256_xor_si256(acc1, _mm256_slli_epi16(y0_hi_u16, $k));
+                acc2 = _mm256_xor_si256(acc2, _mm256_slli_epi16(y1_lo_u16, $k));
+                acc3 = _mm256_xor_si256(acc3, _mm256_slli_epi16(y1_hi_u16, $k));
+            }};
+        }
+        do_k!(0);
+        do_k!(1);
+        do_k!(2);
+        do_k!(3);
+        do_k!(4);
+        do_k!(5);
+        do_k!(6);
+        do_k!(7);
+
+        // Reduce: split each u16 accumulator into lo/hi bytes, then vectorized
+        // GF(2^8) reduction.
+        let mask_lo = _mm256_set1_epi16(0x00FF);
+        let lo0 = _mm256_and_si256(acc0, mask_lo);
+        let hi0 = _mm256_srli_epi16(acc0, 8);
+        let lo1 = _mm256_and_si256(acc1, mask_lo);
+        let hi1 = _mm256_srli_epi16(acc1, 8);
+        let lo2 = _mm256_and_si256(acc2, mask_lo);
+        let hi2 = _mm256_srli_epi16(acc2, 8);
+        let lo3 = _mm256_and_si256(acc3, mask_lo);
+        let hi3 = _mm256_srli_epi16(acc3, 8);
+
+        // Pack 16 u16 lo/hi pairs into 32 u8 with _mm256_packus_epi16, then fix
+        // the AVX2 lane-crossing with _mm256_permute4x64_epi64.
+        let lo_packed_01 = _mm256_permute4x64_epi64(
+            _mm256_packus_epi16(lo0, lo1), 0b11_01_10_00
+        );
+        let hi_packed_01 = _mm256_permute4x64_epi64(
+            _mm256_packus_epi16(hi0, hi1), 0b11_01_10_00
+        );
+        let lo_packed_23 = _mm256_permute4x64_epi64(
+            _mm256_packus_epi16(lo2, lo3), 0b11_01_10_00
+        );
+        let hi_packed_23 = _mm256_permute4x64_epi64(
+            _mm256_packus_epi16(hi2, hi3), 0b11_01_10_00
+        );
+
+        let r01 = crate::field::gf2_8::x86::gf8_reduce_vec32(lo_packed_01, hi_packed_01);
+        let r23 = crate::field::gf2_8::x86::gf8_reduce_vec32(lo_packed_23, hi_packed_23);
+
+        let p = out.as_mut_ptr();
+        _mm256_storeu_si256(p as *mut _, r01);
+        _mm256_storeu_si256(p.add(32) as *mut _, r23);
+    }
+}
+
+/// Dispatch helper — picks the fused NEON kernel when available, AVX2 on x86_64,
+/// otherwise scalar.
 #[inline]
 fn shift_reduce_inner_ab(
     a_packed: &[u8],
@@ -700,7 +811,26 @@ fn shift_reduce_inner_ab(
             out,
         );
     }
-    #[cfg(not(target_arch = "aarch64"))]
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+    {
+        // SAFETY: avx2 target_feature is enabled at compile time.
+        unsafe {
+            shift_reduce_inner_ab_avx2(
+                a_packed,
+                b_packed,
+                inv_table,
+                chunk_byte_base,
+                b_med,
+                out,
+                a_col,
+                b_col,
+            );
+        }
+    }
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        all(target_arch = "x86_64", target_feature = "avx2"),
+    )))]
     {
         shift_reduce_inner_ab_scalar(
             a_packed,

--- a/crates/flock-core/src/zerocheck/univariate_skip_optimized.rs
+++ b/crates/flock-core/src/zerocheck/univariate_skip_optimized.rs
@@ -1037,7 +1037,34 @@ fn process_one_x_hi(
                     state.partial_c[lane] += cf_c_f * eq_lo_val;
                 }
             }
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
+            {
+                use core::arch::x86_64::*;
+                let convert_ptr = convert.as_ptr() as *const u8;
+                for lane in 0..ELL {
+                    let mut cf_ab = unsafe { _mm_setzero_si128() };
+                    let mut cf_c = unsafe { _mm_setzero_si128() };
+                    for b_med in 0..(1 << N_MEDIUM) {
+                        let v_ab = state.chunk_ab_bytes[b_med][lane] as usize;
+                        let v_c = state.chunk_c_bytes[b_med][lane] as usize;
+                        unsafe {
+                            cf_ab = _mm_xor_si128(cf_ab,
+                                _mm_loadu_si128(convert_ptr.add((b_med * 256 + v_ab) * 16) as *const __m128i));
+                            cf_c = _mm_xor_si128(cf_c,
+                                _mm_loadu_si128(convert_ptr.add((b_med * 256 + v_c) * 16) as *const __m128i));
+                        }
+                    }
+                    let cf_ab_f = unsafe {
+                        F128 { lo: _mm_extract_epi64(cf_ab, 0) as u64, hi: _mm_extract_epi64(cf_ab, 1) as u64 }
+                    };
+                    let cf_c_f = unsafe {
+                        F128 { lo: _mm_extract_epi64(cf_c, 0) as u64, hi: _mm_extract_epi64(cf_c, 1) as u64 }
+                    };
+                    state.partial_ab[lane] += cf_ab_f * eq_lo_val;
+                    state.partial_c[lane] += cf_c_f * eq_lo_val;
+                }
+            }
+            #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
             {
                 for lane in 0..ELL {
                     let mut cf_ab = F128::ZERO;
@@ -1103,7 +1130,34 @@ fn process_one_x_hi(
                     state.partial_c[lane] += cf_c_f * eq_lo_val;
                 }
             }
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
+            {
+                use core::arch::x86_64::*;
+                let convert_ptr = convert.as_ptr() as *const u8;
+                for lane in 0..ELL {
+                    let mut cf_ab = unsafe { _mm_setzero_si128() };
+                    let mut cf_c = unsafe { _mm_setzero_si128() };
+                    for b_med in 0..n_b_med {
+                        let v_ab = state.chunk_ab_bytes[b_med][lane] as usize;
+                        let v_c = state.chunk_c_bytes[b_med][lane] as usize;
+                        unsafe {
+                            cf_ab = _mm_xor_si128(cf_ab,
+                                _mm_loadu_si128(convert_ptr.add((b_med * 256 + v_ab) * 16) as *const __m128i));
+                            cf_c = _mm_xor_si128(cf_c,
+                                _mm_loadu_si128(convert_ptr.add((b_med * 256 + v_c) * 16) as *const __m128i));
+                        }
+                    }
+                    let cf_ab_f = unsafe {
+                        F128 { lo: _mm_extract_epi64(cf_ab, 0) as u64, hi: _mm_extract_epi64(cf_ab, 1) as u64 }
+                    };
+                    let cf_c_f = unsafe {
+                        F128 { lo: _mm_extract_epi64(cf_c, 0) as u64, hi: _mm_extract_epi64(cf_c, 1) as u64 }
+                    };
+                    state.partial_ab[lane] += cf_ab_f * eq_lo_val;
+                    state.partial_c[lane] += cf_c_f * eq_lo_val;
+                }
+            }
+            #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
             {
                 for lane in 0..ELL {
                     let mut cf_ab = F128::ZERO;
@@ -1277,7 +1331,43 @@ fn process_one_x_hi_with_s_hat_v(
                     state.partial_c_1[lane] += cf_c_1_f * eq_lo_val;
                 }
             }
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
+            {
+                use core::arch::x86_64::*;
+                let convert_ptr = convert.as_ptr() as *const u8;
+                for lane in 0..ELL {
+                    let mut cf_ab = unsafe { _mm_setzero_si128() };
+                    let mut cf_c_0 = unsafe { _mm_setzero_si128() };
+                    let mut cf_c_1 = unsafe { _mm_setzero_si128() };
+                    for b_med in 0..(1 << N_MEDIUM) {
+                        let v_ab = state.chunk_ab_bytes[b_med][lane] as usize;
+                        let v_c = state.chunk_c_bytes[b_med][lane] as usize;
+                        let v_c_0 = v_c & 0x55;
+                        let v_c_1 = v_c & 0xAA;
+                        unsafe {
+                            cf_ab = _mm_xor_si128(cf_ab,
+                                _mm_loadu_si128(convert_ptr.add((b_med * 256 + v_ab) * 16) as *const __m128i));
+                            cf_c_0 = _mm_xor_si128(cf_c_0,
+                                _mm_loadu_si128(convert_ptr.add((b_med * 256 + v_c_0) * 16) as *const __m128i));
+                            cf_c_1 = _mm_xor_si128(cf_c_1,
+                                _mm_loadu_si128(convert_ptr.add((b_med * 256 + v_c_1) * 16) as *const __m128i));
+                        }
+                    }
+                    let cf_ab_f = unsafe {
+                        F128 { lo: _mm_extract_epi64(cf_ab, 0) as u64, hi: _mm_extract_epi64(cf_ab, 1) as u64 }
+                    };
+                    let cf_c_0_f = unsafe {
+                        F128 { lo: _mm_extract_epi64(cf_c_0, 0) as u64, hi: _mm_extract_epi64(cf_c_0, 1) as u64 }
+                    };
+                    let cf_c_1_f = unsafe {
+                        F128 { lo: _mm_extract_epi64(cf_c_1, 0) as u64, hi: _mm_extract_epi64(cf_c_1, 1) as u64 }
+                    };
+                    state.partial_ab[lane] += cf_ab_f * eq_lo_val;
+                    state.partial_c_0[lane] += cf_c_0_f * eq_lo_val;
+                    state.partial_c_1[lane] += cf_c_1_f * eq_lo_val;
+                }
+            }
+            #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
             {
                 for lane in 0..ELL {
                     let mut cf_ab = F128::ZERO;

--- a/crates/flock-core/src/zerocheck/univariate_skip_optimized.rs
+++ b/crates/flock-core/src/zerocheck/univariate_skip_optimized.rs
@@ -300,8 +300,80 @@ pub fn bit_transpose_64bytes(input: &[u8; 64], output: &mut [u8; 64]) {
     unsafe {
         bit_transpose_64bytes_neon(input, output)
     }
-    #[cfg(not(target_arch = "aarch64"))]
+    #[cfg(target_arch = "x86_64")]
+    // SAFETY: SSE2 is baseline on x86_64.
+    unsafe {
+        bit_transpose_64bytes_sse2(input, output)
+    }
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
     bit_transpose_64bytes_scalar(input, output);
+}
+
+#[cfg(target_arch = "x86_64")]
+unsafe fn bit_transpose_64bytes_sse2(input: &[u8; 64], output: &mut [u8; 64]) {
+    use core::arch::x86_64::*;
+    unsafe {
+        // Step 1: byte-level shuffle. Reorder input so each 8-byte group holds
+        // one b_chunk's x_small=0..7 bytes. NEON uses vqtbl4q_u8 (64-byte cross-
+        // register table lookup); SSE2 doesn't have that, so we do it in scalar.
+        // 64 byte moves — fast because both input and shuffled fit in L1.
+        let mut shuffled = [0u8; 64];
+        for b_chunk in 0..8 {
+            for x_small in 0..8 {
+                shuffled[b_chunk * 8 + x_small] = input[x_small * 8 + b_chunk];
+            }
+        }
+
+        // Step 2: delta-swap 8×8 bit transpose on the shuffled layout.
+        // Each 8-byte group is now (shuffled[b_chunk*8 + 0..8]) = the 8 bytes
+        // from x_small=0..7 for one b_chunk. The delta-swap turns each byte's
+        // 8 bits into 8 output bytes' single-bit contributions.
+        let sp = shuffled.as_ptr();
+        let mut y0 = _mm_loadu_si128(sp as *const __m128i);
+        let mut y1 = _mm_loadu_si128(sp.add(16) as *const __m128i);
+        let mut y2 = _mm_loadu_si128(sp.add(32) as *const __m128i);
+        let mut y3 = _mm_loadu_si128(sp.add(48) as *const __m128i);
+
+        let mask1 = _mm_set1_epi64x(0x00AA00AA00AA00AAu64 as i64);
+        let mask2 = _mm_set1_epi64x(0x0000CCCC0000CCCCu64 as i64);
+        let mask3 = _mm_set1_epi64x(0x00000000F0F0F0F0u64 as i64);
+
+        // Round 1: distance 7
+        let t0 = _mm_and_si128(_mm_xor_si128(y0, _mm_srli_epi64(y0, 7)), mask1);
+        let t1 = _mm_and_si128(_mm_xor_si128(y1, _mm_srli_epi64(y1, 7)), mask1);
+        let t2 = _mm_and_si128(_mm_xor_si128(y2, _mm_srli_epi64(y2, 7)), mask1);
+        let t3 = _mm_and_si128(_mm_xor_si128(y3, _mm_srli_epi64(y3, 7)), mask1);
+        y0 = _mm_xor_si128(y0, _mm_xor_si128(t0, _mm_slli_epi64(t0, 7)));
+        y1 = _mm_xor_si128(y1, _mm_xor_si128(t1, _mm_slli_epi64(t1, 7)));
+        y2 = _mm_xor_si128(y2, _mm_xor_si128(t2, _mm_slli_epi64(t2, 7)));
+        y3 = _mm_xor_si128(y3, _mm_xor_si128(t3, _mm_slli_epi64(t3, 7)));
+
+        // Round 2: distance 14
+        let t0 = _mm_and_si128(_mm_xor_si128(y0, _mm_srli_epi64(y0, 14)), mask2);
+        let t1 = _mm_and_si128(_mm_xor_si128(y1, _mm_srli_epi64(y1, 14)), mask2);
+        let t2 = _mm_and_si128(_mm_xor_si128(y2, _mm_srli_epi64(y2, 14)), mask2);
+        let t3 = _mm_and_si128(_mm_xor_si128(y3, _mm_srli_epi64(y3, 14)), mask2);
+        y0 = _mm_xor_si128(y0, _mm_xor_si128(t0, _mm_slli_epi64(t0, 14)));
+        y1 = _mm_xor_si128(y1, _mm_xor_si128(t1, _mm_slli_epi64(t1, 14)));
+        y2 = _mm_xor_si128(y2, _mm_xor_si128(t2, _mm_slli_epi64(t2, 14)));
+        y3 = _mm_xor_si128(y3, _mm_xor_si128(t3, _mm_slli_epi64(t3, 14)));
+
+        // Round 3: distance 28
+        let t0 = _mm_and_si128(_mm_xor_si128(y0, _mm_srli_epi64(y0, 28)), mask3);
+        let t1 = _mm_and_si128(_mm_xor_si128(y1, _mm_srli_epi64(y1, 28)), mask3);
+        let t2 = _mm_and_si128(_mm_xor_si128(y2, _mm_srli_epi64(y2, 28)), mask3);
+        let t3 = _mm_and_si128(_mm_xor_si128(y3, _mm_srli_epi64(y3, 28)), mask3);
+        y0 = _mm_xor_si128(y0, _mm_xor_si128(t0, _mm_slli_epi64(t0, 28)));
+        y1 = _mm_xor_si128(y1, _mm_xor_si128(t1, _mm_slli_epi64(t1, 28)));
+        y2 = _mm_xor_si128(y2, _mm_xor_si128(t2, _mm_slli_epi64(t2, 28)));
+        y3 = _mm_xor_si128(y3, _mm_xor_si128(t3, _mm_slli_epi64(t3, 28)));
+
+        let out_ptr = output.as_mut_ptr();
+        _mm_storeu_si128(out_ptr as *mut __m128i, y0);
+        _mm_storeu_si128(out_ptr.add(16) as *mut __m128i, y1);
+        _mm_storeu_si128(out_ptr.add(32) as *mut __m128i, y2);
+        _mm_storeu_si128(out_ptr.add(48) as *mut __m128i, y3);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/flock-core/src/zerocheck/univariate_skip_optimized.rs
+++ b/crates/flock-core/src/zerocheck/univariate_skip_optimized.rs
@@ -1520,7 +1520,41 @@ fn process_one_x_hi_with_s_hat_v(
                     state.partial_c_1[lane] += cf_c_1_f * eq_lo_val;
                 }
             }
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
+            {
+                use core::arch::x86_64::*;
+                let convert_ptr = convert.as_ptr() as *const u8;
+                for lane in 0..ELL {
+                    let mut cf_ab = unsafe { _mm_setzero_si128() };
+                    let mut cf_c_0 = unsafe { _mm_setzero_si128() };
+                    let mut cf_c_1 = unsafe { _mm_setzero_si128() };
+                    for b_med in 0..n_b_med {
+                        let v_ab = state.chunk_ab_bytes[b_med][lane] as usize;
+                        let v_c = state.chunk_c_bytes[b_med][lane] as usize;
+                        unsafe {
+                            cf_ab = _mm_xor_si128(cf_ab,
+                                _mm_loadu_si128(convert_ptr.add((b_med * 256 + v_ab) * 16) as *const __m128i));
+                            cf_c_0 = _mm_xor_si128(cf_c_0,
+                                _mm_loadu_si128(convert_ptr.add((b_med * 256 + (v_c & 0x55)) * 16) as *const __m128i));
+                            cf_c_1 = _mm_xor_si128(cf_c_1,
+                                _mm_loadu_si128(convert_ptr.add((b_med * 256 + (v_c & 0xAA)) * 16) as *const __m128i));
+                        }
+                    }
+                    let cf_ab_f = unsafe {
+                        F128 { lo: _mm_extract_epi64(cf_ab, 0) as u64, hi: _mm_extract_epi64(cf_ab, 1) as u64 }
+                    };
+                    let cf_c_0_f = unsafe {
+                        F128 { lo: _mm_extract_epi64(cf_c_0, 0) as u64, hi: _mm_extract_epi64(cf_c_0, 1) as u64 }
+                    };
+                    let cf_c_1_f = unsafe {
+                        F128 { lo: _mm_extract_epi64(cf_c_1, 0) as u64, hi: _mm_extract_epi64(cf_c_1, 1) as u64 }
+                    };
+                    state.partial_ab[lane] += cf_ab_f * eq_lo_val;
+                    state.partial_c_0[lane] += cf_c_0_f * eq_lo_val;
+                    state.partial_c_1[lane] += cf_c_1_f * eq_lo_val;
+                }
+            }
+            #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
             {
                 for lane in 0..ELL {
                     let mut cf_ab = F128::ZERO;


### PR DESCRIPTION
## What

The prover's SIMD fast paths are aarch64/NEON-only; on x86_64 everything falls back to scalar. This ports the hot kernels to x86_64 intrinsics behind the same compile-time gating pattern the aarch64 paths use (`cfg(target_arch, target_feature)`; scalar fallback preserved; aarch64 untouched). Nine commits, in profile-guided order:

1. **GF(2^128) multiply via PCLMULQDQ** (schoolbook 4-mul + ghash reduce) — 2× prove on its own
2. **NTT butterfly vec2/vec4 via VPCLMULQDQ**
3. **Round-2 kernels**: GF(2^8) VPSHUFB split-nibble multiply (32 muls/instruction, feeds `shift_reduce_inner_ab`), lincheck deferred-reduction accumulator (~4k `ghash_reduce` calls saved per k_log=11 instance)
4. **SSE2 `inv_table` apply** — this was the single largest bottleneck on x86 (65.76% of prove time under `perf`)
5. **SSE2 convert-table accumulate** in `process_one_x_hi`
6. **SSE2 `bit_transpose`** (byte-shuffle + delta-swap)
7. **Parallel + cache-blocked NTT unlocked for x86** (three `#[cfg(aarch64)]` gates were hiding the rayon path; 5.1× commit speedup)
8. Review fixes: SSE2 partial-tail path, `target_feature` annotations

## Measured

AWS EC2 (Cascade Lake), `-C target-cpu=native`, 100-path batched keccak Merkle proof (our fork's workload): prove **965 ms → 297 ms (3.25×)**. Post-port `perf` profile is flat (no function >10%). Each step was A/B-measured in isolation; the ordering above is the profile-guided order they were found in.

## Honest notes for review

- Commit 3 also carries two **available-but-not-default** pieces with tests and docs: a Karatsuba 3-PCLMUL variant (schoolbook measured 1.24× *faster* on Cascade Lake — kept as an alternative for other microarchitectures) and a row-compacted CSC eq_inner builder (measured 1.56× on its microbench, not yet wired into the default path). Happy to strip either if you'd rather not carry them.
- Two same-round experiments measured **no end-to-end gain** and are *not* included: AVX2 4-way SHA-256 for the Merkle layer, and a zerocheck padding-block-skip.

## Tests

Full upstream suites pass on this branch: flock-core **276** (255 upstream + 21 new, incl. an exhaustive 65 536-pair GF(2^8) SIMD-vs-scalar check), flock-prover **81**. No public API changes.