### PR TITLE
chore: cargo fmt

### DIFF
--- a/crates/flock-core/src/lib.rs
+++ b/crates/flock-core/src/lib.rs
@@ -120,10 +120,11 @@ fn perf_core_count() -> usize {
             .args(["-n", "hw.perflevel0.physicalcpu"])
             .output()
             && let Ok(s) = std::str::from_utf8(&out.stdout)
-                && let Ok(n) = s.trim().parse::<usize>()
-                    && n > 0 {
-                        return n;
-                    }
+            && let Ok(n) = s.trim().parse::<usize>()
+            && n > 0
+        {
+            return n;
+        }
     }
     std::thread::available_parallelism()
         .map(|n| n.get())

--- a/crates/flock-core/src/lincheck.rs
+++ b/crates/flock-core/src/lincheck.rs
@@ -1077,11 +1077,14 @@ fn partial_fold_packed_z_best(
             // n_log ≥ 16; below that the L1-resident `iblock` wins. `FOLD_IBLOCK` forces
             // iblock everywhere (bench A/B).
             let n_log = m - k_log;
-            if n_log >= OBLOCK_MIN_N_LOG
-                && !FOLD_IBLOCK.load(std::sync::atomic::Ordering::Relaxed)
+            if n_log >= OBLOCK_MIN_N_LOG && !FOLD_IBLOCK.load(std::sync::atomic::Ordering::Relaxed)
             {
                 return partial_fold_packed_z_neon_oblock_padded(
-                    z_packed, m, k_log, useful_bits, eq_outer,
+                    z_packed,
+                    m,
+                    k_log,
+                    useful_bits,
+                    eq_outer,
                 );
             }
             partial_fold_packed_z_neon_iblock_padded(z_packed, m, k_log, useful_bits, eq_outer)
@@ -2213,7 +2216,10 @@ mod tests {
             (22, 14, 15_409),  // padded, non-byte-aligned (k=16384)
         ];
         for &(m, k_log, useful_bits) in cases {
-            assert!(n_log_ok_for_tile(m, k_log, NEON_TILE_T), "case must be tile-eligible");
+            assert!(
+                n_log_ok_for_tile(m, k_log, NEON_TILE_T),
+                "case must be tile-eligible"
+            );
             let k = 1usize << k_log;
             let n_log = m - k_log;
             let n_blocks = 1usize << n_log;
@@ -2229,7 +2235,8 @@ mod tests {
             let eq = build_eq_table(&rng.f128_vec(n_log));
             let want =
                 partial_fold_packed_z_neon_iblock_padded(&z_packed, m, k_log, useful_bits, &eq);
-            let got = partial_fold_packed_z_neon_oblock_padded(&z_packed, m, k_log, useful_bits, &eq);
+            let got =
+                partial_fold_packed_z_neon_oblock_padded(&z_packed, m, k_log, useful_bits, &eq);
             assert_eq!(want, got, "m={m} k_log={k_log} useful={useful_bits}");
         }
     }

--- a/crates/flock-core/src/pcs.rs
+++ b/crates/flock-core/src/pcs.rs
@@ -546,9 +546,8 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
     // incremental round-0 prime adjustment), so they only require
     // `pd_dense.is_empty()`, not `packed_direct.is_empty()`. This keeps the two
     // big ab/c claims on the fused fold instead of materializing them.
-    let use_fast = !rs_deferred.is_empty()
-        && rs_deferred.len() == rs_results.len()
-        && pd_dense.is_empty();
+    let use_fast =
+        !rs_deferred.is_empty() && rs_deferred.len() == rs_results.len() && pd_dense.is_empty();
 
     let (mut round0_u0, mut round0_u2) = if use_fast {
         let b = rs_deferred[0].0.len(); // eq_lo.len(); shared across claims (same split)
@@ -661,8 +660,7 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
             // full O(L) re-pass over b_combined. The prime is linear in
             // b_combined, so the delta from scattering `g·eq` equals
             // Σ adjust_prime_for_delta(idx, g·val) over the live positions.
-            let (du0, du2) =
-                sparse_scatter_add_parallel(&mut b_combined, packed_witness, eq, *g);
+            let (du0, du2) = sparse_scatter_add_parallel(&mut b_combined, packed_witness, eq, *g);
             round0_u0 += du0;
             round0_u2 += du2;
         }

--- a/crates/flock-core/src/pcs/basefold.rs
+++ b/crates/flock-core/src/pcs/basefold.rs
@@ -1114,12 +1114,13 @@ fn verify_multi_with_dedup(
     let mut deduped: Vec<(usize, Hash)> = Vec::with_capacity(paired.len());
     for (p, h) in paired {
         if let Some(last) = deduped.last()
-            && last.0 == p {
-                if last.1 != h {
-                    return false;
-                }
-                continue;
+            && last.0 == p
+        {
+            if last.1 != h {
+                return false;
             }
+            continue;
+        }
         deduped.push((p, h));
     }
     let positions_sorted: Vec<usize> = deduped.iter().map(|(p, _)| *p).collect();

--- a/crates/flock-core/src/pcs/jagged.rs
+++ b/crates/flock-core/src/pcs/jagged.rs
@@ -259,7 +259,9 @@ fn generate_f_and_claim(
             let g0 = ci * CHUNK;
             let q_chunk = &q[g0..g0 + b_chunk.len()];
             // Column containing g0 (== num_columns sentinel once g0 ≥ area).
-            let mut col = prefix.partition_point(|&t| t <= g0 as u64).saturating_sub(1);
+            let mut col = prefix
+                .partition_point(|&t| t <= g0 as u64)
+                .saturating_sub(1);
             let mut acc = F128::ZERO;
             for (local, slot) in b_chunk.iter_mut().enumerate() {
                 let i = g0 + local;
@@ -388,7 +390,7 @@ pub fn verify<C: Challenger>(
 #[inline]
 fn fold_round_claim(claim: F128, g_one: F128, g_inf: F128, r: F128) -> F128 {
     let g0 = claim + g_one; // char-2: G(0) = claim - G(1)
-                            // G(X) = g0 + (G(1) + g0 + g_inf)·X + g_inf·X²
+    // G(X) = g0 + (G(1) + g0 + g_inf)·X + g_inf·X²
     g0 + (g_one + g0 + g_inf) * r + g_inf * (r * r)
 }
 
@@ -536,7 +538,6 @@ fn fold_and_round_oop_par(
         .reduce(|| (F128::ZERO, F128::ZERO), |(p, q), (s, t)| (p + s, q + t))
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -569,7 +570,10 @@ mod tests {
     /// `q̂(point)` directly = ⟨q, eq(point, ·)⟩.
     fn mle_eval(q: &[F128], point: &[F128]) -> F128 {
         let eq = build_eq_table(point);
-        q.iter().zip(eq.iter()).map(|(&a, &b)| a * b).fold(F128::ZERO, |s, x| s + x)
+        q.iter()
+            .zip(eq.iter())
+            .map(|(&a, &b)| a * b)
+            .fold(F128::ZERO, |s, x| s + x)
     }
 
     /// A small random jagged config + dense data, with total area < 2^m.
@@ -626,9 +630,7 @@ mod tests {
         let eq_row = build_eq_table(&z_row);
         let eq_col = build_eq_table(&z_col);
         for i in 0..params.area() {
-            let z_idx: Vec<F128> = (0..params.m)
-                .map(|bit| int_bit(i, bit))
-                .collect();
+            let z_idx: Vec<F128> = (0..params.m).map(|bit| int_bit(i, bit)).collect();
             let got = f_hat_t(&params, &z_row, &z_col, &z_idx);
             let (row, col) = params.unrank(i);
             let want = eq_row[row] * eq_col[col];
@@ -895,9 +897,17 @@ mod tests {
         let m = 25usize;
         let len = 1usize << m;
         let half = len / 2;
-        let a: Vec<F128> = (0..len).map(|i| F128 { lo: i as u64, hi: i as u64 }).collect();
+        let a: Vec<F128> = (0..len)
+            .map(|i| F128 {
+                lo: i as u64,
+                hi: i as u64,
+            })
+            .collect();
         let b = a.clone();
-        let r = F128 { lo: 0x9E37, hi: 0x1234 };
+        let r = F128 {
+            lo: 0x9E37,
+            hi: 0x1234,
+        };
         const REPS: usize = 6;
         const CHUNK: usize = 1 << 13; // coarse: 8K outputs / task
 
@@ -913,7 +923,10 @@ mod tests {
         let sp = |s: Duration, p: Duration| s.as_secs_f64() / p.as_secs_f64();
         let gbps = |bytes: usize, t: Duration| bytes as f64 / t.as_secs_f64() / 1e9;
 
-        eprintln!("\n[scaling diag] m={m}, threads={}", rayon::current_num_threads());
+        eprintln!(
+            "\n[scaling diag] m={m}, threads={}",
+            rayon::current_num_threads()
+        );
 
         // --- memcpy baseline: read len, write len (the raw bandwidth ceiling) ---
         let mut dst = crate::alloc_uninit_f128_vec(len);
@@ -926,7 +939,11 @@ mod tests {
         let bytes = len * 32; // read+write 16B each
         eprintln!(
             "  memcpy        : serial {:>7.1?} ({:>4.0} GB/s)  parallel {:>7.1?} ({:>4.0} GB/s)  {:.2}x",
-            ts, gbps(bytes, ts), tp, gbps(bytes, tp), sp(ts, tp)
+            ts,
+            gbps(bytes, ts),
+            tp,
+            gbps(bytes, tp),
+            sp(ts, tp)
         );
 
         // --- fold (read len, write half): fine (par_iter_mut) vs coarse ---
@@ -953,7 +970,12 @@ mod tests {
         let bytes = half * 16 * 3; // read 2, write 1
         eprintln!(
             "  fold   serial {:>7.1?} ({:>4.0} GB/s)  par.fine {:>7.1?} {:.2}x  par.coarse {:>7.1?} {:.2}x",
-            ts, gbps(bytes, ts), tp_fine, sp(ts, tp_fine), tp_coarse, sp(ts, tp_coarse)
+            ts,
+            gbps(bytes, ts),
+            tp_fine,
+            sp(ts, tp_fine),
+            tp_coarse,
+            sp(ts, tp_coarse)
         );
 
         // --- real round message (contiguous a+b read): round_msg vs round_msg_par ---
@@ -982,7 +1004,12 @@ mod tests {
         let rd_bytes = len * 16 * 2; // read all of a and b
         eprintln!(
             "  round_msg serial {:>7.1?} ({:>4.0} GB/s)  par.fine {:>7.1?} {:.2}x  par.coarse {:>7.1?} {:.2}x",
-            ts, gbps(rd_bytes, ts), tp_fine, sp(ts, tp_fine), tp_coarse, sp(ts, tp_coarse)
+            ts,
+            gbps(rd_bytes, ts),
+            tp_fine,
+            sp(ts, tp_fine),
+            tp_coarse,
+            sp(ts, tp_coarse)
         );
         // slice/chunks_exact iteration: no per-element bounds checks.
         let tp_slice = bench(&mut || {
@@ -1003,7 +1030,9 @@ mod tests {
         });
         eprintln!(
             "  round_msg par.slice(chunks_exact)   {:>7.1?} ({:>4.0} GB/s)  {:.2}x",
-            tp_slice, gbps(rd_bytes, tp_slice), sp(ts, tp_slice)
+            tp_slice,
+            gbps(rd_bytes, tp_slice),
+            sp(ts, tp_slice)
         );
 
         // --- per-round breakdown of the actual parallel-fused sumcheck ---
@@ -1022,10 +1051,20 @@ mod tests {
                 let t = Instant::now();
                 if cur > 2 {
                     (_g1, _gi) = fold_and_round_oop_par(
-                        &av[..cur], &bv[..cur], r, &mut sa[..half_r], &mut sb[..half_r],
+                        &av[..cur],
+                        &bv[..cur],
+                        r,
+                        &mut sa[..half_r],
+                        &mut sb[..half_r],
                     );
                 } else {
-                    fold_oop_par(&av[..cur], &bv[..cur], r, &mut sa[..half_r], &mut sb[..half_r]);
+                    fold_oop_par(
+                        &av[..cur],
+                        &bv[..cur],
+                        r,
+                        &mut sa[..half_r],
+                        &mut sb[..half_r],
+                    );
                 }
                 std::mem::swap(&mut av, &mut sa);
                 std::mem::swap(&mut bv, &mut sb);
@@ -1037,7 +1076,11 @@ mod tests {
         let tail: Duration = round_t[6..].iter().sum(); // rounds with cur ≤ 2^20
         eprintln!(
             "  sumcheck per-round: total {:.1?} | r0 {:.1?} r1 {:.1?} r2 {:.1?} | tail(r6+, cur≤2^19) {:.2?} ({:.0}%)",
-            total, round_t[1], round_t[2], round_t[3], tail,
+            total,
+            round_t[1],
+            round_t[2],
+            round_t[3],
+            tail,
             100.0 * tail.as_secs_f64() / total.as_secs_f64()
         );
         std::hint::black_box(&out);

--- a/crates/flock-core/src/pcs/ligerito.rs
+++ b/crates/flock-core/src/pcs/ligerito.rs
@@ -845,7 +845,8 @@ impl LigeritoLevelConfig {
                 // has size 1, so (per Diamond and Gruen) the MCA-commutes step
                 // holds with error ε directly — the Johnson regime's 2^{ℓ-1}
                 // row union is unnecessary. So eps_pg = 128 − log₂ a.
-                let log_a = paper_thm_1_4_log_a(self.log_inv_rate, self.log_msg_cols, proximity_loss);
+                let log_a =
+                    paper_thm_1_4_log_a(self.log_inv_rate, self.log_msg_cols, proximity_loss);
                 let eps_pg = ANALYSIS_LOG_Q - log_a;
                 let per_q =
                     udr_per_query_bits(self.log_inv_rate, self.log_msg_cols, proximity_loss);
@@ -1060,13 +1061,14 @@ impl LigeritoSecurityConfig {
             // OOD binding must reach target on its own (no grind covers it;
             // escalate ood_samples instead).
             if let Some(ood) = lv.expected_eps_ood_bits
-                && ood + 1e-3 < lv.target_security_bits as f64 {
-                    return Err(format!(
-                        "L{i}: expected_eps_ood_bits ({ood:.2}) < target ({}); \
+                && ood + 1e-3 < lv.target_security_bits as f64
+            {
+                return Err(format!(
+                    "L{i}: expected_eps_ood_bits ({ood:.2}) < target ({}); \
                          increase ood_samples",
-                        lv.target_security_bits
-                    ));
-                }
+                    lv.target_security_bits
+                ));
+            }
 
             if lv.target_security_bits < self.target_security_bits {
                 return Err(format!(
@@ -1279,7 +1281,8 @@ impl LigeritoSecurityConfig {
                     // No row-union penalty in the unique-decoding regime (list
                     // size 1): per Diamond and Gruen, MCA-commutes holds with
                     // error ε directly (vs the Johnson regime's 2^{ℓ-1} factor).
-                    let eps_pg = ANALYSIS_LOG_Q - paper_thm_1_4_log_a(rate, cols, UDR_PROXIMITY_LOSS);
+                    let eps_pg =
+                        ANALYSIS_LOG_Q - paper_thm_1_4_log_a(rate, cols, UDR_PROXIMITY_LOSS);
                     (
                         SoundnessRegime::Udr,
                         None,

--- a/crates/flock-core/src/pcs/ring_switch.rs
+++ b/crates/flock-core/src/pcs/ring_switch.rs
@@ -1240,8 +1240,6 @@ pub fn fold_1b_rows_naive(packed_witness: &[F128], suffix_tensor: &[F128]) -> Ve
     // Empty accumulator allocator returns Vec<F128>(n) for the fold's init.
     let zero_acc = || vec![F128::ZERO; n];
 
-    
-
     packed_witness
         .par_iter()
         .zip(suffix_tensor.par_iter())

--- a/crates/flock-prover/benches/field.rs
+++ b/crates/flock-prover/benches/field.rs
@@ -13,9 +13,9 @@
 use std::hint::black_box;
 use std::time::Instant;
 
-use flock_prover::field::gf2_128::software;
 #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
 use flock_prover::field::gf2_128::aarch64;
+use flock_prover::field::gf2_128::software;
 use flock_prover::field::{F8, F128, F256Unreduced};
 
 const N: usize = 100_000_000;

--- a/crates/flock-prover/benches/grinding_sha256.rs
+++ b/crates/flock-prover/benches/grinding_sha256.rs
@@ -22,10 +22,9 @@ fn has_leading_zero_bits(h: &[u8; 32], n: u32) -> bool {
             return false;
         }
     }
-    if extra_bits > 0
-        && (h[full_bytes] >> (8 - extra_bits)) != 0 {
-            return false;
-        }
+    if extra_bits > 0 && (h[full_bytes] >> (8 - extra_bits)) != 0 {
+        return false;
+    }
     true
 }
 

--- a/crates/flock-prover/benches/lincheck.rs
+++ b/crates/flock-prover/benches/lincheck.rs
@@ -151,14 +151,30 @@ fn main() {
                 FOLD_IBLOCK.store(false, Ordering::Relaxed); // default (oblock if n_log≥16)
                 let mut ch = FsChallenger::new(b"flock-bench-v0");
                 let t0 = Instant::now();
-                let (p, c) = prove(black_box(z_packed), m, K_LOG, K_SKIP, &circuit, black_box(x_ab), &mut ch);
+                let (p, c) = prove(
+                    black_box(z_packed),
+                    m,
+                    K_LOG,
+                    K_SKIP,
+                    &circuit,
+                    black_box(x_ab),
+                    &mut ch,
+                );
                 def_min = def_min.min(t0.elapsed().as_secs_f64() * 1000.0);
                 cs ^= p.z_partial[0].lo ^ c.w.lo;
 
                 FOLD_IBLOCK.store(true, Ordering::Relaxed); // forced iblock
                 let mut ch = FsChallenger::new(b"flock-bench-v0");
                 let t0 = Instant::now();
-                let (p, c) = prove(black_box(z_packed), m, K_LOG, K_SKIP, &circuit, black_box(x_ab), &mut ch);
+                let (p, c) = prove(
+                    black_box(z_packed),
+                    m,
+                    K_LOG,
+                    K_SKIP,
+                    &circuit,
+                    black_box(x_ab),
+                    &mut ch,
+                );
                 ib_min = ib_min.min(t0.elapsed().as_secs_f64() * 1000.0);
                 cs ^= p.z_partial[0].lo ^ c.w.lo;
             }

--- a/crates/flock-prover/src/proof_io.rs
+++ b/crates/flock-prover/src/proof_io.rs
@@ -34,9 +34,9 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+use crate::r1cs_hashes::chain_common::ChainProof;
 use flock_core::pcs::Commitment;
 use flock_core::proof::R1csProof;
-use crate::r1cs_hashes::chain_common::ChainProof;
 
 /// Magic bytes prepended to every serialized proof. Lets readers reject
 /// random binary data early.
@@ -411,8 +411,8 @@ impl std::error::Error for BundleReadError {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use flock_core::challenger::FsChallenger;
     use crate::r1cs_hashes::blake3::{Blake3Setup, Compression, blake3_compress, cv_to_phys_bits};
+    use flock_core::challenger::FsChallenger;
 
     /// SplitMix64.
     struct Rng(u64);

--- a/crates/flock-prover/src/prover.rs
+++ b/crates/flock-prover/src/prover.rs
@@ -154,12 +154,7 @@ pub fn prove<Ch: Challenger>(
     // identical to the bit packing the zerocheck consumes, so a raw cast
     // suffices — no allocation, no copy.
     let cast = |v: &[F128]| -> &[u8] {
-        unsafe {
-            std::slice::from_raw_parts(
-                v.as_ptr() as *const u8,
-                std::mem::size_of_val(v),
-            )
-        }
+        unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, std::mem::size_of_val(v)) }
     };
     let a_packed: &[u8] = cast(&a_packed_f128);
     let b_packed: &[u8] = cast(&b_packed_f128);
@@ -290,12 +285,7 @@ pub fn prove_ligerito<Ch: Challenger>(
         r1cs.apply_c_packed(&z_packed)
     };
     let cast = |v: &[F128]| -> &[u8] {
-        unsafe {
-            std::slice::from_raw_parts(
-                v.as_ptr() as *const u8,
-                std::mem::size_of_val(v),
-            )
-        }
+        unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, std::mem::size_of_val(v)) }
     };
     let a_packed: &[u8] = cast(&a_packed_f128);
     let b_packed: &[u8] = cast(&b_packed_f128);

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -1279,7 +1279,10 @@ impl Blake3Setup {
 
     /// Build a setup for a named Ligerito profile (fast/slim/secure);
     /// the PCS rate follows the profile.
-    pub fn with_profile(n_blocks: usize, profile: flock_core::pcs::ligerito::LigeritoProfile) -> Self {
+    pub fn with_profile(
+        n_blocks: usize,
+        profile: flock_core::pcs::ligerito::LigeritoProfile,
+    ) -> Self {
         Self::with_profile_and_rate(n_blocks, profile, profile.log_inv_rate())
     }
 
@@ -2089,9 +2092,12 @@ mod tests {
         let zeros: Vec<Compression> = vec![([0u32; 8], [0u32; 16], 0u64, 0u32, 0u32); n];
         let (mut z, mut a, mut b, mut zlc) =
             generate_witness_with_ab_packed_and_lincheck(&zeros, setup.n_blocks_log());
-        z.iter_mut().for_each(|v| *v = flock_core::field::F128::ZERO);
-        a.iter_mut().for_each(|v| *v = flock_core::field::F128::ZERO);
-        b.iter_mut().for_each(|v| *v = flock_core::field::F128::ZERO);
+        z.iter_mut()
+            .for_each(|v| *v = flock_core::field::F128::ZERO);
+        a.iter_mut()
+            .for_each(|v| *v = flock_core::field::F128::ZERO);
+        b.iter_mut()
+            .for_each(|v| *v = flock_core::field::F128::ZERO);
         zlc.iter_mut().for_each(|v| *v = 0);
         let circuit = setup.r1cs.csc_lincheck_circuit();
         let mut ch_p = FsChallenger::new(b"poc");

--- a/crates/flock-prover/src/r1cs_hashes/common.rs
+++ b/crates/flock-prover/src/r1cs_hashes/common.rs
@@ -342,4 +342,3 @@ pub(crate) fn xor_dedup(mut v: Vec<usize>) -> Vec<usize> {
     }
     out
 }
-

--- a/crates/flock-prover/src/r1cs_hashes/keccak.rs
+++ b/crates/flock-prover/src/r1cs_hashes/keccak.rs
@@ -62,13 +62,13 @@
 //! the slow `prove` path will report "everything satisfied vacuously" for
 //! this encoding — only use `prove_fast`/`prove_chain`.
 
+use crate::r1cs_hashes::chain_common::{ChainLayout, ChainProof, ChainVerifyError};
 use flock_core::challenger::Challenger;
 use flock_core::field::F128;
 use flock_core::lincheck::LincheckCircuit;
 use flock_core::pcs::{Commitment, PcsParams};
 use flock_core::proof::{R1csClaim, R1csProof};
 use flock_core::r1cs::BlockR1cs;
-use crate::r1cs_hashes::chain_common::{ChainLayout, ChainProof, ChainVerifyError};
 use flock_core::verifier;
 
 // ===========================================================================
@@ -883,7 +883,10 @@ impl KeccakSetup {
 
     /// Build a setup for a named Ligerito profile (fast/slim/secure);
     /// the PCS rate follows the profile.
-    pub fn with_profile(n_keccaks: usize, profile: flock_core::pcs::ligerito::LigeritoProfile) -> Self {
+    pub fn with_profile(
+        n_keccaks: usize,
+        profile: flock_core::pcs::ligerito::LigeritoProfile,
+    ) -> Self {
         Self::with_profile_and_rate(n_keccaks, profile, profile.log_inv_rate())
     }
 

--- a/crates/flock-prover/src/r1cs_hashes/keccak3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/keccak3.rs
@@ -511,7 +511,10 @@ impl KeccakSetup {
 
     /// Build a setup for a named Ligerito profile (fast/slim/secure);
     /// the PCS rate follows the profile.
-    pub fn with_profile(n_keccaks: usize, profile: flock_core::pcs::ligerito::LigeritoProfile) -> Self {
+    pub fn with_profile(
+        n_keccaks: usize,
+        profile: flock_core::pcs::ligerito::LigeritoProfile,
+    ) -> Self {
         Self::with_profile_and_rate(n_keccaks, profile, profile.log_inv_rate())
     }
 
@@ -830,8 +833,8 @@ mod tests {
     #[test]
     #[ignore = "timing comparison; run manually with --nocapture"]
     fn pack_win() {
-        use flock_core::challenger::FsChallenger;
         use crate::r1cs_hashes::keccak as k1;
+        use flock_core::challenger::FsChallenger;
         use std::time::Instant;
 
         let n = 6144usize;
@@ -938,8 +941,8 @@ mod tests {
     /// (z[Z_CONST] = 1, folded into lincheck) must now reject it.
     #[test]
     fn all_zero_witness_rejected() {
-        use flock_core::challenger::FsChallenger;
         use crate::r1cs_hashes::keccak::keccak_f;
+        use flock_core::challenger::FsChallenger;
 
         let n_keccaks = 49; // m = 22 (m22_fast)
         let setup = KeccakSetup::new(n_keccaks);

--- a/crates/flock-prover/src/r1cs_hashes/merkle_path_common.rs
+++ b/crates/flock-prover/src/r1cs_hashes/merkle_path_common.rs
@@ -19,10 +19,10 @@
 //! coords, so its contents are invisible to the sumcheck but participate in
 //! the multilinear extension over the slot-selector dimensions.
 
+use crate::merkle_path::{MerklePathShiftProof, SlotLayout};
 use flock_core::challenger::Challenger;
 use flock_core::field::F128;
 use flock_core::lincheck::build_eq_table;
-use crate::merkle_path::{MerklePathShiftProof, SlotLayout};
 use flock_core::pcs::{
     Commitment, DirectEqInd, LOG_PACKING, PackedDirectClaim, PackedDirectClaimRef, PcsParams,
 };
@@ -798,9 +798,12 @@ pub fn prove_merkle_paths_ligerito_generic<Ch: Challenger>(
     let trace = std::env::var("MERKLE_TRACE").is_ok();
 
     let log_n = r1cs.m - LOG_PACKING;
-    let lig_config =
-        flock_core::pcs::ligerito::prover_config_for(log_n, pcs_params.log_batch_size, pcs_params.profile)
-            .expect("Ligerito config for merkle-path prove; bump m for tiny instances");
+    let lig_config = flock_core::pcs::ligerito::prover_config_for(
+        log_n,
+        pcs_params.log_batch_size,
+        pcs_params.profile,
+    )
+    .expect("Ligerito config for merkle-path prove; bump m for tiny instances");
 
     // ---- Core: commit → zerocheck → lincheck.
     let t = if trace {

--- a/crates/flock-prover/src/r1cs_hashes/sha2.rs
+++ b/crates/flock-prover/src/r1cs_hashes/sha2.rs
@@ -2380,9 +2380,12 @@ mod tests {
         let zeros: Vec<([u32; 8], [u32; 16])> = vec![([0u32; 8], [0u32; 16]); n];
         let (mut z, mut a, mut b, mut zlc) =
             generate_witness_with_ab_packed_and_lincheck(&zeros, setup.n_blocks_log());
-        z.iter_mut().for_each(|v| *v = flock_core::field::F128::ZERO);
-        a.iter_mut().for_each(|v| *v = flock_core::field::F128::ZERO);
-        b.iter_mut().for_each(|v| *v = flock_core::field::F128::ZERO);
+        z.iter_mut()
+            .for_each(|v| *v = flock_core::field::F128::ZERO);
+        a.iter_mut()
+            .for_each(|v| *v = flock_core::field::F128::ZERO);
+        b.iter_mut()
+            .for_each(|v| *v = flock_core::field::F128::ZERO);
         zlc.iter_mut().for_each(|v| *v = 0);
         let circuit = setup.r1cs.csc_lincheck_circuit();
         let mut ch_p = FsChallenger::new(b"poc");

--- a/crates/flock-prover/tests/verifier_roundtrip.rs
+++ b/crates/flock-prover/tests/verifier_roundtrip.rs
@@ -88,9 +88,15 @@ fn r1cs_prove_verify_roundtrip_ligerito() {
 
     let mut ch_v = FsChallenger::new(b"flock-lig-r1cs-v0");
     let lc_circuit = r1cs.sparse_lincheck_circuit();
-    let claim_v =
-        verifier::verify_ligerito(&r1cs, &commitment, &proof, &lc_circuit, &pcs_params, &mut ch_v)
-            .unwrap_or_else(|e| panic!("ligerito verify rejected honest proof: {e:?}"));
+    let claim_v = verifier::verify_ligerito(
+        &r1cs,
+        &commitment,
+        &proof,
+        &lc_circuit,
+        &pcs_params,
+        &mut ch_v,
+    )
+    .unwrap_or_else(|e| panic!("ligerito verify rejected honest proof: {e:?}"));
     assert_eq!(claim_p, claim_v);
 }
 


### PR DESCRIPTION
Mechanical `cargo fmt --all` over the workspace — no logic changes (verified: full test suite green, clippy clean, 358 tests).

Brings the repo to rustfmt-clean so the formatting CI check (follow-up PR) can be enabled.

**Landing-order note:** this conflicts textually with #11 (batch-major layout) on several files. Recommended order: land #11 first, then I'll regenerate this PR on updated main (trivial); or land this first and #11 gets rebased + re-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2pDdTiogC8PTADa15f56v