### PR TITLE
feat: chain and Merkle-path relations under batch-major layout

### DIFF
--- a/crates/flock-prover/examples/keccak_chain_bench.rs
+++ b/crates/flock-prover/examples/keccak_chain_bench.rs
@@ -114,7 +114,12 @@ fn bench(n_keccaks: usize, n_runs: usize) {
     let mut io = (Vec::new(), Vec::new());
     for _ in 0..n_runs {
         let t = Instant::now();
-        io = fold_in_out(&CHAIN_LAYOUT, &z_packed, &fold);
+        io = fold_in_out(
+            &CHAIN_LAYOUT,
+            flock_prover::r1cs::WitnessLayout::RowMajor,
+            &z_packed,
+            &fold,
+        );
         best_fold = best_fold.min(t.elapsed().as_secs_f64());
     }
     let (in_vals, out_vals) = io;

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -1568,9 +1568,7 @@ impl Blake3Setup {
             self.n_blocks,
             self.n_block_slots(),
         );
-        let n_log = self.n_blocks_log();
-        let (z_packed, a_packed, b_packed, z_lincheck) =
-            generate_witness_with_ab_packed_and_lincheck(blocks, n_log);
+        let (z_packed, a_packed, b_packed, z_lincheck) = self.generate_witness_ab(blocks);
         let lc_circuit = self.r1cs.csc_lincheck_circuit();
         super::chain_common::prove_chain_generic(
             &self.r1cs,
@@ -1593,9 +1591,7 @@ impl Blake3Setup {
     ) -> (super::chain_common::ChainProofLigerito, Commitment) {
         assert_eq!(blocks.len(), self.n_blocks);
         assert_eq!(self.n_blocks, self.n_block_slots());
-        let n_log = self.n_blocks_log();
-        let (z_packed, a_packed, b_packed, z_lincheck) =
-            generate_witness_with_ab_packed_and_lincheck(blocks, n_log);
+        let (z_packed, a_packed, b_packed, z_lincheck) = self.generate_witness_ab(blocks);
         let lc_circuit = self.r1cs.csc_lincheck_circuit();
         super::chain_common::prove_chain_ligerito_generic(
             &self.r1cs,

--- a/crates/flock-prover/src/r1cs_hashes/chain_common.rs
+++ b/crates/flock-prover/src/r1cs_hashes/chain_common.rs
@@ -129,6 +129,7 @@ impl ChainFold {
 /// mul-adds (16 for keccak, 2 for blake3/sha2).
 pub fn fold_in_out(
     layout: &ChainLayout,
+    wl: flock_core::r1cs::WitnessLayout,
     packed: &[F128],
     fold: &ChainFold,
 ) -> (Vec<F128>, Vec<F128>) {
@@ -145,24 +146,35 @@ pub fn fold_in_out(
         "packed witness length must be a whole number of blocks"
     );
     let n_inst = packed.len() / block_packed;
+    let n_log = n_inst.trailing_zeros() as usize;
 
     let eq_tau = build_eq_table(&fold.tau_pos);
 
-    let fold_one = |base: usize| -> F128 {
+    // Word address of within-block word `w` of instance `i`: row-major puts
+    // instances contiguous (`i·block + w`); batch-major puts word-columns
+    // contiguous (`(w << n_log) + i`).
+    let word_addr = move |i: usize, w: usize| -> usize {
+        match wl {
+            flock_core::r1cs::WitnessLayout::RowMajor => i * block_packed + w,
+            flock_core::r1cs::WitnessLayout::BatchMajor => (w << n_log) + i,
+        }
+    };
+
+    let fold_one = |i: usize, base: usize| -> F128 {
         let mut acc = F128::ZERO;
         for pos in 0..n_packed_per_region {
-            acc += eq_tau[pos] * packed[base + pos];
+            acc += eq_tau[pos] * packed[word_addr(i, base + pos)];
         }
         acc
     };
 
     let in_vals: Vec<F128> = (0..n_inst)
         .into_par_iter()
-        .map(|i| fold_one(i * block_packed + in_pos_base))
+        .map(|i| fold_one(i, in_pos_base))
         .collect();
     let out_vals: Vec<F128> = (0..n_inst)
         .into_par_iter()
-        .map(|i| fold_one(i * block_packed + out_pos_base))
+        .map(|i| fold_one(i, out_pos_base))
         .collect();
 
     (in_vals, out_vals)
@@ -182,20 +194,12 @@ pub fn fold_in_out(
 /// `build_eq_sparse` to skip the zero-coord halvings.
 pub fn assemble_chain_claim(
     layout: &ChainLayout,
+    wl: flock_core::r1cs::WitnessLayout,
     fold: &ChainFold,
     claims: &crate::chain::ChainClaims,
 ) -> PackedDirectClaim {
-    let high = layout.high_zeros();
-    let point_len = fold.tau_pos.len() + 1 + high + claims.instance_point.len();
-    let mut point = Vec::with_capacity(point_len);
-    point.extend_from_slice(&fold.tau_pos);
-    point.push(claims.sel0);
-    point.extend(std::iter::repeat_n(F128::ZERO, high));
-    point.extend_from_slice(&claims.instance_point);
-    debug_assert_eq!(point.len(), point_len);
-
+    let point = build_chain_claim_point(layout, wl, fold, claims);
     let sparse_eq = flock_core::pcs::ring_switch::build_eq_sparse(&point);
-
     PackedDirectClaim {
         point,
         value: claims.value,
@@ -206,18 +210,30 @@ pub fn assemble_chain_claim(
 /// Verifier-side helper: build the chain-claim point identically to
 /// [`assemble_chain_claim`] but without constructing the sparse eq tensor (the
 /// verifier evaluates `eq_eval(point, basefold_challenges)` directly).
+/// Word-index claim point over `L = m − LOG_PACKING` coords, ordered by the
+/// witness layout's address decomposition of a word index:
+/// - RowMajor: `word = (inst << (k_log−7)) | in_block`
+///   → `[τ_pos…, sel0, 0^high, instance…]`;
+/// - BatchMajor: `word = (in_block << n_log) | inst`
+///   → `[instance…, τ_pos…, sel0, 0^high]`.
 fn build_chain_claim_point(
     layout: &ChainLayout,
+    wl: flock_core::r1cs::WitnessLayout,
     fold: &ChainFold,
     claims: &crate::chain::ChainClaims,
 ) -> Vec<F128> {
     let high = layout.high_zeros();
     let point_len = fold.tau_pos.len() + 1 + high + claims.instance_point.len();
     let mut point = Vec::with_capacity(point_len);
+    if wl == flock_core::r1cs::WitnessLayout::BatchMajor {
+        point.extend_from_slice(&claims.instance_point);
+    }
     point.extend_from_slice(&fold.tau_pos);
     point.push(claims.sel0);
     point.extend(std::iter::repeat_n(F128::ZERO, high));
-    point.extend_from_slice(&claims.instance_point);
+    if wl == flock_core::r1cs::WitnessLayout::RowMajor {
+        point.extend_from_slice(&claims.instance_point);
+    }
     debug_assert_eq!(point.len(), point_len);
     point
 }
@@ -270,12 +286,6 @@ pub fn prove_chain_generic<Ch: Challenger>(
     lincheck_circuit: &dyn flock_core::lincheck::LincheckCircuit,
     challenger: &mut Ch,
 ) -> (ChainProof, Commitment) {
-    assert_eq!(
-        r1cs.layout,
-        flock_core::r1cs::WitnessLayout::RowMajor,
-        "chain/merkle wrappers require the row-major witness layout (their \
-         shift sumcheck and extra claims are not yet ported to batch-major)"
-    );
     let trace = std::env::var("CHAIN_TRACE").is_ok();
 
     // ---- Core: commit → zerocheck → lincheck → base claims (ab, c).
@@ -311,7 +321,7 @@ pub fn prove_chain_generic<Ch: Challenger>(
     };
     let tau_pos = challenger.sample_f128_vec(layout.tau_pos_len());
     let fold = ChainFold::new(layout, tau_pos);
-    let (in_vals, out_vals) = fold_in_out(layout, &core.z_packed, &fold);
+    let (in_vals, out_vals) = fold_in_out(layout, r1cs.layout, &core.z_packed, &fold);
     if let Some(t) = t {
         eprintln!(
             "[chain] {:<18} {:>8.2} ms",
@@ -327,7 +337,7 @@ pub fn prove_chain_generic<Ch: Challenger>(
         None
     };
     let (shift, claims) = crate::chain::prove_chain_shift(&in_vals, &out_vals, challenger);
-    let chain_claim = assemble_chain_claim(layout, &fold, &claims);
+    let chain_claim = assemble_chain_claim(layout, r1cs.layout, &fold, &claims);
     if let Some(t) = t {
         eprintln!(
             "[chain] {:<18} {:>8.2} ms",
@@ -342,10 +352,7 @@ pub fn prove_chain_generic<Ch: Challenger>(
     } else {
         None
     };
-    let padding = flock_core::zerocheck::PaddingSpec {
-        k_log: r1cs.k_log,
-        useful_bits_per_block: r1cs.useful_bits,
-    };
+    let padding = r1cs.padding_spec();
     let ab_x_outer = crate::prover::quirky_x_outer_full(&core.ab.point);
     let c_x_outer = crate::prover::quirky_x_outer_full(&core.c.point);
     let pre_ab: Option<&[flock_core::field::F128]> = core.s_hat_v_ab.as_deref();
@@ -394,12 +401,6 @@ pub fn prove_chain_ligerito_generic<Ch: Challenger>(
     lincheck_circuit: &dyn flock_core::lincheck::LincheckCircuit,
     challenger: &mut Ch,
 ) -> (ChainProofLigerito, Commitment) {
-    assert_eq!(
-        r1cs.layout,
-        flock_core::r1cs::WitnessLayout::RowMajor,
-        "chain/merkle wrappers require the row-major witness layout (their \
-         shift sumcheck and extra claims are not yet ported to batch-major)"
-    );
     let log_n = r1cs.m - flock_core::pcs::LOG_PACKING;
     let lig_config = flock_core::pcs::ligerito::prover_config_for(
         log_n,
@@ -421,15 +422,12 @@ pub fn prove_chain_ligerito_generic<Ch: Challenger>(
 
     let tau_pos = challenger.sample_f128_vec(layout.tau_pos_len());
     let fold = ChainFold::new(layout, tau_pos);
-    let (in_vals, out_vals) = fold_in_out(layout, &core.z_packed, &fold);
+    let (in_vals, out_vals) = fold_in_out(layout, r1cs.layout, &core.z_packed, &fold);
 
     let (shift, claims) = crate::chain::prove_chain_shift(&in_vals, &out_vals, challenger);
-    let chain_claim = assemble_chain_claim(layout, &fold, &claims);
+    let chain_claim = assemble_chain_claim(layout, r1cs.layout, &fold, &claims);
 
-    let padding = flock_core::zerocheck::PaddingSpec {
-        k_log: r1cs.k_log,
-        useful_bits_per_block: r1cs.useful_bits,
-    };
+    let padding = r1cs.padding_spec();
     let ab_x_outer = crate::prover::quirky_x_outer_full(&core.ab.point);
     let c_x_outer = crate::prover::quirky_x_outer_full(&core.c.point);
     // Destructure core to move z_packed by value into the open (saves a 128 MB
@@ -501,7 +499,7 @@ pub fn verify_chain_ligerito_generic<Ch: Challenger>(
     let claims = crate::chain::verify_chain_shift(&proof.shift, x0_r, xlast_r, n_log, challenger)
         .map_err(ChainVerifyError::Shift)?;
 
-    let chain_point = build_chain_claim_point(layout, &fold, &claims);
+    let chain_point = build_chain_claim_point(layout, r1cs.layout, &fold, &claims);
     let ab_x_outer = crate::prover::quirky_x_outer_full(&ab.point);
     let c_x_outer = crate::prover::quirky_x_outer_full(&c.point);
     let pd_ref = PackedDirectClaimRef {
@@ -596,7 +594,7 @@ pub fn verify_chain_generic<Ch: Challenger>(
     //      mixed batched open. ab/c go through ring-switch; chain goes
     //      packed-direct.
     let t = std::time::Instant::now();
-    let chain_point = build_chain_claim_point(layout, &fold, &claims);
+    let chain_point = build_chain_claim_point(layout, r1cs.layout, &fold, &claims);
     let ab_x_outer = crate::prover::quirky_x_outer_full(&ab.point);
     let c_x_outer = crate::prover::quirky_x_outer_full(&c.point);
     let pd_ref = PackedDirectClaimRef {

--- a/crates/flock-prover/src/r1cs_hashes/keccak.rs
+++ b/crates/flock-prover/src/r1cs_hashes/keccak.rs
@@ -1047,9 +1047,7 @@ impl KeccakSetup {
             self.n_keccaks,
             self.n_keccak_slots(),
         );
-        let n_log = self.n_keccaks_log();
-        let (z_packed, a_packed, b_packed, z_lincheck) =
-            generate_witness_with_ab_packed_and_lincheck(initial_states, n_log);
+        let (z_packed, a_packed, b_packed, z_lincheck) = self.generate_witness(initial_states);
         crate::r1cs_hashes::chain_common::prove_chain_generic(
             &self.r1cs,
             &self.pcs_params,
@@ -1077,9 +1075,7 @@ impl KeccakSetup {
     ) {
         assert_eq!(initial_states.len(), self.n_keccaks);
         assert_eq!(self.n_keccaks, self.n_keccak_slots());
-        let n_log = self.n_keccaks_log();
-        let (z_packed, a_packed, b_packed, z_lincheck) =
-            generate_witness_with_ab_packed_and_lincheck(initial_states, n_log);
+        let (z_packed, a_packed, b_packed, z_lincheck) = self.generate_witness(initial_states);
         crate::r1cs_hashes::chain_common::prove_chain_ligerito_generic(
             &self.r1cs,
             &self.pcs_params,
@@ -1937,6 +1933,102 @@ mod tests {
             matches!(res, Err(flock_core::verifier::VerifyError::Lincheck(_))),
             "all-zero witness must be rejected by the constant-wire pin; got {res:?}"
         );
+    }
+
+    /// Batch-major chain: the packed-pos fold must produce IDENTICAL In/Out
+    /// vectors from the batch-major and row-major witnesses (same semantic
+    /// content, different addressing), pinning `fold_in_out`'s batch-major
+    /// word addressing.
+    #[test]
+    fn batch_major_chain_fold_matches_row_major() {
+        use crate::r1cs_hashes::chain_common::{ChainFold, fold_in_out};
+        let n_log = 3;
+        let mut rng = Rng::new(0xF01D_BA7C);
+        let inputs: Vec<State> = (0..8).map(|_| random_state(&mut rng)).collect();
+        let (z_r, _, _, _) = generate_witness_with_ab_packed_and_lincheck(&inputs, n_log);
+        let (z_b, _, _, _) = generate_witness_batch_major(&inputs, n_log);
+
+        let tau_pos: Vec<F128> = (0..CHAIN_LAYOUT.tau_pos_len())
+            .map(|i| F128 {
+                lo: rng.next_u64() ^ i as u64,
+                hi: rng.next_u64(),
+            })
+            .collect();
+        let fold = ChainFold::new(&CHAIN_LAYOUT, tau_pos);
+        let (in_r, out_r) = fold_in_out(
+            &CHAIN_LAYOUT,
+            flock_core::r1cs::WitnessLayout::RowMajor,
+            &z_r,
+            &fold,
+        );
+        let (in_b, out_b) = fold_in_out(
+            &CHAIN_LAYOUT,
+            flock_core::r1cs::WitnessLayout::BatchMajor,
+            &z_b,
+            &fold,
+        );
+        assert_eq!(in_b, in_r, "In fold diverged across layouts");
+        assert_eq!(out_b, out_r, "Out fold diverged across layouts");
+    }
+
+    /// Batch-major chain prove -> verify roundtrip (BaseFold, K=8) + rejection
+    /// of a wrong public output endpoint.
+    #[test]
+    fn batch_major_prove_chain_basefold_roundtrip() {
+        use flock_core::challenger::FsChallenger;
+        let setup = KeccakSetup::new_batch_major(8);
+        let mut rng = Rng::new(0xBA7C_CA11);
+        let x0 = random_state(&mut rng);
+        let mut inputs = Vec::with_capacity(8);
+        let mut cur = x0;
+        for _ in 0..8 {
+            inputs.push(cur);
+            keccak_f(&mut cur);
+        }
+        let x_last = cur;
+
+        let mut chp = FsChallenger::new(b"flock-test-v0");
+        let (proof, comm) = setup.prove_chain_basefold(&inputs, &mut chp);
+        let mut chv = FsChallenger::new(b"flock-test-v0");
+        setup
+            .verify_chain_basefold(&comm, &proof, &x0, &x_last, &mut chv)
+            .expect("batch-major chain must verify");
+
+        // Wrong endpoint must be rejected.
+        let mut bad_last = x_last;
+        bad_last[0] = !bad_last[0];
+        let mut chv = FsChallenger::new(b"flock-test-v0");
+        assert!(
+            setup
+                .verify_chain_basefold(&comm, &proof, &x0, &bad_last, &mut chv)
+                .is_err(),
+            "wrong endpoint accepted under batch-major"
+        );
+    }
+
+    /// Batch-major chain roundtrip on the Ligerito backend (K=64, m=22) —
+    /// covers the mixed open (2 ring-switched + 1 packed-direct claim) with
+    /// the batch-major point ordering. Ignored like the row-major variant.
+    #[test]
+    #[ignore]
+    fn batch_major_prove_chain_ligerito_roundtrip() {
+        use flock_core::challenger::RandomChallenger;
+        let setup = KeccakSetup::new_batch_major(64);
+        let mut rng = Rng::new(0xBA7C_11C7);
+        let x0 = random_state(&mut rng);
+        let mut inputs = Vec::with_capacity(64);
+        let mut cur = x0;
+        for _ in 0..64 {
+            inputs.push(cur);
+            keccak_f(&mut cur);
+        }
+        let x_last = cur;
+        let mut chp = RandomChallenger::new(0xCA2);
+        let (proof, comm) = setup.prove_chain(&inputs, &mut chp);
+        let mut chv = RandomChallenger::new(0xCA2);
+        setup
+            .verify_chain(&comm, &proof, &x0, &x_last, &mut chv)
+            .expect("batch-major ligerito chain must verify");
     }
 
     /// Chain prove → verify roundtrip (Ligerito default). K=64 → m=22.

--- a/crates/flock-prover/src/r1cs_hashes/merkle_path_common.rs
+++ b/crates/flock-prover/src/r1cs_hashes/merkle_path_common.rs
@@ -163,6 +163,7 @@ impl MerklePathFold {
 /// `s = sel_slot | (side << 1)`, matching the cube convention.
 pub fn fold_all_slots(
     layout: &MerkleLayout,
+    wl: flock_core::r1cs::WitnessLayout,
     packed: &[F128],
     fold: &MerklePathFold,
 ) -> [Vec<F128>; 4] {
@@ -178,13 +179,23 @@ pub fn fold_all_slots(
         "packed witness length must be a whole number of blocks"
     );
     let n_inst = packed.len() / block_packed;
+    let n_log = n_inst.trailing_zeros() as usize;
 
     let eq_tau = build_eq_table(&fold.tau_pos);
 
-    let fold_one = |base: usize| -> F128 {
+    // Word address of within-block word `w` of instance `i` (see
+    // `chain_common::fold_in_out`).
+    let word_addr = move |i: usize, w: usize| -> usize {
+        match wl {
+            flock_core::r1cs::WitnessLayout::RowMajor => i * block_packed + w,
+            flock_core::r1cs::WitnessLayout::BatchMajor => (w << n_log) + i,
+        }
+    };
+
+    let fold_one = |i: usize, base: usize| -> F128 {
         let mut acc = F128::ZERO;
         for pos in 0..n_packed_per_slot {
-            acc += eq_tau[pos] * packed[base + pos];
+            acc += eq_tau[pos] * packed[word_addr(i, base + pos)];
         }
         acc
     };
@@ -195,7 +206,7 @@ pub fn fold_all_slots(
         let slot_offset = slot_base_packed + slot_idx * n_packed_per_slot;
         *vec_out = (0..n_inst)
             .into_par_iter()
-            .map(|i| fold_one(i * block_packed + slot_offset))
+            .map(|i| fold_one(i, slot_offset))
             .collect();
     }
     results
@@ -218,19 +229,11 @@ pub fn fold_all_slots(
 /// `eq_ind(point)` sparse with a `2^high_zeros ×` density reduction.
 pub fn assemble_merkle_path_claim(
     layout: &MerkleLayout,
+    wl: flock_core::r1cs::WitnessLayout,
     fold: &MerklePathFold,
     claims: &crate::merkle_path::MerklePathClaims,
 ) -> PackedDirectClaim {
-    let high = layout.high_zeros();
-    let point_len = fold.tau_pos.len() + 2 + high + claims.instance_point.len();
-    let mut point = Vec::with_capacity(point_len);
-    point.extend_from_slice(&fold.tau_pos);
-    point.push(claims.sel_slot);
-    point.push(claims.side);
-    point.extend(std::iter::repeat_n(F128::ZERO, high));
-    point.extend_from_slice(&claims.instance_point);
-    debug_assert_eq!(point.len(), point_len);
-
+    let point = build_merkle_claim_point(layout, wl, fold, claims);
     let sparse_eq = flock_core::pcs::ring_switch::build_eq_sparse(&point);
     PackedDirectClaim {
         point,
@@ -241,19 +244,29 @@ pub fn assemble_merkle_path_claim(
 
 /// Verifier-side helper: build the claim point identically to
 /// [`assemble_merkle_path_claim`] without constructing the sparse eq tensor.
+/// Word-index claim point ordered by the witness layout's address
+/// decomposition (see `chain_common::build_chain_claim_point`):
+/// RowMajor `[τ_pos…, sel_slot, side, 0^high, instance…]`;
+/// BatchMajor `[instance…, τ_pos…, sel_slot, side, 0^high]`.
 fn build_merkle_claim_point(
     layout: &MerkleLayout,
+    wl: flock_core::r1cs::WitnessLayout,
     fold: &MerklePathFold,
     claims: &crate::merkle_path::MerklePathClaims,
 ) -> Vec<F128> {
     let high = layout.high_zeros();
     let point_len = fold.tau_pos.len() + 2 + high + claims.instance_point.len();
     let mut point = Vec::with_capacity(point_len);
+    if wl == flock_core::r1cs::WitnessLayout::BatchMajor {
+        point.extend_from_slice(&claims.instance_point);
+    }
     point.extend_from_slice(&fold.tau_pos);
     point.push(claims.sel_slot);
     point.push(claims.side);
     point.extend(std::iter::repeat_n(F128::ZERO, high));
-    point.extend_from_slice(&claims.instance_point);
+    if wl == flock_core::r1cs::WitnessLayout::RowMajor {
+        point.extend_from_slice(&claims.instance_point);
+    }
     debug_assert_eq!(point.len(), point_len);
     point
 }
@@ -311,12 +324,6 @@ pub fn prove_merkle_path_generic<Ch: Challenger>(
     lincheck_circuit: &dyn flock_core::lincheck::LincheckCircuit,
     challenger: &mut Ch,
 ) -> (MerklePathProof, Commitment) {
-    assert_eq!(
-        r1cs.layout,
-        flock_core::r1cs::WitnessLayout::RowMajor,
-        "chain/merkle wrappers require the row-major witness layout (their \
-         shift sumcheck and extra claims are not yet ported to batch-major)"
-    );
     let trace = std::env::var("MERKLE_TRACE").is_ok();
 
     // ---- Core: commit → zerocheck → lincheck.
@@ -351,7 +358,7 @@ pub fn prove_merkle_path_generic<Ch: Challenger>(
     };
     let tau_pos = challenger.sample_f128_vec(layout.tau_pos_len());
     let fold = MerklePathFold::new(layout, tau_pos);
-    let slot_vals = fold_all_slots(layout, &core.z_packed, &fold);
+    let slot_vals = fold_all_slots(layout, r1cs.layout, &core.z_packed, &fold);
     if let Some(t) = t {
         eprintln!(
             "[merkle] {:<18} {:>8.2} ms",
@@ -380,7 +387,7 @@ pub fn prove_merkle_path_generic<Ch: Challenger>(
         layout.slot_layout(),
         challenger,
     );
-    let merkle_claim = assemble_merkle_path_claim(layout, &fold, &claims);
+    let merkle_claim = assemble_merkle_path_claim(layout, r1cs.layout, &fold, &claims);
     if let Some(t) = t {
         eprintln!(
             "[merkle] {:<18} {:>8.2} ms",
@@ -395,10 +402,7 @@ pub fn prove_merkle_path_generic<Ch: Challenger>(
     } else {
         None
     };
-    let padding = flock_core::zerocheck::PaddingSpec {
-        k_log: r1cs.k_log,
-        useful_bits_per_block: r1cs.useful_bits,
-    };
+    let padding = r1cs.padding_spec();
     let ab_x_outer = crate::prover::quirky_x_outer_full(&core.ab.point);
     let c_x_outer = crate::prover::quirky_x_outer_full(&core.c.point);
     let pre_ab: Option<&[flock_core::field::F128]> = core.s_hat_v_ab.as_deref();
@@ -505,7 +509,7 @@ pub fn verify_merkle_path_generic<Ch: Challenger>(
 
     // ---- Verify the mixed batched open (2 ring-switched + 1 packed-direct).
     let t = std::time::Instant::now();
-    let merkle_point = build_merkle_claim_point(layout, &fold, &claims);
+    let merkle_point = build_merkle_claim_point(layout, r1cs.layout, &fold, &claims);
     let ab_x_outer = crate::prover::quirky_x_outer_full(&ab.point);
     let c_x_outer = crate::prover::quirky_x_outer_full(&c.point);
     let pd_ref = PackedDirectClaimRef {
@@ -559,12 +563,6 @@ pub fn prove_merkle_paths_generic<Ch: Challenger>(
     lincheck_circuit: &dyn flock_core::lincheck::LincheckCircuit,
     challenger: &mut Ch,
 ) -> (MerklePathProof, Commitment) {
-    assert_eq!(
-        r1cs.layout,
-        flock_core::r1cs::WitnessLayout::RowMajor,
-        "chain/merkle wrappers require the row-major witness layout (their \
-         shift sumcheck and extra claims are not yet ported to batch-major)"
-    );
     let trace = std::env::var("MERKLE_TRACE").is_ok();
 
     let t = if trace {
@@ -597,7 +595,7 @@ pub fn prove_merkle_paths_generic<Ch: Challenger>(
     };
     let tau_pos = challenger.sample_f128_vec(layout.tau_pos_len());
     let fold = MerklePathFold::new(layout, tau_pos);
-    let slot_vals = fold_all_slots(layout, &core.z_packed, &fold);
+    let slot_vals = fold_all_slots(layout, r1cs.layout, &core.z_packed, &fold);
     if let Some(t) = t {
         eprintln!(
             "[merkle] {:<18} {:>8.2} ms",
@@ -625,7 +623,7 @@ pub fn prove_merkle_paths_generic<Ch: Challenger>(
         layout.slot_layout(),
         challenger,
     );
-    let merkle_claim = assemble_merkle_path_claim(layout, &fold, &claims);
+    let merkle_claim = assemble_merkle_path_claim(layout, r1cs.layout, &fold, &claims);
     if let Some(t) = t {
         eprintln!(
             "[merkle] {:<18} {:>8.2} ms",
@@ -639,10 +637,7 @@ pub fn prove_merkle_paths_generic<Ch: Challenger>(
     } else {
         None
     };
-    let padding = flock_core::zerocheck::PaddingSpec {
-        k_log: r1cs.k_log,
-        useful_bits_per_block: r1cs.useful_bits,
-    };
+    let padding = r1cs.padding_spec();
     let ab_x_outer = crate::prover::quirky_x_outer_full(&core.ab.point);
     let c_x_outer = crate::prover::quirky_x_outer_full(&core.c.point);
     let pre_ab: Option<&[flock_core::field::F128]> = core.s_hat_v_ab.as_deref();
@@ -757,7 +752,7 @@ pub fn verify_merkle_paths_generic<Ch: Challenger>(
     }
 
     let t = std::time::Instant::now();
-    let merkle_point = build_merkle_claim_point(layout, &fold, &claims);
+    let merkle_point = build_merkle_claim_point(layout, r1cs.layout, &fold, &claims);
     let ab_x_outer = crate::prover::quirky_x_outer_full(&ab.point);
     let c_x_outer = crate::prover::quirky_x_outer_full(&c.point);
     let pd_ref = PackedDirectClaimRef {
@@ -807,12 +802,6 @@ pub fn prove_merkle_paths_ligerito_generic<Ch: Challenger>(
     lincheck_circuit: &dyn flock_core::lincheck::LincheckCircuit,
     challenger: &mut Ch,
 ) -> (MerklePathProofLigerito, Commitment) {
-    assert_eq!(
-        r1cs.layout,
-        flock_core::r1cs::WitnessLayout::RowMajor,
-        "chain/merkle wrappers require the row-major witness layout (their \
-         shift sumcheck and extra claims are not yet ported to batch-major)"
-    );
     let trace = std::env::var("MERKLE_TRACE").is_ok();
 
     let log_n = r1cs.m - LOG_PACKING;
@@ -855,7 +844,7 @@ pub fn prove_merkle_paths_ligerito_generic<Ch: Challenger>(
     };
     let tau_pos = challenger.sample_f128_vec(layout.tau_pos_len());
     let fold = MerklePathFold::new(layout, tau_pos);
-    let slot_vals = fold_all_slots(layout, &core.z_packed, &fold);
+    let slot_vals = fold_all_slots(layout, r1cs.layout, &core.z_packed, &fold);
     if let Some(t) = t {
         eprintln!(
             "[merkle] {:<18} {:>8.2} ms",
@@ -884,7 +873,7 @@ pub fn prove_merkle_paths_ligerito_generic<Ch: Challenger>(
         layout.slot_layout(),
         challenger,
     );
-    let merkle_claim = assemble_merkle_path_claim(layout, &fold, &claims);
+    let merkle_claim = assemble_merkle_path_claim(layout, r1cs.layout, &fold, &claims);
     if let Some(t) = t {
         eprintln!(
             "[merkle] {:<18} {:>8.2} ms",
@@ -899,10 +888,7 @@ pub fn prove_merkle_paths_ligerito_generic<Ch: Challenger>(
     } else {
         None
     };
-    let padding = flock_core::zerocheck::PaddingSpec {
-        k_log: r1cs.k_log,
-        useful_bits_per_block: r1cs.useful_bits,
-    };
+    let padding = r1cs.padding_spec();
     let ab_x_outer = crate::prover::quirky_x_outer_full(&core.ab.point);
     let c_x_outer = crate::prover::quirky_x_outer_full(&core.c.point);
     // Destructure core to move z_packed by value into the open (saves a large
@@ -1005,7 +991,7 @@ pub fn verify_merkle_paths_ligerito_generic<Ch: Challenger>(
     )
     .map_err(MerklePathVerifyError::Shift)?;
 
-    let merkle_point = build_merkle_claim_point(layout, &fold, &claims);
+    let merkle_point = build_merkle_claim_point(layout, r1cs.layout, &fold, &claims);
     let ab_x_outer = crate::prover::quirky_x_outer_full(&ab.point);
     let c_x_outer = crate::prover::quirky_x_outer_full(&c.point);
     let pd_ref = PackedDirectClaimRef {

--- a/crates/flock-prover/src/r1cs_hashes/sha2.rs
+++ b/crates/flock-prover/src/r1cs_hashes/sha2.rs
@@ -1633,9 +1633,7 @@ impl Sha256HybridSetup {
             self.n_compressions,
             self.n_block_slots(),
         );
-        let n_log = self.n_blocks_log();
-        let (z_packed, a_packed, b_packed, z_lincheck) =
-            generate_witness_with_ab_packed_and_lincheck(compressions, n_log);
+        let (z_packed, a_packed, b_packed, z_lincheck) = self.generate_witness_ab(compressions);
         super::chain_common::prove_chain_generic(
             &self.r1cs,
             &self.pcs_params,
@@ -1660,9 +1658,7 @@ impl Sha256HybridSetup {
     ) {
         assert_eq!(compressions.len(), self.n_compressions);
         assert_eq!(self.n_compressions, self.n_block_slots());
-        let n_log = self.n_blocks_log();
-        let (z_packed, a_packed, b_packed, z_lincheck) =
-            generate_witness_with_ab_packed_and_lincheck(compressions, n_log);
+        let (z_packed, a_packed, b_packed, z_lincheck) = self.generate_witness_ab(compressions);
         super::chain_common::prove_chain_ligerito_generic(
             &self.r1cs,
             &self.pcs_params,
@@ -2846,6 +2842,31 @@ mod tests {
         setup
             .verify_merkle_path(&commitment, &proof, &leaf, &root, &b, &mut chv)
             .expect("honest merkle path must verify");
+    }
+
+    /// Batch-major Merkle path prove -> verify roundtrip (BaseFold, n=8) +
+    /// wrong-leaf rejection.
+    #[test]
+    fn batch_major_prove_merkle_path_roundtrip() {
+        use flock_core::challenger::FsChallenger;
+        let setup = Sha256HybridSetup::new_batch_major(8);
+        let (blocks, leaf, root, b) = honest_merkle_path(setup.n_compressions, 0xBA7C_BEEF);
+        let mut ch = FsChallenger::new(b"sha2-merkle-test");
+        let (proof, commitment) = setup.prove_merkle_path(&blocks, &b, &mut ch);
+        let mut chv = FsChallenger::new(b"sha2-merkle-test");
+        setup
+            .verify_merkle_path(&commitment, &proof, &leaf, &root, &b, &mut chv)
+            .expect("batch-major merkle path must verify");
+
+        let mut bad_leaf = leaf;
+        bad_leaf[0] ^= 1;
+        let mut chv = FsChallenger::new(b"sha2-merkle-test");
+        assert!(
+            setup
+                .verify_merkle_path(&commitment, &proof, &bad_leaf, &root, &b, &mut chv)
+                .is_err(),
+            "wrong leaf accepted under batch-major"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #11. Extends the batch-major witness layout to the **chain** and **Merkle-path** relation wrappers, removing their row-major guards — both paths now work under either layout.

## What changes

The relation sumchecks turned out to be nearly layout-free already: `prove_chain_shift` / the Merkle shift consume *folded per-instance vectors*, and the extra PCS claim is **packed-direct** over word-index coordinates. So the migration is exactly two seams per relation:

1. **Region folds** (`fold_in_out`, `fold_all_slots`): word address of within-block word `w` of instance `i` is `i·block + w` row-major vs `(w << n_log) + i` batch-major. One address function, dispatched on `r1cs.layout`.
2. **Packed-direct claim points**: reordered per the layout's word-index decomposition — row-major `[τ_pos…, sel(s), 0^high, instance…]`, batch-major `[instance…, τ_pos…, sel(s), 0^high]`. The eq-sparsity from the zero coordinates is position-independent, so the sparse-eq machinery is untouched.

Everything else composes for free: the ab/c ring-switched claims arrive address-ordered from the layout-aware core (#11), `padding_spec()` handles the suffix form, and the per-hash chain/Merkle provers dispatch witness generation on the layout.

## Validation (same discipline as #11)

- **Fold equality gate**: `fold_in_out` over the batch-major witness produces *identical* In/Out vectors to the row-major witness — pins the addressing exactly.
- **Chain**: batch-major prove→verify roundtrip (keccak, BaseFold K=8) + wrong-endpoint rejection; Ligerito K=64 roundtrip (ignored-by-default, run manually — covers the mixed 2×ring-switch + 1×packed-direct open with the reordered point).
- **Merkle path**: batch-major roundtrip + wrong-leaf rejection (sha2, BaseFold n=8).
- Full workspace suite green (275 + 89 tests), fmt-clean, clippy-clean — the new Lint gate passes.

With this, all three standalone encoders **and** the chain/Merkle relations run on both layouts; keccak3 remains row-major-only (its own encoder, separate follow-up if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2pDdTiogC8PTADa15f56v