### PR TITLE
benchmarks: add hash throughput matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Rust implementation of the **Flock** proving system: a prover and verifier for
 R1CS-over-GF(2) statements, built on a zerocheck + lincheck PIOP with a
 multilinear PCS (Ligerito) over the binary field F₂₁₂₈. Tuned for
-Apple silicon (M-series).
+Apple silicon (M-series) and AVX-512-capable x86-64 CPUs.
 
 It ships end-to-end provers for hash-chain and Merkle-path statements over
 BLAKE3, SHA-256, and Keccak-f[1600].
@@ -30,9 +30,9 @@ cargo build --release
 cargo test --release
 ```
 
-Requires a recent stable Rust toolchain (edition 2024). All optimizations target
-`aarch64-apple-darwin`; the code compiles on other targets but the NEON paths are
-gated to ARM64.
+Requires a recent stable Rust toolchain (edition 2024). Optimized kernels target
+ARM64 NEON and x86-64 AVX-512/VPCLMULQDQ, with portable fallbacks for other
+targets.
 
 ## CLI — hash-chain prover
 
@@ -52,8 +52,45 @@ cargo run --release -p flock-prover --bin flock_chain -- verify --in /tmp/chain.
 
 ## Benchmarks
 
-There are no Criterion harnesses; each bench is a no-harness binary that prints
-its own table. Run one with:
+Hash proving throughput on an **AMD Ryzen Threadripper 7970X** (32 physical
+cores / 64 hardware threads, 256 GB RAM), measured on Linux x86-64 on
+2026-07-17. The build uses `-C target-cpu=native`; the active optimized path is
+**AVX-512 + VPCLMULQDQ** (the CPU also supports AVX and AVX2). Multi-threaded
+runs use the 32 physical cores, without SMT.
+
+| Hash | Batch | 1T row-major | 1T batch-major | 32T row-major | 32T batch-major |
+|---|---:|---:|---:|---:|---:|
+| SHA-256 | 1024 | 30283.6 | 32211.1 | 84197.8 | 80355.8 |
+| SHA-256 | 4096 | 34595.0 | 33473.0 | 174886.0 | 144259.7 |
+| SHA-256 | 16384 | 31518.9 | 32845.5 | 248985.2 | 248710.1 |
+| BLAKE3 | 1024 | 35346.7 | 35921.0 | 112434.0 | 99394.9 |
+| BLAKE3 | 4096 | 56776.5 | 58900.6 | 234164.2 | 217310.7 |
+| BLAKE3 | 16384 | 60884.7 | 63222.0 | 409967.1 | 402883.6 |
+| Keccak-f[1600] | 1024 | 19005.0 | 18947.8 | 57544.3 | 54681.3 |
+| Keccak-f[1600] | 4096 | 19388.2 | 19574.2 | 105399.0 | 105880.0 |
+| Keccak-f[1600] | 16384 | 19047.8 | 18782.5 | 137969.2 | 143392.7 |
+
+All results are hashes/s from the full default Ligerito `prove_fast` path,
+including witness generation and proof construction. SHA-256 and BLAKE3 count
+compression functions; Keccak counts Keccak-f[1600] permutations. “Batch” is
+the number of independent hash operations proved together. Each value is the
+best of three measured proofs after one untimed warm-up; the warm-up proof is
+also verified. Row-major stores each hash witness contiguously, while
+batch-major groups corresponding witness chunks across the batch. The Keccak
+rows use the single-permutation encoder so the two layouts are directly
+comparable; the separate 3-wide Keccak benchmark remains available for maximum
+Keccak throughput.
+
+Regenerate the complete table with:
+
+```sh
+benchmarks/bench_hash_throughput.sh
+```
+
+Override `LOG2S`, `RUNS`, or `MT_THREADS` to change the batches, trial count,
+or multi-threaded pool size. There are no Criterion harnesses; each Rust bench
+is a no-harness binary that prints its own results. Run an individual bench
+with:
 
 ```sh
 cargo bench --bench blake3_proof

--- a/benchmarks/BENCHMARKS.md
+++ b/benchmarks/BENCHMARKS.md
@@ -49,6 +49,23 @@ cross-prover comparison tables.
 
 ---
 
+## README hash throughput matrix
+
+Regenerate the README table across SHA-256, BLAKE3, and Keccak-f[1600], at
+multiple batch sizes, with row-major and batch-major witnesses, using one
+thread and the machine's physical-core count:
+
+```bash
+benchmarks/bench_hash_throughput.sh
+```
+
+The runner prints a Markdown table ready to paste into the README. Defaults are
+best-of-3 measurements at batches 2¹⁰, 2¹², and 2¹⁴. Override them with
+`LOG2S="..."`, `RUNS=N`, and `MT_THREADS=N`. Every point includes an untimed
+warm-up proof that is verified before the timed trials.
+
+---
+
 ## 1. Native hashing baseline
 
 Per-core software-hashing throughput (the "Native" reference row):

--- a/benchmarks/bench_hash_throughput.sh
+++ b/benchmarks/bench_hash_throughput.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Regenerate the README's hash proving-throughput matrix.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG2S="${LOG2S:-10 12 14}"
+RUNS="${RUNS:-3}"
+
+if [[ -z "${MT_THREADS:-}" ]]; then
+	case "$(uname -s)" in
+		Darwin)
+			MT_THREADS="$(sysctl -n hw.perflevel0.physicalcpu)"
+			;;
+		Linux)
+			MT_THREADS="$(lscpu -p=SOCKET,CORE | awk -F, '!/^#/ { print $1 "," $2 }' | sort -u | wc -l)"
+			;;
+		*)
+			MT_THREADS="$(getconf _NPROCESSORS_ONLN)"
+			;;
+	esac
+fi
+
+[[ "$MT_THREADS" =~ ^[1-9][0-9]*$ ]] || {
+	echo "MT_THREADS must be a positive integer, got '$MT_THREADS'" >&2
+	exit 1
+}
+[[ "$RUNS" =~ ^[1-9][0-9]*$ ]] || {
+	echo "RUNS must be a positive integer, got '$RUNS'" >&2
+	exit 1
+}
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+results="$work/results.tsv"
+
+run_bench() {
+	local threads="$1"
+	echo
+	echo "=== hash throughput: ${threads} thread(s), batches 2^[${LOG2S}] ==="
+	(
+		cd "$ROOT"
+		RAYON_NUM_THREADS="$threads" \
+			HASH_BENCH_LOG2S="$LOG2S" \
+			HASH_BENCH_RUNS="$RUNS" \
+			cargo bench --bench hash_throughput
+	) 2>&1 | tee "$work/run-${threads}.log"
+	awk -F '\t' '$1 == "RESULT"' "$work/run-${threads}.log" >> "$results"
+}
+
+run_bench "$MT_THREADS"
+if [[ "$MT_THREADS" != "1" ]]; then
+	run_bench 1
+fi
+
+lookup() {
+	local hash="$1" layout="$2" batch="$3" threads="$4"
+	awk -F '\t' \
+		-v hash="$hash" -v layout="$layout" -v batch="$batch" -v threads="$threads" \
+		'$1 == "RESULT" && $2 == hash && $3 == layout && $4 == batch && $5 == threads {
+			found = 1
+			printf "%.1f", $7
+			exit
+		}
+		END { if (!found) exit 1 }' "$results"
+}
+
+echo
+echo "| Hash | Batch | 1T row-major | 1T batch-major | ${MT_THREADS}T row-major | ${MT_THREADS}T batch-major |"
+echo "|---|---:|---:|---:|---:|---:|"
+for hash_spec in "sha2:SHA-256" "blake3:BLAKE3" "keccak:Keccak-f[1600]"; do
+	hash="${hash_spec%%:*}"
+	label="${hash_spec#*:}"
+	for log2 in $LOG2S; do
+		batch="$((1 << log2))"
+		st_row="$(lookup "$hash" row-major "$batch" 1)"
+		st_batch="$(lookup "$hash" batch-major "$batch" 1)"
+		mt_row="$(lookup "$hash" row-major "$batch" "$MT_THREADS")"
+		mt_batch="$(lookup "$hash" batch-major "$batch" "$MT_THREADS")"
+		printf '| %s | %s | %s | %s | %s | %s |\n' \
+			"$label" "$batch" "$st_row" "$st_batch" "$mt_row" "$mt_batch"
+	done
+done

--- a/crates/flock-prover/Cargo.toml
+++ b/crates/flock-prover/Cargo.toml
@@ -166,6 +166,10 @@ name = "native_hash"
 harness = false
 
 [[bench]]
+name = "hash_throughput"
+harness = false
+
+[[bench]]
 name = "ecore_offload_probe"
 harness = false
 

--- a/crates/flock-prover/benches/hash_throughput.rs
+++ b/crates/flock-prover/benches/hash_throughput.rs
@@ -1,0 +1,270 @@
+//! Reproducible headline proving-throughput matrix for the README.
+//!
+//! Measures SHA-256 compressions, BLAKE3 compressions, and Keccak-f[1600]
+//! permutations with both witness layouts. Thread count is controlled through
+//! `RAYON_NUM_THREADS`; `benchmarks/bench_hash_throughput.sh` runs the complete
+//! single- and multi-threaded matrix and renders it as Markdown.
+
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use flock_prover::challenger::FsChallenger;
+use flock_prover::r1cs_hashes::blake3::{Blake3Setup, Compression};
+use flock_prover::r1cs_hashes::keccak::{KeccakSetup, STATE_BITS, State};
+use flock_prover::r1cs_hashes::sha2::Sha256HybridSetup;
+
+const LAYOUTS: [BenchLayout; 2] = [BenchLayout::RowMajor, BenchLayout::BatchMajor];
+
+#[derive(Clone, Copy)]
+enum BenchLayout {
+    RowMajor,
+    BatchMajor,
+}
+
+impl BenchLayout {
+    fn name(self) -> &'static str {
+        match self {
+            Self::RowMajor => "row-major",
+            Self::BatchMajor => "batch-major",
+        }
+    }
+}
+
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn next_u32(&mut self) -> u32 {
+        self.next_u64() as u32
+    }
+}
+
+fn random_sha2_input(rng: &mut Rng) -> ([u32; 8], [u32; 16]) {
+    (
+        std::array::from_fn(|_| rng.next_u32()),
+        std::array::from_fn(|_| rng.next_u32()),
+    )
+}
+
+fn random_blake3_input(rng: &mut Rng) -> Compression {
+    (
+        std::array::from_fn(|_| rng.next_u32()),
+        std::array::from_fn(|_| rng.next_u32()),
+        rng.next_u64(),
+        64,
+        11,
+    )
+}
+
+fn random_keccak_state(rng: &mut Rng) -> State {
+    let mut state = [false; STATE_BITS];
+    for chunk in state.chunks_mut(64) {
+        let word = rng.next_u64();
+        for (bit, value) in chunk.iter_mut().enumerate() {
+            *value = (word >> bit) & 1 == 1;
+        }
+    }
+    state
+}
+
+fn best_of<T, F, O>(inputs: &[T], runs: usize, mut prove: F) -> Duration
+where
+    F: FnMut(&T) -> O,
+{
+    let mut best = Duration::MAX;
+    for (run, input) in inputs[1..=runs].iter().enumerate() {
+        let start = Instant::now();
+        let output = prove(input);
+        let elapsed = start.elapsed();
+        best = best.min(elapsed);
+        black_box(output);
+        eprintln!(
+            "    run {}/{}: {:.3} s",
+            run + 1,
+            runs,
+            elapsed.as_secs_f64()
+        );
+    }
+    best
+}
+
+fn report(hash: &str, layout: BenchLayout, batch: usize, best: Duration) {
+    let seconds = best.as_secs_f64();
+    let throughput = batch as f64 / seconds;
+    println!(
+        "RESULT\t{hash}\t{}\t{batch}\t{}\t{seconds:.6}\t{throughput:.2}",
+        layout.name(),
+        rayon::current_num_threads(),
+    );
+}
+
+fn bench_sha2(batch: usize, layout: BenchLayout, runs: usize) {
+    eprintln!("  SHA-256, {}, batch {batch}", layout.name());
+    let setup = match layout {
+        BenchLayout::RowMajor => Sha256HybridSetup::new(batch),
+        BenchLayout::BatchMajor => Sha256HybridSetup::new_batch_major(batch),
+    };
+    let input_sets: Vec<Vec<_>> = (0..=runs)
+        .map(|run| {
+            let mut rng = Rng::new(0x5A25_6000 ^ batch as u64 ^ run as u64);
+            (0..batch).map(|_| random_sha2_input(&mut rng)).collect()
+        })
+        .collect();
+
+    let mut challenger = FsChallenger::new(b"flock-readme-bench-v0");
+    let (proof, commitment, _) = setup.prove_fast(&input_sets[0], &mut challenger);
+    let mut challenger = FsChallenger::new(b"flock-readme-bench-v0");
+    setup
+        .verify(&commitment, &proof, &mut challenger)
+        .expect("SHA-256 warm-up proof failed verification");
+    black_box(proof);
+
+    let best = best_of(&input_sets, runs, |inputs| {
+        let mut challenger = FsChallenger::new(b"flock-readme-bench-v0");
+        setup.prove_fast(inputs, &mut challenger)
+    });
+    report("sha2", layout, batch, best);
+}
+
+fn bench_blake3(batch: usize, layout: BenchLayout, runs: usize) {
+    eprintln!("  BLAKE3, {}, batch {batch}", layout.name());
+    let setup = match layout {
+        BenchLayout::RowMajor => Blake3Setup::new(batch),
+        BenchLayout::BatchMajor => Blake3Setup::new_batch_major(batch),
+    };
+    let input_sets: Vec<Vec<_>> = (0..=runs)
+        .map(|run| {
+            let mut rng = Rng::new(0xB1A3_E000 ^ batch as u64 ^ run as u64);
+            (0..batch).map(|_| random_blake3_input(&mut rng)).collect()
+        })
+        .collect();
+
+    let mut challenger = FsChallenger::new(b"flock-readme-bench-v0");
+    let (proof, commitment, _) = setup.prove_fast(&input_sets[0], &mut challenger);
+    let mut challenger = FsChallenger::new(b"flock-readme-bench-v0");
+    setup
+        .verify(&commitment, &proof, &mut challenger)
+        .expect("BLAKE3 warm-up proof failed verification");
+    black_box(proof);
+
+    let best = best_of(&input_sets, runs, |inputs| {
+        let mut challenger = FsChallenger::new(b"flock-readme-bench-v0");
+        setup.prove_fast(inputs, &mut challenger)
+    });
+    report("blake3", layout, batch, best);
+}
+
+fn bench_keccak(batch: usize, layout: BenchLayout, runs: usize) {
+    eprintln!("  Keccak-f[1600], {}, batch {batch}", layout.name());
+    let setup = match layout {
+        BenchLayout::RowMajor => KeccakSetup::new(batch),
+        BenchLayout::BatchMajor => KeccakSetup::new_batch_major(batch),
+    };
+    let input_sets: Vec<Vec<_>> = (0..=runs)
+        .map(|run| {
+            let mut rng = Rng::new(0xAECC_A000 ^ batch as u64 ^ run as u64);
+            (0..batch).map(|_| random_keccak_state(&mut rng)).collect()
+        })
+        .collect();
+
+    let mut challenger = FsChallenger::new(b"flock-readme-bench-v0");
+    let (proof, commitment, _) = setup.prove_fast(&input_sets[0], &mut challenger);
+    let mut challenger = FsChallenger::new(b"flock-readme-bench-v0");
+    setup
+        .verify(&commitment, &proof, &mut challenger)
+        .expect("Keccak warm-up proof failed verification");
+    black_box(proof);
+
+    let best = best_of(&input_sets, runs, |inputs| {
+        let mut challenger = FsChallenger::new(b"flock-readme-bench-v0");
+        setup.prove_fast(inputs, &mut challenger)
+    });
+    report("keccak", layout, batch, best);
+}
+
+fn parse_log2_batches() -> Vec<u32> {
+    let value = std::env::var("HASH_BENCH_LOG2S").unwrap_or_else(|_| "10 12 14".to_owned());
+    let batches: Vec<u32> = value
+        .split([',', ' '])
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let log2 = part
+                .parse::<u32>()
+                .expect("HASH_BENCH_LOG2S must contain integer log2 batch sizes");
+            assert!(
+                log2 >= 8,
+                "HASH_BENCH_LOG2S values must be at least 8 for every hash"
+            );
+            assert!(
+                log2 < usize::BITS,
+                "HASH_BENCH_LOG2S contains a batch size too large for this target"
+            );
+            log2
+        })
+        .collect();
+    assert!(!batches.is_empty(), "HASH_BENCH_LOG2S must not be empty");
+    batches
+}
+
+fn parse_runs() -> usize {
+    let runs = std::env::var("HASH_BENCH_RUNS")
+        .unwrap_or_else(|_| "3".to_owned())
+        .parse::<usize>()
+        .expect("HASH_BENCH_RUNS must be a positive integer");
+    assert!(runs > 0, "HASH_BENCH_RUNS must be greater than zero");
+    runs
+}
+
+fn enabled_x86_features() -> &'static str {
+    if cfg!(all(
+        target_arch = "x86_64",
+        target_feature = "avx512f",
+        target_feature = "vpclmulqdq"
+    )) {
+        "AVX-512 + VPCLMULQDQ"
+    } else if cfg!(all(target_arch = "x86_64", target_feature = "avx2")) {
+        "AVX2"
+    } else if cfg!(all(target_arch = "x86_64", target_feature = "avx")) {
+        "AVX"
+    } else {
+        "portable"
+    }
+}
+
+fn main() {
+    let _ = flock_prover::init_perf_thread_pool();
+    let batches = parse_log2_batches();
+    let runs = parse_runs();
+    eprintln!(
+        "Flock hash proving throughput: {} thread(s), {}, best of {runs} after one warm-up",
+        rayon::current_num_threads(),
+        enabled_x86_features(),
+    );
+
+    for layout in LAYOUTS {
+        for &log2 in &batches {
+            bench_sha2(1usize << log2, layout, runs);
+        }
+    }
+    for layout in LAYOUTS {
+        for &log2 in &batches {
+            bench_blake3(1usize << log2, layout, runs);
+        }
+    }
+    for layout in LAYOUTS {
+        for &log2 in &batches {
+            bench_keccak(1usize << log2, layout, runs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a README hash proving-throughput matrix for SHA-256, BLAKE3, and Keccak-f[1600]
- cover batches 1,024, 4,096, and 16,384 across one-thread/32-thread execution and row-major/batch-major witness layouts
- add a reproducible no-harness Rust benchmark and a runner that emits the README-ready Markdown table
- document the x86-64 AVX-512/VPCLMULQDQ optimized path and benchmark reproduction knobs

## Methodology

Measured on 2026-07-17 using an AMD Ryzen Threadripper 7970X (32C/64T, 256 GB RAM) on Linux x86-64. The build uses `-C target-cpu=native`; the benchmark reports the AVX-512 + VPCLMULQDQ path active. Multi-threaded runs use 32 physical cores without SMT.

Each matrix point runs the default Ligerito `prove_fast` path, including witness generation and proof construction. Results are best-of-three after one warm-up, and every warm-up proof is verified. Keccak uses the single-permutation encoder so row-major and batch-major layouts are directly comparable.

## Validation

- `LOG2S="10 12 14" RUNS=3 MT_THREADS=32 benchmarks/bench_hash_throughput.sh`
- `cargo fmt --all --check`
- `bash -n benchmarks/bench_hash_throughput.sh`
- `shellcheck benchmarks/bench_hash_throughput.sh`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --release` (324 passed, 0 failed; heavy/diagnostic tests ignored)