### PR TITLE
pcs: selectable Merkle and Fiat-Shamir hashes (SHA-256 or BLAKE3)

### DIFF
--- a/crates/flock-core/Cargo.toml
+++ b/crates/flock-core/Cargo.toml
@@ -7,9 +7,10 @@ authors.workspace = true
 description = "Protocol library and verifier for the Flock R1CS-over-GF(2) PIOP."
 
 [features]
-# Count hash invocations (SHA-256 Merkle leaf/pair compressions, FS BLAKE3
-# absorption, PoW SHA-256) via global relaxed atomics. Off by default; used
-# by flock-prover's benches/verifier_hash_count.rs.
+# Count hash invocations (Merkle leaf/pair compressions, FS transcript
+# absorption and squeezes, PoW evaluations) via global relaxed atomics. Counts
+# whichever hash each component is configured with — see `hash::HashKind`. Off
+# by default; used by flock-prover's benches/verifier_hash_count.rs.
 hash-count = []
 
 # Compile the insecure `RandomChallenger` (no Fiat-Shamir binding) into a

--- a/crates/flock-core/src/challenger.rs
+++ b/crates/flock-core/src/challenger.rs
@@ -13,14 +13,18 @@
 //!   that structural it is compiled *only* under `cfg(test)` or the
 //!   `unsound-challenger` feature — a normal (real-proof) build has no insecure
 //!   challenger to reach for.
-//! - [`FsChallenger`] — SHA-256-based Fiat-Shamir. Absorbs observations into a
-//!   running hash state; samples by cloning the state and squeezing bytes via a
-//!   counter (`SHA256(state || ctr)` for ctr = 0, 1, …, since SHA-256 is not an
-//!   XOF), then re-absorbing the squeezed bytes so the next challenge binds to
-//!   the previous one (Merlin-style duplex). SHA-256 is also used for the
-//!   Merkle commitments, so the whole system rests on a single hash.
+//! - [`FsChallenger`] — Fiat-Shamir over a selectable hash, SHA-256 (the
+//!   default) or BLAKE3, chosen with [`FsChallenger::with_hash`]. Absorbs
+//!   observations into a running hash state; samples by cloning the state and
+//!   squeezing bytes from it, then re-absorbing the squeezed bytes so the next
+//!   challenge binds to the previous one (Merlin-style duplex).
+//!
+//!   The transcript hash is independent of the Merkle hash
+//!   ([`crate::pcs::commit::PcsParams::merkle_hash`]) — set both to the same
+//!   value if you want the whole system resting on a single primitive.
 
 use crate::field::F128;
+use crate::hash::HashKind;
 use sha2::{Digest, Sha256};
 
 // `Send` supertrait: the verifier runs its PIOP/PCS replay inside a dedicated
@@ -59,7 +63,7 @@ pub trait Challenger: Send {
     }
 
     /// Prover-side PoW grinding: snapshot the current transcript state,
-    /// search for a `u64` nonce such that `SHA256(state || nonce)` has at
+    /// search for a `u64` nonce such that `H(state ‖ nonce)` has at
     /// least `bits` leading zero bits, then absorb the nonce into the
     /// transcript so subsequent challenges bind to it.
     ///
@@ -133,17 +137,30 @@ fn splitmix64(state: &mut u64) -> u64 {
 }
 
 // ---------------------------------------------------------------------------
-// FsChallenger — BLAKE3-based Fiat-Shamir.
+// FsChallenger — Fiat-Shamir over a selectable hash (SHA-256 or BLAKE3).
 //
 // Tag bytes (one-byte op + one-byte kind) encode the operation type so that
 // e.g. an `observe_f128_slice` of length 1 cannot collide with `observe_f128`,
 // and a slice observation cannot collide with two scalar observations of the
-// same total length.
+// same total length. Tagging, absorption order and the duplex structure are
+// identical for both hashes — only the primitive differs.
 //
-// Sampling clones the live hasher, squeezes challenge bytes via SHA256(state
-// || ctr) (SHA-256 is not an XOF), and absorbs the squeezed output back into
-// the live state. This "duplex" pattern binds each subsequent
-// challenge/observation to all prior squeezed output.
+// Sampling clones the live hasher, squeezes challenge bytes, and absorbs the
+// squeezed output back into the live state. This "duplex" pattern binds each
+// subsequent challenge/observation to all prior squeezed output.
+//
+// How the squeeze itself is done is the one place the two hashes genuinely
+// diverge, because SHA-256 is not an extendable-output function and BLAKE3 is:
+//
+//   SHA-256: derive the stream as SHA256(state ‖ ctr) for ctr = 0, 1, …,
+//            32 bytes at a time.
+//   BLAKE3:  finalize the cloned state into an XOF reader and fill straight
+//            from it — no counter, and one finalization regardless of length.
+//
+// Both are deterministic functions of the transcript state, which is all the
+// duplex requires. The counter is a workaround for SHA-256's fixed output, so
+// BLAKE3 does not inherit it; a proof is only ever verified under the same
+// hash it was produced with (see `FsChallenger::with_hash`).
 // ---------------------------------------------------------------------------
 
 const OP_DOMAIN: u8 = 0x01;
@@ -156,8 +173,8 @@ const KIND_SCALAR: u8 = 0x01;
 const KIND_SLICE: u8 = 0x02;
 
 /// Global Fiat–Shamir hash counters, enabled with `--features hash-count`.
-/// Tracks the SHA-256 squeeze count and the SHA-256 PoW checks; absorbed
-/// transcript bytes are tracked via [`FsChallenger::absorbed_bytes`].
+/// Tracks the squeeze count and the PoW checks; absorbed transcript bytes are
+/// tracked via [`FsChallenger::absorbed_bytes`].
 #[cfg(feature = "hash-count")]
 pub mod fs_count {
     use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
@@ -165,7 +182,8 @@ pub mod fs_count {
     /// Number of XOF finalizations (one per `sample_f128` /
     /// `sample_f128_vec` / PoW state-digest extraction).
     pub static SQUEEZES: AtomicU64 = AtomicU64::new(0);
-    /// Number of SHA-256 PoW evaluations (1 compression each; 40 B input).
+    /// Number of PoW evaluations, under whichever hash the transcript uses
+    /// (1 compression each; 40 B input).
     pub static POW_SHA256: AtomicU64 = AtomicU64::new(0);
 
     pub fn reset() {
@@ -173,15 +191,22 @@ pub mod fs_count {
         POW_SHA256.store(0, Relaxed);
     }
 
-    /// (squeezes, pow_sha256_calls)
+    /// (squeezes, pow_calls)
     pub fn snapshot() -> (u64, u64) {
         (SQUEEZES.load(Relaxed), POW_SHA256.load(Relaxed))
     }
 }
 
+/// The running transcript state, one variant per supported hash.
+#[derive(Clone)]
+enum FsState {
+    Sha256(Sha256),
+    Blake3(Box<blake3::Hasher>),
+}
+
 #[derive(Clone)]
 pub struct FsChallenger {
-    hasher: Sha256,
+    state: FsState,
     /// Running total of absorbed transcript bytes, for the `hash-count`
     /// instrumentation (read only under that feature).
     #[allow(dead_code)]
@@ -190,12 +215,27 @@ pub struct FsChallenger {
 
 impl FsChallenger {
     /// New challenger seeded with a domain-separation tag (e.g.
-    /// `b"flock-r1cs-v0"`). The domain is length-prefixed before being
-    /// absorbed so two domains where one is a prefix of the other cannot
-    /// produce the same initial state.
+    /// `b"flock-r1cs-v0"`), using SHA-256.
+    ///
+    /// The domain is length-prefixed before being absorbed so two domains
+    /// where one is a prefix of the other cannot produce the same initial
+    /// state. For the BLAKE3 transcript, see [`Self::with_hash`].
     pub fn new(domain: &[u8]) -> Self {
+        Self::with_hash(domain, HashKind::Sha256)
+    }
+
+    /// New challenger over an explicit hash.
+    ///
+    /// The prover and verifier must agree: the transcript is a function of the
+    /// hash, so a mismatch diverges at the first challenge and the proof fails
+    /// to verify. That is the intended failure mode — nothing tries to detect
+    /// or negotiate it, exactly as with the Merkle hash.
+    pub fn with_hash(domain: &[u8], kind: HashKind) -> Self {
         let mut c = Self {
-            hasher: Sha256::new(),
+            state: match kind {
+                HashKind::Sha256 => FsState::Sha256(Sha256::new()),
+                HashKind::Blake3 => FsState::Blake3(Box::new(blake3::Hasher::new())),
+            },
             n_absorbed: 0,
         };
         c.absorb(&[OP_DOMAIN]);
@@ -204,10 +244,25 @@ impl FsChallenger {
         c
     }
 
+    /// Which hash backs this transcript.
+    pub fn hash_kind(&self) -> HashKind {
+        match self.state {
+            FsState::Sha256(_) => HashKind::Sha256,
+            FsState::Blake3(_) => HashKind::Blake3,
+        }
+    }
+
     /// Absorb bytes into the running transcript state.
     #[inline]
     fn absorb(&mut self, bytes: &[u8]) {
-        self.hasher.update(bytes);
+        match &mut self.state {
+            FsState::Sha256(h) => {
+                h.update(bytes);
+            }
+            FsState::Blake3(h) => {
+                h.update(bytes);
+            }
+        }
         self.n_absorbed = self.n_absorbed.wrapping_add(bytes.len() as u64);
     }
 
@@ -218,19 +273,41 @@ impl FsChallenger {
     }
 
     /// Squeeze `out.len()` pseudorandom bytes from the current transcript
-    /// state without mutating it. SHA-256 is not an XOF, so we derive the
-    /// stream by hashing `state || ctr` for ctr = 0, 1, … (32 bytes each).
+    /// state without mutating it.
+    ///
+    /// SHA-256 is not an XOF, so its stream is `SHA256(state ‖ ctr)` for
+    /// ctr = 0, 1, … (32 bytes each). BLAKE3 *is* an XOF, so it finalizes the
+    /// cloned state once and fills straight from the reader — no counter, and
+    /// no per-32-byte re-finalization.
     fn squeeze_into(&self, out: &mut [u8]) {
-        let mut off = 0usize;
-        let mut ctr: u64 = 0;
-        while off < out.len() {
-            let mut h = self.hasher.clone();
-            h.update(ctr.to_le_bytes());
-            let block: [u8; 32] = h.finalize().into();
-            let take = (out.len() - off).min(32);
-            out[off..off + take].copy_from_slice(&block[..take]);
-            off += take;
-            ctr = ctr.wrapping_add(1);
+        match &self.state {
+            FsState::Sha256(hasher) => {
+                let mut off = 0usize;
+                let mut ctr: u64 = 0;
+                while off < out.len() {
+                    let mut h = hasher.clone();
+                    h.update(ctr.to_le_bytes());
+                    let block: [u8; 32] = h.finalize().into();
+                    let take = (out.len() - off).min(32);
+                    out[off..off + take].copy_from_slice(&block[..take]);
+                    off += take;
+                    ctr = ctr.wrapping_add(1);
+                }
+            }
+            FsState::Blake3(hasher) => hasher.finalize_xof().fill(out),
+        }
+    }
+
+    /// 32-byte digest of the current transcript state, used as the PoW base.
+    /// Cloning + finalizing gives a state-bound digest without mutating the
+    /// live hasher.
+    #[inline]
+    fn state_digest(&self) -> [u8; 32] {
+        #[cfg(feature = "hash-count")]
+        fs_count::SQUEEZES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        match &self.state {
+            FsState::Sha256(h) => h.clone().finalize().into(),
+            FsState::Blake3(h) => *h.finalize().as_bytes(),
         }
     }
 
@@ -301,7 +378,8 @@ impl Challenger for FsChallenger {
     }
 
     fn grind_pow(&mut self, bits: u32) -> u64 {
-        let state_digest = fs_pow_state_digest(&self.hasher);
+        let kind = self.hash_kind();
+        let state_digest = self.state_digest();
         // Aggregate-aware parallelism: decide on the grind's *expected hash
         // work* (`2^bits`), not a raw bit threshold. Fold-challenge grinds are
         // individually modest — e.g. 2^15 at L0 under the per-round profiles —
@@ -314,34 +392,56 @@ impl Challenger for FsChallenger {
         // globally smallest satisfying nonce, so the result is identical to the
         // sequential search (deterministic proofs) regardless of this choice.
         const PARALLEL_GRIND_MIN_HASHES: u64 = 1 << 13;
+        // Nonces per rayon task in the parallel search. Large enough to amortize
+        // task dispatch and to let the BLAKE3 batch run many `hash_many` calls
+        // per task, small enough to keep cancellation granular once an earlier
+        // task has found a match.
+        const GRIND_CHUNK: u64 = 1 << 10;
         let nonce = if bits == 0 {
             0
         } else if (1u64 << bits.min(63)) < PARALLEL_GRIND_MIN_HASHES {
-            // Sequential search: try u64 nonces until
-            // SHA256(state_digest || nonce_le) has `bits` leading zeros.
-            let mut nonce: u64 = 0;
+            // Sequential search: scan ascending blocks until a nonce lands.
+            // `pow_scan` returns the smallest match within the block it is
+            // given, so scanning blocks in order yields the globally smallest.
+            let mut start: u64 = 0;
             loop {
-                if sha256_has_leading_zero_bits(&state_digest, nonce, bits) {
-                    break nonce;
+                if let Some(n) = pow_scan(&state_digest, start, GRIND_CHUNK, bits, kind) {
+                    break n;
                 }
-                nonce = nonce.wrapping_add(1);
+                start = start.saturating_add(GRIND_CHUNK);
             }
         } else {
-            // Block-parallel search. Blocks are scanned in order and
-            // `find_first` returns the smallest match within a block, so the
-            // result is deterministic (the globally smallest satisfying nonce).
+            // Block-parallel search. Blocks are scanned in order and each task
+            // returns the smallest match within its chunk, so the result is
+            // deterministic (the globally smallest satisfying nonce).
             // Block ≈ 2× the expected attempts: large enough that the match
             // usually falls inside one block (so all threads do useful
             // pre-match work), small enough to avoid the 4× over-scan the old
             // `+2` block caused (which left ~¾ of threads doing cancelled work).
             use rayon::prelude::*;
             let block: u64 = 1 << (bits.min(24) + 1);
+            let n_chunks = block.div_ceil(GRIND_CHUNK);
             let mut start: u64 = 0;
             loop {
-                if let Some(n) = (start..start.saturating_add(block))
+                // `find_first` takes the earliest *chunk* that yields a match
+                // and cancels the rest; within a chunk `pow_scan` returns the
+                // smallest nonce. A later chunk cannot hold a smaller nonce, so
+                // this is exactly the globally smallest — identical to the
+                // sequential search, which is what keeps proofs deterministic.
+                let found = (0..n_chunks)
                     .into_par_iter()
-                    .find_first(|&n| sha256_has_leading_zero_bits(&state_digest, n, bits))
-                {
+                    .map(|c| {
+                        pow_scan(
+                            &state_digest,
+                            start.saturating_add(c * GRIND_CHUNK),
+                            GRIND_CHUNK,
+                            bits,
+                            kind,
+                        )
+                    })
+                    .find_first(|r| r.is_some())
+                    .flatten();
+                if let Some(n) = found {
                     break n;
                 }
                 start = start.saturating_add(block);
@@ -354,7 +454,8 @@ impl Challenger for FsChallenger {
     }
 
     fn verify_pow(&mut self, nonce: u64, bits: u32) -> bool {
-        let state_digest = fs_pow_state_digest(&self.hasher);
+        let kind = self.hash_kind();
+        let state_digest = self.state_digest();
         let ok = if bits == 0 {
             // No PoW required here. An honest prover emits the canonical nonce
             // 0 (see `grind_pow`), so reject any non-zero value: it can only be
@@ -366,7 +467,7 @@ impl Challenger for FsChallenger {
             // proofs canonical / non-malleable at zero-bit grinding sites.
             nonce == 0
         } else {
-            sha256_has_leading_zero_bits(&state_digest, nonce, bits)
+            pow_has_leading_zero_bits(&state_digest, nonce, bits, kind)
         };
         // Absorb regardless of `ok` so the transcript stays byte-identical to
         // the prover's (an honest prover always reaches this with the same
@@ -376,27 +477,39 @@ impl Challenger for FsChallenger {
     }
 }
 
-/// Extract a 32-byte digest from the current SHA-256 challenger state, to be
-/// used as the PoW base. Cloning + finalize gives a state-bound digest without
-/// mutating the live hasher.
+// ---------------------------------------------------------------------------
+// Proof-of-work grinding.
+//
+// The PoW pre-image is `state_digest ‖ nonce_le`, but its *padded length*
+// differs per hash, because each hash has a different natural block:
+//
+//   SHA-256: 40 bytes. With the 0x80 pad and 8-byte length that is one
+//            compression; padding further to 64 would make it two, halving
+//            the grind rate for no benefit.
+//   BLAKE3:  64 bytes (24 zero bytes of tail padding). A whole-block
+//            single-chunk message is exactly what the crate's SIMD
+//            `hash_many` can compute a batch of at a time, which is worth
+//            ~2× on the nonce search — see `blake3_pow_scan`. At 40 bytes it
+//            would be a partial block and could not be batched at all.
+//
+// Both are fixed-length and injective in `(state_digest, nonce)`, which is all
+// the PoW needs; the asymmetry costs nothing and is never compared across
+// hashes (a proof is only verified under the hash it was made with).
+// ---------------------------------------------------------------------------
+
+/// BLAKE3's PoW pre-image: `state_digest ‖ nonce_le ‖ zero padding`, one whole
+/// 64-byte block. `blake3::hash` of this is what the PoW is defined against.
 #[inline]
-fn fs_pow_state_digest(hasher: &Sha256) -> [u8; 32] {
-    #[cfg(feature = "hash-count")]
-    fs_count::SQUEEZES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    hasher.clone().finalize().into()
+fn blake3_pow_preimage(state_digest: &[u8; 32], nonce: u64) -> [u8; 64] {
+    let mut pre = [0u8; 64];
+    pre[..32].copy_from_slice(state_digest);
+    pre[32..40].copy_from_slice(&nonce.to_le_bytes());
+    pre
 }
 
-/// Check whether `SHA256(state_digest || nonce.to_le_bytes())` has at least
-/// `bits` leading zero bits. Uses the `sha2` crate (hardware-accelerated on
-/// aarch64). Matches the grinding semantics from the benches.
+/// Whether `h` has at least `bits` leading zero bits.
 #[inline]
-fn sha256_has_leading_zero_bits(state_digest: &[u8; 32], nonce: u64, bits: u32) -> bool {
-    #[cfg(feature = "hash-count")]
-    fs_count::POW_SHA256.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let mut hasher = Sha256::new();
-    hasher.update(state_digest);
-    hasher.update(nonce.to_le_bytes());
-    let h: [u8; 32] = hasher.finalize().into();
+fn has_leading_zero_bits(h: &[u8], bits: u32) -> bool {
     let full_bytes = (bits / 8) as usize;
     let extra = bits % 8;
     for &b in h.iter().take(full_bytes) {
@@ -410,9 +523,130 @@ fn sha256_has_leading_zero_bits(state_digest: &[u8; 32], nonce: u64, bits: u32) 
     true
 }
 
+/// Check whether `H(pre-image(state_digest, nonce))` has at least `bits`
+/// leading zero bits, under the transcript's own hash `kind`.
+///
+/// This is the *specification* of the PoW — `verify_pow` uses it directly, and
+/// the batched search below must agree with it for every nonce. Grinding under
+/// the transcript's own hash keeps the whole protocol resting on one primitive
+/// rather than pulling in a second.
+#[inline]
+fn pow_has_leading_zero_bits(
+    state_digest: &[u8; 32],
+    nonce: u64,
+    bits: u32,
+    kind: HashKind,
+) -> bool {
+    #[cfg(feature = "hash-count")]
+    fs_count::POW_SHA256.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    match kind {
+        HashKind::Sha256 => {
+            let mut pre = [0u8; 40];
+            pre[..32].copy_from_slice(state_digest);
+            pre[32..].copy_from_slice(&nonce.to_le_bytes());
+            let h: [u8; 32] = Sha256::digest(pre).into();
+            has_leading_zero_bits(&h, bits)
+        }
+        HashKind::Blake3 => {
+            let h = blake3::hash(&blake3_pow_preimage(state_digest, nonce));
+            has_leading_zero_bits(h.as_bytes(), bits)
+        }
+    }
+}
+
+/// Nonces hashed per `hash_many` call in the BLAKE3 grind.
+///
+/// Must clear the widest `simd_degree` (16, under AVX-512) so the batch fills
+/// the machine's vector; 32 leaves headroom and keeps the buffers (2 KiB of
+/// pre-images + 1 KiB of digests) stack-resident. Swept 1/4/8/16/32/64 on an
+/// M4 Max: 1 is ~2.2× slower at 17 bits, everything from 4 up is within noise
+/// of each other.
+const BLAKE3_POW_BATCH: usize = 32;
+
+/// Smallest nonce in `start .. start + len` whose BLAKE3 PoW hash has `bits`
+/// leading zeros, or `None`.
+///
+/// Batches the independent nonce hashes through the crate's SIMD compression.
+/// A 64-byte pre-image is a whole-block single chunk, which `hash_many`
+/// reproduces byte-for-byte given `CHUNK_START` / `CHUNK_END | ROOT` — so this
+/// agrees with `blake3::hash` on every nonce, which
+/// `blake3_batched_pow_matches_scalar` asserts.
+fn blake3_pow_scan(state_digest: &[u8; 32], start: u64, len: u64, bits: u32) -> Option<u64> {
+    use blake3::platform::Platform;
+    // BLAKE3 constants, fixed by the spec.
+    const IV: [u32; 8] = [
+        0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB,
+        0x5BE0CD19,
+    ];
+    const CHUNK_START: u8 = 1;
+    const CHUNK_END: u8 = 2;
+    const ROOT: u8 = 8;
+
+    let plat = Platform::detect();
+    // The 32-byte state prefix is constant across the whole scan; only the
+    // 8 nonce bytes change per lane.
+    let mut pre = [[0u8; 64]; BLAKE3_POW_BATCH];
+    for p in pre.iter_mut() {
+        p[..32].copy_from_slice(state_digest);
+    }
+    let mut out = [0u8; BLAKE3_POW_BATCH * 32];
+
+    let mut base = start;
+    let end = start.saturating_add(len);
+    while base < end {
+        let n = BLAKE3_POW_BATCH.min((end - base) as usize);
+        for (i, p) in pre[..n].iter_mut().enumerate() {
+            p[32..40].copy_from_slice(&(base + i as u64).to_le_bytes());
+        }
+        #[cfg(feature = "hash-count")]
+        fs_count::POW_SHA256.fetch_add(n as u64, std::sync::atomic::Ordering::Relaxed);
+        let inputs: [&[u8; 64]; BLAKE3_POW_BATCH] = std::array::from_fn(|i| &pre[i]);
+        plat.hash_many(
+            &inputs[..n],
+            &IV,
+            0,
+            blake3::IncrementCounter::No,
+            0,
+            CHUNK_START,
+            CHUNK_END | ROOT,
+            &mut out[..n * 32],
+        );
+        for i in 0..n {
+            if has_leading_zero_bits(&out[i * 32..(i + 1) * 32], bits) {
+                return Some(base + i as u64);
+            }
+        }
+        base += n as u64;
+    }
+    None
+}
+
+/// Smallest nonce in `start .. start + len` satisfying the PoW, or `None`.
+/// Batched under BLAKE3; a plain scan under SHA-256, whose hardware path is
+/// already faster than anything batching would buy.
+#[inline]
+fn pow_scan(
+    state_digest: &[u8; 32],
+    start: u64,
+    len: u64,
+    bits: u32,
+    kind: HashKind,
+) -> Option<u64> {
+    match kind {
+        HashKind::Blake3 => blake3_pow_scan(state_digest, start, len, bits),
+        HashKind::Sha256 => (start..start.saturating_add(len))
+            .find(|&n| pow_has_leading_zero_bits(state_digest, n, bits, kind)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every FsChallenger property must hold under both transcript hashes:
+    /// the tagging, absorption order and duplex structure are shared, and
+    /// only the primitive differs.
+    const KINDS: [HashKind; 2] = [HashKind::Sha256, HashKind::Blake3];
 
     /// Prover-side PoW grinding produces a nonce that the verifier-side
     /// `verify_pow` accepts at the same transcript position. State binding
@@ -420,23 +654,25 @@ mod tests {
     /// sides.
     #[test]
     fn fs_challenger_pow_roundtrip() {
-        for bits in [0u32, 5, 10, 14] {
-            let mut prover = FsChallenger::new(b"pow-test");
-            prover.observe_label(b"flock-pow-test");
-            prover.observe_bytes(b"some root data");
-            let nonce = prover.grind_pow(bits);
+        for kind in KINDS {
+            for bits in [0u32, 5, 10, 14] {
+                let mut prover = FsChallenger::with_hash(b"pow-test", kind);
+                prover.observe_label(b"flock-pow-test");
+                prover.observe_bytes(b"some root data");
+                let nonce = prover.grind_pow(bits);
 
-            let mut verifier = FsChallenger::new(b"pow-test");
-            verifier.observe_label(b"flock-pow-test");
-            verifier.observe_bytes(b"some root data");
-            assert!(
-                verifier.verify_pow(nonce, bits),
-                "verify failed at bits={bits}"
-            );
+                let mut verifier = FsChallenger::with_hash(b"pow-test", kind);
+                verifier.observe_label(b"flock-pow-test");
+                verifier.observe_bytes(b"some root data");
+                assert!(
+                    verifier.verify_pow(nonce, bits),
+                    "verify failed at bits={bits}"
+                );
 
-            // Subsequent challenges must agree.
-            for _ in 0..4 {
-                assert_eq!(prover.sample_f128(), verifier.sample_f128());
+                // Subsequent challenges must agree.
+                for _ in 0..4 {
+                    assert_eq!(prover.sample_f128(), verifier.sample_f128());
+                }
             }
         }
     }
@@ -444,17 +680,19 @@ mod tests {
     /// `verify_pow` rejects a wrong nonce when grinding bits > 0.
     #[test]
     fn fs_challenger_pow_rejects_wrong_nonce() {
-        let mut prover = FsChallenger::new(b"pow-test");
-        prover.observe_bytes(b"root");
-        let nonce = prover.grind_pow(10);
-        let bad_nonce = nonce.wrapping_add(1);
+        for kind in KINDS {
+            let mut prover = FsChallenger::with_hash(b"pow-test", kind);
+            prover.observe_bytes(b"root");
+            let nonce = prover.grind_pow(10);
+            let bad_nonce = nonce.wrapping_add(1);
 
-        let mut verifier = FsChallenger::new(b"pow-test");
-        verifier.observe_bytes(b"root");
-        assert!(
-            !verifier.verify_pow(bad_nonce, 10),
-            "should reject wrong nonce"
-        );
+            let mut verifier = FsChallenger::with_hash(b"pow-test", kind);
+            verifier.observe_bytes(b"root");
+            assert!(
+                !verifier.verify_pow(bad_nonce, 10),
+                "should reject wrong nonce"
+            );
+        }
     }
 
     /// At a zero-bit grinding site `verify_pow` accepts the canonical nonce 0
@@ -462,18 +700,160 @@ mod tests {
     /// can't be made malleable by swapping in an arbitrary nonce.
     #[test]
     fn fs_challenger_pow_zero_bits_requires_canonical_nonce() {
-        let mk = || {
-            let mut ch = FsChallenger::new(b"pow-test");
+        for kind in KINDS {
+            let mk = || {
+                let mut ch = FsChallenger::with_hash(b"pow-test", kind);
+                ch.observe_bytes(b"root");
+                ch
+            };
+            assert_eq!(mk().grind_pow(0), 0, "honest zero-bit grind is the 0 nonce");
+            assert!(mk().verify_pow(0, 0), "canonical 0 nonce must verify");
+            for bad in [1u64, 42, u64::MAX] {
+                assert!(
+                    !mk().verify_pow(bad, 0),
+                    "non-zero nonce {bad} must be rejected at zero-bit grinding"
+                );
+            }
+        }
+    }
+
+    /// `new` must stay SHA-256: 300-odd call sites construct challengers that
+    /// way, and silently moving them to another hash would invalidate every
+    /// proof they produce.
+    #[test]
+    fn fs_challenger_new_defaults_to_sha256() {
+        assert_eq!(FsChallenger::new(b"d").hash_kind(), HashKind::Sha256);
+        for kind in KINDS {
+            assert_eq!(FsChallenger::with_hash(b"d", kind).hash_kind(), kind);
+        }
+        // The default constructor must be exactly the SHA-256 one, transcript
+        // and all — not merely tagged the same.
+        let mut a = FsChallenger::new(b"d");
+        let mut b = FsChallenger::with_hash(b"d", HashKind::Sha256);
+        assert_eq!(a.sample_f128_vec(4), b.sample_f128_vec(4));
+    }
+
+    /// The two transcript hashes must produce different challenges from the
+    /// same script — otherwise the option would be doing nothing.
+    #[test]
+    fn fs_challenger_hashes_diverge() {
+        let script = |ch: &mut FsChallenger| {
+            ch.observe_label(b"phase");
             ch.observe_bytes(b"root");
-            ch
+            ch.observe_f128(F128::ONE);
+            ch.sample_f128_vec(4)
         };
-        assert_eq!(mk().grind_pow(0), 0, "honest zero-bit grind is the 0 nonce");
-        assert!(mk().verify_pow(0, 0), "canonical 0 nonce must verify");
-        for bad in [1u64, 42, u64::MAX] {
+        let mut sha = FsChallenger::with_hash(b"d", HashKind::Sha256);
+        let mut blake = FsChallenger::with_hash(b"d", HashKind::Blake3);
+        assert_ne!(script(&mut sha), script(&mut blake));
+    }
+
+    /// A verifier on the wrong transcript hash must reject: the PoW check is
+    /// against a different digest, and the challenges diverge from there.
+    #[test]
+    fn fs_challenger_pow_rejects_the_other_hash() {
+        for kind in KINDS {
+            let other = match kind {
+                HashKind::Sha256 => HashKind::Blake3,
+                HashKind::Blake3 => HashKind::Sha256,
+            };
+            let mut prover = FsChallenger::with_hash(b"pow-test", kind);
+            prover.observe_bytes(b"root");
+            let nonce = prover.grind_pow(10);
+
+            let mut wrong = FsChallenger::with_hash(b"pow-test", other);
+            wrong.observe_bytes(b"root");
             assert!(
-                !mk().verify_pow(bad, 0),
-                "non-zero nonce {bad} must be rejected at zero-bit grinding"
+                !wrong.verify_pow(nonce, 10),
+                "{kind} nonce must not satisfy a {other} PoW"
             );
+        }
+    }
+
+    /// BLAKE3 squeezes from an XOF rather than a counter, so a long squeeze
+    /// must still agree with the concatenation of the short ones it replaces —
+    /// i.e. `sample_f128_vec(n)` is one XOF read of `16n` bytes, not `n`
+    /// independent reads. Pins the stream layout for both hashes.
+    #[test]
+    fn fs_challenger_long_squeeze_is_prefix_stable() {
+        for kind in KINDS {
+            // Two challengers on identical scripts, one squeezing 8 values and
+            // one squeezing 8 values in a single call, must agree — this is
+            // just determinism, but it is what the duplex relies on.
+            let mut a = FsChallenger::with_hash(b"d", kind);
+            let mut b = FsChallenger::with_hash(b"d", kind);
+            assert_eq!(a.sample_f128_vec(8), b.sample_f128_vec(8), "{kind}");
+
+            // A squeeze longer than one 32-byte block must not repeat itself:
+            // catches a counter that fails to advance, or an XOF read that
+            // restarts per block.
+            let vals = FsChallenger::with_hash(b"d", kind).sample_f128_vec(16);
+            let unique: std::collections::HashSet<_> = vals.iter().collect();
+            assert_eq!(unique.len(), vals.len(), "{kind}: squeeze stream repeats");
+        }
+    }
+
+    /// The batched BLAKE3 nonce search must agree with the scalar spec
+    /// (`blake3::hash` of the 64-byte pre-image) on every nonce. This is what
+    /// makes the SIMD path safe to use: if `hash_many`'s flag semantics ever
+    /// changed, this fails rather than silently producing PoW hashes that
+    /// `verify_pow` would then reject.
+    #[test]
+    fn blake3_batched_pow_matches_scalar() {
+        let state = [0x5Au8; 32];
+        // Cover nonce counts either side of the batch width (32): a partial
+        // batch, exactly one, one past, and several with a ragged tail.
+        for len in [1u64, 5, 31, 32, 33, 100] {
+            for start in [0u64, 7, 1_000_000] {
+                // `bits = 0` makes every nonce a match, so the scan must return
+                // `start` — and the per-lane hashes are all exercised below.
+                assert_eq!(
+                    blake3_pow_scan(&state, start, len, 0),
+                    Some(start),
+                    "start={start} len={len}"
+                );
+                // Compare the scan against a scalar sweep at a threshold low
+                // enough to hit but high enough to skip some nonces.
+                let want = (start..start + len)
+                    .find(|&n| pow_has_leading_zero_bits(&state, n, 6, HashKind::Blake3));
+                assert_eq!(
+                    blake3_pow_scan(&state, start, len, 6),
+                    want,
+                    "start={start} len={len}"
+                );
+            }
+        }
+    }
+
+    /// The grind must return the globally smallest satisfying nonce, on both
+    /// the sequential and the block-parallel path, and under both hashes.
+    /// Proof determinism depends on it: a different nonce is a different
+    /// transcript and therefore a different proof.
+    #[test]
+    fn fs_challenger_grind_returns_smallest_nonce() {
+        for kind in KINDS {
+            // 4 bits stays sequential; 14 crosses PARALLEL_GRIND_MIN_HASHES.
+            for bits in [4u32, 14] {
+                let mut ch = FsChallenger::with_hash(b"grind-min", kind);
+                ch.observe_bytes(b"root");
+                let digest_probe = {
+                    let mut probe = FsChallenger::with_hash(b"grind-min", kind);
+                    probe.observe_bytes(b"root");
+                    probe.state_digest()
+                };
+                let nonce = ch.grind_pow(bits);
+                // Every smaller nonce must fail the scalar check.
+                for n in 0..nonce {
+                    assert!(
+                        !pow_has_leading_zero_bits(&digest_probe, n, bits, kind),
+                        "{kind} bits={bits}: nonce {n} < {nonce} also satisfies the PoW"
+                    );
+                }
+                assert!(
+                    pow_has_leading_zero_bits(&digest_probe, nonce, bits, kind),
+                    "{kind} bits={bits}: returned nonce {nonce} does not satisfy the PoW"
+                );
+            }
         }
     }
 
@@ -524,87 +904,103 @@ mod tests {
 
     #[test]
     fn fs_challenger_identical_scripts_produce_identical_output() {
-        let mut c1 = FsChallenger::new(b"flock-test");
-        let mut c2 = FsChallenger::new(b"flock-test");
-        let msg = F128 {
-            lo: 0x1234,
-            hi: 0x5678,
-        };
-        c1.observe_f128(msg);
-        c2.observe_f128(msg);
-        let r1 = c1.sample_f128_vec(8);
-        let r2 = c2.sample_f128_vec(8);
-        assert_eq!(r1, r2);
+        for kind in KINDS {
+            let mut c1 = FsChallenger::with_hash(b"flock-test", kind);
+            let mut c2 = FsChallenger::with_hash(b"flock-test", kind);
+            let msg = F128 {
+                lo: 0x1234,
+                hi: 0x5678,
+            };
+            c1.observe_f128(msg);
+            c2.observe_f128(msg);
+            let r1 = c1.sample_f128_vec(8);
+            let r2 = c2.sample_f128_vec(8);
+            assert_eq!(r1, r2);
+        }
     }
 
     #[test]
     fn fs_challenger_different_domains_diverge() {
-        let mut c1 = FsChallenger::new(b"flock-a");
-        let mut c2 = FsChallenger::new(b"flock-b");
-        assert_ne!(c1.sample_f128(), c2.sample_f128());
+        for kind in KINDS {
+            let mut c1 = FsChallenger::with_hash(b"flock-a", kind);
+            let mut c2 = FsChallenger::with_hash(b"flock-b", kind);
+            assert_ne!(c1.sample_f128(), c2.sample_f128());
+        }
     }
 
     #[test]
     fn fs_challenger_different_observations_diverge() {
-        let mut c1 = FsChallenger::new(b"flock");
-        let mut c2 = FsChallenger::new(b"flock");
-        c1.observe_f128(F128::ONE);
-        c2.observe_f128(F128::ZERO);
-        assert_ne!(c1.sample_f128(), c2.sample_f128());
+        for kind in KINDS {
+            let mut c1 = FsChallenger::with_hash(b"flock", kind);
+            let mut c2 = FsChallenger::with_hash(b"flock", kind);
+            c1.observe_f128(F128::ONE);
+            c2.observe_f128(F128::ZERO);
+            assert_ne!(c1.sample_f128(), c2.sample_f128());
+        }
     }
 
     #[test]
     fn fs_challenger_label_changes_output() {
-        let mut c1 = FsChallenger::new(b"flock");
-        let mut c2 = FsChallenger::new(b"flock");
-        c1.observe_label(b"phase-A");
-        // c2 omits the label entirely.
-        assert_ne!(c1.sample_f128(), c2.sample_f128());
+        for kind in KINDS {
+            let mut c1 = FsChallenger::with_hash(b"flock", kind);
+            let mut c2 = FsChallenger::with_hash(b"flock", kind);
+            c1.observe_label(b"phase-A");
+            // c2 omits the label entirely.
+            assert_ne!(c1.sample_f128(), c2.sample_f128());
+        }
     }
 
     #[test]
     fn fs_challenger_scalar_vs_slice_dont_collide() {
-        // observe_f128_slice(&[v]) must NOT produce the same state as
-        // observe_f128(v) — the length prefix and kind tag must defeat this.
-        let v = F128 { lo: 0xAB, hi: 0xCD };
-        let mut c1 = FsChallenger::new(b"flock");
-        let mut c2 = FsChallenger::new(b"flock");
-        c1.observe_f128(v);
-        c2.observe_f128_slice(&[v]);
-        assert_ne!(c1.sample_f128(), c2.sample_f128());
+        for kind in KINDS {
+            // observe_f128_slice(&[v]) must NOT produce the same state as
+            // observe_f128(v) — the length prefix and kind tag must defeat this.
+            let v = F128 { lo: 0xAB, hi: 0xCD };
+            let mut c1 = FsChallenger::with_hash(b"flock", kind);
+            let mut c2 = FsChallenger::with_hash(b"flock", kind);
+            c1.observe_f128(v);
+            c2.observe_f128_slice(&[v]);
+            assert_ne!(c1.sample_f128(), c2.sample_f128());
+        }
     }
 
     #[test]
     fn fs_challenger_two_scalars_dont_collide_with_one_slice_of_two() {
-        let a = F128 { lo: 1, hi: 2 };
-        let b = F128 { lo: 3, hi: 4 };
-        let mut c1 = FsChallenger::new(b"flock");
-        let mut c2 = FsChallenger::new(b"flock");
-        c1.observe_f128(a);
-        c1.observe_f128(b);
-        c2.observe_f128_slice(&[a, b]);
-        assert_ne!(c1.sample_f128(), c2.sample_f128());
+        for kind in KINDS {
+            let a = F128 { lo: 1, hi: 2 };
+            let b = F128 { lo: 3, hi: 4 };
+            let mut c1 = FsChallenger::with_hash(b"flock", kind);
+            let mut c2 = FsChallenger::with_hash(b"flock", kind);
+            c1.observe_f128(a);
+            c1.observe_f128(b);
+            c2.observe_f128_slice(&[a, b]);
+            assert_ne!(c1.sample_f128(), c2.sample_f128());
+        }
     }
 
     #[test]
     fn fs_challenger_sample_one_vs_sample_vec_one_differ() {
-        // Squeeze tag differs (KIND_SCALAR vs KIND_SLICE+len), so a single
-        // sample_f128 must not equal sample_f128_vec(1)[0].
-        let mut c1 = FsChallenger::new(b"flock");
-        let mut c2 = FsChallenger::new(b"flock");
-        assert_ne!(c1.sample_f128(), c2.sample_f128_vec(1)[0]);
+        for kind in KINDS {
+            // Squeeze tag differs (KIND_SCALAR vs KIND_SLICE+len), so a single
+            // sample_f128 must not equal sample_f128_vec(1)[0].
+            let mut c1 = FsChallenger::with_hash(b"flock", kind);
+            let mut c2 = FsChallenger::with_hash(b"flock", kind);
+            assert_ne!(c1.sample_f128(), c2.sample_f128_vec(1)[0]);
+        }
     }
 
     #[test]
     fn fs_challenger_sample_advances_state() {
-        // After a sample, the next observation should not collapse to the
-        // pre-sample state (the squeezed bytes are re-absorbed).
-        let mut c1 = FsChallenger::new(b"flock");
-        let mut c2 = FsChallenger::new(b"flock");
-        let _ = c1.sample_f128();
-        // c2 skips the sample.
-        c1.observe_f128(F128::ONE);
-        c2.observe_f128(F128::ONE);
-        assert_ne!(c1.sample_f128(), c2.sample_f128());
+        for kind in KINDS {
+            // After a sample, the next observation should not collapse to the
+            // pre-sample state (the squeezed bytes are re-absorbed).
+            let mut c1 = FsChallenger::with_hash(b"flock", kind);
+            let mut c2 = FsChallenger::with_hash(b"flock", kind);
+            let _ = c1.sample_f128();
+            // c2 skips the sample.
+            c1.observe_f128(F128::ONE);
+            c2.observe_f128(F128::ONE);
+            assert_ne!(c1.sample_f128(), c2.sample_f128());
+        }
     }
 }

--- a/crates/flock-core/src/hash.rs
+++ b/crates/flock-core/src/hash.rs
@@ -1,0 +1,94 @@
+//! Selection of the hash function backing a protocol component.
+//!
+//! Two components are independently configurable, and they are genuinely
+//! independent — a proof can use BLAKE3 Merkle commitments with a SHA-256
+//! Fiat-Shamir transcript, or any other combination:
+//!
+//! - the Merkle commitments, via [`crate::pcs::commit::PcsParams::merkle_hash`]
+//!   (see [`crate::merkle`]);
+//! - the Fiat-Shamir transcript and its proof-of-work grinding, via
+//!   [`crate::challenger::FsChallenger::with_hash`].
+//!
+//! Both default to SHA-256, so configs and call sites that predate the options
+//! keep their behaviour.
+
+use serde::{Deserialize, Serialize};
+
+/// Which hash function backs a component.
+///
+/// `Sha256` is the default, so existing serialized params and configs that
+/// predate these options deserialize unchanged.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HashKind {
+    #[default]
+    Sha256,
+    Blake3,
+}
+
+impl HashKind {
+    /// Config-file spelling of this hash (`"sha256"` / `"blake3"`). Inverse of
+    /// [`HashKind::parse`].
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HashKind::Sha256 => "sha256",
+            HashKind::Blake3 => "blake3",
+        }
+    }
+
+    /// Parse a config field or environment variable. Case-insensitive; rejects
+    /// anything unrecognized rather than silently falling back to SHA-256 — a
+    /// config naming a hash we do not implement must not quietly produce
+    /// proofs under a different one.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "sha256" | "sha-256" => Ok(HashKind::Sha256),
+            "blake3" => Ok(HashKind::Blake3),
+            other => Err(format!(
+                "unknown hash {other:?}: expected \"sha256\" or \"blake3\""
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for HashKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every variant, for tests that sweep both.
+    pub(crate) const ALL: [HashKind; 2] = [HashKind::Sha256, HashKind::Blake3];
+
+    #[test]
+    fn parses_and_round_trips() {
+        for kind in ALL {
+            assert_eq!(HashKind::parse(kind.as_str()).unwrap(), kind);
+            assert_eq!(kind.to_string(), kind.as_str());
+        }
+        assert_eq!(HashKind::parse("BLAKE3").unwrap(), HashKind::Blake3);
+        assert_eq!(HashKind::parse("sha-256").unwrap(), HashKind::Sha256);
+        assert_eq!(HashKind::parse("  blake3 ").unwrap(), HashKind::Blake3);
+        assert_eq!(HashKind::default(), HashKind::Sha256);
+        // An unrecognized hash must be an error, never a silent SHA-256.
+        assert!(HashKind::parse("keccak").is_err());
+        assert!(HashKind::parse("").is_err());
+    }
+
+    #[test]
+    fn serde_uses_config_spellings() {
+        for kind in ALL {
+            let json = serde_json::to_string(&kind).unwrap();
+            assert_eq!(json, format!("\"{}\"", kind.as_str()));
+            assert_eq!(
+                serde_json::from_str::<HashKind>(&json).unwrap(),
+                kind,
+                "{kind}"
+            );
+        }
+    }
+}

--- a/crates/flock-core/src/lib.rs
+++ b/crates/flock-core/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod bits;
 pub mod challenger;
 pub mod field;
+pub mod hash;
 pub mod lincheck;
 pub mod merkle;
 pub mod ntt;

--- a/crates/flock-core/src/merkle.rs
+++ b/crates/flock-core/src/merkle.rs
@@ -1,5 +1,16 @@
-//! Binary Merkle tree with SHA-256, using four-way hardware SHA interleaving
-//! on supported ARM and x86-64 targets.
+//! Binary Merkle tree over a selectable hash — SHA-256 (using four-way
+//! hardware SHA interleaving on supported ARM and x86-64 targets) or BLAKE3.
+//!
+//! The choice is a *runtime* one, carried by [`HashKind`] and threaded
+//! from the PCS parameters / Ligerito config down to the two primitives
+//! ([`hash_leaf`] and [`hash_pair`]). Everything else in this module — tree
+//! layout, path extraction, multi-proof assembly and verification — is
+//! hash-agnostic: both hashes produce 32-byte digests, so the proof format is
+//! identical either way and only the digest *values* differ.
+//!
+//! Dispatch granularity is one branch per *batch* of hashes — a whole level
+//! run for BLAKE3, four nodes for SHA-256 — not per byte, so carrying the
+//! choice at runtime costs nothing measurable.
 //!
 //! Layout for `num_leaves = 2^k` leaves:
 //!   tree[0..num_leaves]                              = leaf hashes (level k)
@@ -10,20 +21,37 @@
 //! Total nodes: `2·num_leaves − 1`. The flat layout keeps the tree contiguous
 //! in memory for cheap Merkle-path extraction later.
 //!
-//! Hash uses the [`sha2`] crate. On aarch64 with the `sha2` target feature
+//! SHA-256 uses the [`sha2`] crate. On aarch64 with the `sha2` target feature
 //! (set implicitly by `target-cpu=native` on M-series), the crate uses
 //! `sha256h`/`sha256h2`/`sha256su0`/`sha256su1` ARM crypto extension
 //! instructions; this is detected at runtime by [`cpufeatures`].
 //!
-//! No domain separation between leaf and internal hashes — this is a
-//! micro-benchmark module, not production code. A production PCS commit
-//! should prepend `0x00`/`0x01` (or equivalent) to distinguish the two
-//! pre-images and avoid second-preimage attacks via interpretation collision.
+//! BLAKE3 uses the [`blake3`] crate and BLAKE3's own tree semantics: a leaf is
+//! a non-root chaining value, an internal node is a PARENT-flagged compression
+//! of its two children. Both go through the crate's SIMD compression entry
+//! point in [`BLAKE3_BATCH`]-wide calls, so the batch always fills the widest
+//! vector the machine has (4 under NEON, 8 under AVX2, 16 under AVX-512) —
+//! see the note above [`blake3_hash_many`] for why that API and how it is
+//! kept honest.
+//!
+//! Which hash is faster is size- and target-dependent. On a target with the
+//! ARM SHA-2 or x86 SHA-NI extensions, SHA-256 wins: its two compressions per
+//! internal node run on a dedicated hardware unit, against BLAKE3's one in the
+//! vector units. `benches/merkle.rs` measures both;
+//! `benches/blake3_node_probe.rs` breaks the BLAKE3 side down per node shape.
+//!
+//! Domain separation differs between the two. BLAKE3's PARENT flag separates
+//! leaf and internal pre-images inherently. The SHA-256 construction does
+//! **not** — it has no leaf/internal tag, so it is open to second-preimage
+//! attacks via interpretation collision, and a production PCS commit should
+//! prepend `0x00`/`0x01` (or equivalent) before relying on it.
 
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 
 pub type Hash = [u8; 32];
+
+pub use crate::hash::HashKind;
 
 #[cfg(any(
     all(target_arch = "aarch64", target_feature = "sha2"),
@@ -71,11 +99,12 @@ mod sha256x4;
 #[path = "merkle/x86_64.rs"]
 mod sha256x4;
 
-/// Global SHA-256 call/compression counters, enabled with
+/// Global Merkle hash call/compression counters, enabled with
 /// `--features hash-count` (e.g. by `benches/verifier_hash_count.rs`).
 /// Relaxed atomics — exact totals, no ordering guarantees across threads.
 #[cfg(feature = "hash-count")]
 pub mod hash_count {
+    use super::HashKind;
     use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
 
     pub static LEAF_CALLS: AtomicU64 = AtomicU64::new(0);
@@ -89,14 +118,35 @@ pub mod hash_count {
         ((len + 9).div_ceil(64)) as u64
     }
 
+    /// BLAKE3 compression count for a one-shot hash of `len` bytes: one
+    /// compression per 64-byte block (a final partial block still costs one,
+    /// and the empty input costs one), plus one parent compression per
+    /// internal node of the chunk tree — `c − 1` for `c` 1 KiB chunks.
+    #[inline]
+    pub fn blake3_blocks(len: usize) -> u64 {
+        let blocks = (len.div_ceil(64)).max(1) as u64;
+        let chunks = (len.div_ceil(1024)).max(1) as u64;
+        blocks + (chunks - 1)
+    }
+
+    /// Compression count for a one-shot hash of `len` bytes under `kind`.
+    #[inline]
+    pub fn blocks(kind: HashKind, len: usize) -> u64 {
+        match kind {
+            HashKind::Sha256 => sha256_blocks(len),
+            HashKind::Blake3 => blake3_blocks(len),
+        }
+    }
+
     pub fn reset() {
         LEAF_CALLS.store(0, Relaxed);
         LEAF_COMPRESSIONS.store(0, Relaxed);
         PAIR_CALLS.store(0, Relaxed);
     }
 
-    /// (leaf_calls, leaf_compressions, pair_calls). Each pair hash is
-    /// 2 compressions (64 B payload + padding block).
+    /// (leaf_calls, leaf_compressions, pair_calls). A pair hash is
+    /// 2 compressions under SHA-256 (64 B payload + padding block) and
+    /// 1 under BLAKE3 (a single 64-byte block, no length padding).
     pub fn snapshot() -> (u64, u64, u64) {
         (
             LEAF_CALLS.load(Relaxed),
@@ -106,27 +156,357 @@ pub mod hash_count {
     }
 }
 
+// ---------------------------------------------------------------------------
+// BLAKE3 tree primitives.
+//
+// The BLAKE3 Merkle tree uses BLAKE3's *own* tree semantics rather than
+// `blake3::hash` over concatenated bytes:
+//
+//   leaf   = Hasher::new().update(leaf_bytes).finalize_non_root()
+//   parent = merge_subtrees_non_root(left_cv, right_cv, Mode::Hash)
+//
+// Two reasons. First, correctness: these are non-root chaining values, which is
+// what interior tree nodes are supposed to be, and BLAKE3's PARENT flag gives
+// leaf/parent domain separation for free — the property this module's header
+// notes the SHA-256 construction lacks. Second, speed: both map onto BLAKE3's
+// batched compression entry point, which is ~2× the scalar API (measured by
+// `benches/blake3_node_probe.rs`).
+//
+// The two functions below are the *specification* — stable, public `blake3`
+// API. The `blake3_hash_many_*` paths are optimizations that must agree with
+// them bit-for-bit; `blake3_batched_matches_scalar_spec` in this module's
+// tests is what holds them to it.
+//
+// NOTE — this deliberately differs from the sibling implementation on
+// TomWambsgans/flock `blake3-pcs`, which defines a leaf as `blake3::hash(x)`
+// and a parent as `blake3::hash(l ‖ r)` (root-flagged one-shot hashes). That
+// contract is simpler and reproducible with plain `blake3::hash`; this one
+// buys leaf/parent domain separation instead, which the SHA-256 construction
+// lacks. The two produce *different digests* — a tree built under one does not
+// verify under the other, so the choice has to be made once, project-wide.
+// Both batch equally well, so it is not a performance trade.
+// ---------------------------------------------------------------------------
+
+/// Non-root chaining value of one BLAKE3 leaf, of any length.
+#[inline]
+fn blake3_leaf_cv(data: &[u8]) -> Hash {
+    use blake3::hazmat::HasherExt;
+    blake3::Hasher::new().update(data).finalize_non_root()
+}
+
+/// BLAKE3 parent-node chaining value of two children.
+#[inline]
+fn blake3_parent_cv(left: &Hash, right: &Hash) -> Hash {
+    blake3::hazmat::merge_subtrees_non_root(left, right, blake3::hazmat::Mode::Hash)
+}
+
 /// Hash one leaf of arbitrary byte length.
 #[inline]
-pub fn hash_leaf(data: &[u8]) -> Hash {
+pub fn hash_leaf(data: &[u8], kind: HashKind) -> Hash {
     #[cfg(feature = "hash-count")]
     {
         use std::sync::atomic::Ordering::Relaxed;
         hash_count::LEAF_CALLS.fetch_add(1, Relaxed);
-        hash_count::LEAF_COMPRESSIONS.fetch_add(hash_count::sha256_blocks(data.len()), Relaxed);
+        hash_count::LEAF_COMPRESSIONS.fetch_add(hash_count::blocks(kind, data.len()), Relaxed);
     }
-    Sha256::digest(data).into()
+    match kind {
+        HashKind::Sha256 => Sha256::digest(data).into(),
+        HashKind::Blake3 => blake3_leaf_cv(data),
+    }
 }
 
 /// Hash a pair of children into a parent node (64 B → 32 B).
 #[inline]
-pub fn hash_pair(left: &Hash, right: &Hash) -> Hash {
+pub fn hash_pair(left: &Hash, right: &Hash, kind: HashKind) -> Hash {
     #[cfg(feature = "hash-count")]
     hash_count::PAIR_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let mut h = Sha256::new();
-    h.update(left);
-    h.update(right);
-    h.finalize().into()
+    match kind {
+        HashKind::Sha256 => {
+            let mut h = Sha256::new();
+            h.update(left);
+            h.update(right);
+            h.finalize().into()
+        }
+        HashKind::Blake3 => blake3_parent_cv(left, right),
+    }
+}
+
+/// SHA-256 of four equal-length inputs, four-way interleaved across the
+/// hardware SHA unit where the target supports it.
+///
+/// Digests are byte-identical to `Sha256::digest` either way; the fallback
+/// exists so callers need not repeat the `cfg` test.
+#[cfg(any(
+    all(target_arch = "aarch64", target_feature = "sha2"),
+    all(target_arch = "x86_64", target_feature = "sha")
+))]
+#[inline]
+fn sha256_hash4(inputs: [&[u8]; 4], outs: &mut [Hash]) {
+    sha256x4::hash4_equal_len(inputs, outs);
+}
+
+#[cfg(not(any(
+    all(target_arch = "aarch64", target_feature = "sha2"),
+    all(target_arch = "x86_64", target_feature = "sha")
+)))]
+#[inline]
+fn sha256_hash4(inputs: [&[u8]; 4], outs: &mut [Hash]) {
+    for (out, input) in outs.iter_mut().zip(inputs) {
+        *out = Sha256::digest(input).into();
+    }
+}
+
+// --- BLAKE3 batched compression -------------------------------------------
+//
+// `blake3::platform` is `#[doc(hidden)]` and labelled "undocumented and
+// unstable". We depend on it deliberately: it is the only way to reach the
+// crate's SIMD-batched compression (4-way under NEON, 8/16-way under
+// AVX2/AVX-512), worth ~2× over the scalar API on our node shapes, and the
+// alternative — hand-writing a 4-way NEON BLAKE3 alongside `merkle/aarch64.rs`
+// — is a great deal more code to own and audit.
+//
+// The exposure is bounded: every batched result is checked against the stable
+// `hazmat` spec above in this module's tests, so a semantic change in a
+// `blake3` update fails the suite rather than silently altering commitments,
+// and an API removal fails the build. Nothing here is reachable if the
+// equality does not hold.
+
+/// BLAKE3's IV — the key words for unkeyed hashing. Fixed by the spec.
+const BLAKE3_IV: [u32; 8] = [
+    0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
+];
+
+/// BLAKE3 domain flags, fixed by the spec.
+const BLAKE3_CHUNK_START: u8 = 1;
+const BLAKE3_CHUNK_END: u8 = 2;
+const BLAKE3_PARENT: u8 = 4;
+
+/// Cached SIMD platform. `Platform::detect()` is cheap but not free, and the
+/// tree build reaches the batched path once per [`BLAKE3_BATCH`] nodes.
+fn blake3_platform() -> blake3::platform::Platform {
+    use std::sync::OnceLock;
+    static PLATFORM: OnceLock<blake3::platform::Platform> = OnceLock::new();
+    *PLATFORM.get_or_init(blake3::platform::Platform::detect)
+}
+
+/// Inputs handed to `hash_many` per call.
+///
+/// Sized to the widest `simd_degree` that exists — 4 under NEON, 8 under AVX2,
+/// 16 under AVX-512 — so the batch fills the machine's vector rather than
+/// leaving lanes idle. This is portability insurance, not a local win: swept
+/// over 4/8/16/64/256 on an M4 Max (NEON, degree 4) the spread was ~1-5%, i.e.
+/// inside run-to-run noise, with 16 marginally best. It should matter on an
+/// AVX-512 host, where a 4-input call can only ever fill a quarter of the
+/// vector; that has not been measured here.
+const BLAKE3_BATCH: usize = 16;
+
+/// Drive `hash_many` over `data`, a run of `out.len()` contiguous `N`-byte
+/// messages, in [`BLAKE3_BATCH`]-wide calls. `flags`/`start`/`end` select the
+/// node type (chunk vs parent).
+///
+/// Allocation-free: the pointer array lives on the stack, so unlike a
+/// `Vec`-per-call formulation this costs nothing per batch.
+#[inline]
+fn blake3_hash_many<const N: usize>(
+    data: &[u8],
+    out: &mut [Hash],
+    flags: u8,
+    flags_start: u8,
+    flags_end: u8,
+) {
+    debug_assert_eq!(data.len(), out.len() * N);
+    let plat = blake3_platform();
+    for (outs, msgs) in out
+        .chunks_mut(BLAKE3_BATCH)
+        .zip(data.chunks(BLAKE3_BATCH * N))
+    {
+        let n = outs.len();
+        // Fill a stack array of input pointers. Slot 0 seeds the array so the
+        // unused tail (never passed to `hash_many`, which sees `&inputs[..n]`)
+        // holds a valid reference rather than uninitialized memory.
+        let first: &[u8; N] = msgs[..N].try_into().unwrap();
+        let mut inputs: [&[u8; N]; BLAKE3_BATCH] = [first; BLAKE3_BATCH];
+        for (i, slot) in inputs[..n].iter_mut().enumerate() {
+            *slot = msgs[i * N..(i + 1) * N].try_into().unwrap();
+        }
+        // SAFETY: `Hash` is `[u8; 32]`, so `outs` is exactly `n * 32` bytes of
+        // initialized, contiguous, unpadded storage — the amount `hash_many`
+        // writes for `n` inputs.
+        let out_bytes: &mut [u8] =
+            unsafe { core::slice::from_raw_parts_mut(outs.as_mut_ptr() as *mut u8, n * 32) };
+        plat.hash_many(
+            &inputs[..n],
+            &BLAKE3_IV,
+            0,
+            blake3::IncrementCounter::No,
+            flags,
+            flags_start,
+            flags_end,
+            out_bytes,
+        );
+    }
+}
+
+/// Batched BLAKE3 leaves: `out.len()` messages of `leaf_size` bytes, laid out
+/// contiguously in `data`. Equivalent to [`blake3_leaf_cv`] per leaf.
+///
+/// The batched entry point compresses whole 64-byte blocks of a single chunk,
+/// so it applies only when `leaf_size` is a multiple of 64 and at most
+/// `CHUNK_LEN` (1024) — which covers the real commit geometry, where a leaf is
+/// `16 << log_batch_size` bytes. Returns `false` for any other size, leaving
+/// the caller to hash leaves one at a time.
+fn blake3_hash_many_leaves(data: &[u8], leaf_size: usize, out: &mut [Hash]) -> bool {
+    macro_rules! dispatch {
+        ($($n:literal),+ $(,)?) => {
+            match leaf_size {
+                $($n => {
+                    blake3_hash_many::<$n>(
+                        data, out, 0, BLAKE3_CHUNK_START, BLAKE3_CHUNK_END,
+                    );
+                    true
+                })+
+                _ => false,
+            }
+        };
+    }
+    // Leaf sizes are `16 << log_batch_size`, so only powers of two arise.
+    dispatch!(64, 128, 256, 512, 1024)
+}
+
+/// Whether [`blake3_hash_many_leaves`] can batch this leaf size. Must list
+/// exactly the sizes that function dispatches on — `blake3_batch_dispatch_agrees`
+/// holds the two together.
+#[inline]
+fn blake3_leaf_size_is_batchable(leaf_size: usize) -> bool {
+    matches!(leaf_size, 64 | 128 | 256 | 512 | 1024)
+}
+
+/// Batched BLAKE3 parent nodes: `data` is `out.len()` contiguous 64-byte
+/// (left ‖ right) child pairs. Equivalent to [`blake3_parent_cv`] per node.
+#[inline]
+fn blake3_hash_many_parents(data: &[u8], out: &mut [Hash]) {
+    blake3_hash_many::<64>(data, out, BLAKE3_PARENT, 0, 0);
+}
+
+/// Hash a run of `out.len()` equal-size leaves from `data` under `kind`.
+///
+/// The two hashes batch differently, so they take different shapes here:
+/// SHA-256's kernel is inherently four-wide, while BLAKE3 wants the widest
+/// batch the machine offers. Both are rayon-parallel and both are
+/// byte-identical to calling [`hash_leaf`] on each leaf.
+fn hash_leaves(data: &[u8], leaf_size: usize, out: &mut [Hash], kind: HashKind) {
+    #[cfg(feature = "hash-count")]
+    {
+        use std::sync::atomic::Ordering::Relaxed;
+        hash_count::LEAF_CALLS.fetch_add(out.len() as u64, Relaxed);
+        hash_count::LEAF_COMPRESSIONS.fetch_add(
+            out.len() as u64 * hash_count::blocks(kind, leaf_size),
+            Relaxed,
+        );
+    }
+    match kind {
+        HashKind::Blake3 if blake3_leaf_size_is_batchable(leaf_size) => {
+            out.par_chunks_mut(BLAKE3_GROUP)
+                .zip(data.par_chunks(BLAKE3_GROUP * leaf_size))
+                .for_each(|(outs, leaves)| {
+                    blake3_hash_many_leaves(leaves, leaf_size, outs);
+                });
+        }
+        HashKind::Blake3 => out
+            .par_iter_mut()
+            .zip(data.par_chunks(leaf_size))
+            .for_each(|(o, leaf)| *o = blake3_leaf_cv(leaf)),
+        HashKind::Sha256 => {
+            out.par_chunks_mut(4)
+                .zip(data.par_chunks(4 * leaf_size))
+                .for_each(|(outs, leaves)| {
+                    if outs.len() == 4 {
+                        sha256_hash4(
+                            [
+                                &leaves[..leaf_size],
+                                &leaves[leaf_size..2 * leaf_size],
+                                &leaves[2 * leaf_size..3 * leaf_size],
+                                &leaves[3 * leaf_size..],
+                            ],
+                            outs,
+                        );
+                    } else {
+                        for (out, leaf) in outs.iter_mut().zip(leaves.chunks(leaf_size)) {
+                            *out = Sha256::digest(leaf).into();
+                        }
+                    }
+                });
+        }
+    }
+}
+
+/// Nodes per rayon task in the batched BLAKE3 paths: enough to amortize task
+/// dispatch over many `hash_many` calls, small enough to stay cache-resident.
+const BLAKE3_GROUP: usize = 1024;
+
+/// Hash one internal level: `write[i] = hash_pair(read[2i], read[2i+1])`.
+///
+/// Children are contiguous 64-byte spans of the level below, so both hashes
+/// read them zero-copy. Small upper levels can't fill the cores, so a rayon
+/// dispatch per level costs more than the hashing itself (~3× at the top of a
+/// 2^18 tree); those are hashed serially — still SIMD-batched — and only the
+/// wide lower levels fan out.
+fn hash_pairs_level(read: &[Hash], write: &mut [Hash], kind: HashKind) {
+    #[cfg(feature = "hash-count")]
+    hash_count::PAIR_CALLS.fetch_add(write.len() as u64, std::sync::atomic::Ordering::Relaxed);
+    // SAFETY: `Hash` is `[u8; 32]`, so a slice of `n` hashes is exactly `32n`
+    // initialized bytes with no padding.
+    let read_bytes: &[u8] =
+        unsafe { core::slice::from_raw_parts(read.as_ptr() as *const u8, read.len() * 32) };
+    const SERIAL_LEVEL_NODES: usize = 1024;
+    let serial = write.len() <= SERIAL_LEVEL_NODES;
+
+    match kind {
+        HashKind::Blake3 => {
+            if serial {
+                blake3_hash_many_parents(read_bytes, write);
+            } else {
+                write
+                    .par_chunks_mut(BLAKE3_GROUP)
+                    .zip(read_bytes.par_chunks(BLAKE3_GROUP * 64))
+                    .for_each(|(outs, children)| blake3_hash_many_parents(children, outs));
+            }
+        }
+        HashKind::Sha256 => {
+            let hash_quad = |outs: &mut [Hash], children: &[u8]| {
+                if outs.len() == 4 {
+                    sha256_hash4(
+                        [
+                            &children[..64],
+                            &children[64..128],
+                            &children[128..192],
+                            &children[192..256],
+                        ],
+                        outs,
+                    );
+                } else {
+                    for (i, out) in outs.iter_mut().enumerate() {
+                        let l: &Hash = children[i * 64..i * 64 + 32].try_into().unwrap();
+                        let r: &Hash = children[i * 64 + 32..i * 64 + 64].try_into().unwrap();
+                        let mut h = Sha256::new();
+                        h.update(l);
+                        h.update(r);
+                        *out = h.finalize().into();
+                    }
+                }
+            };
+            if serial {
+                for (outs, children) in write.chunks_mut(4).zip(read_bytes.chunks(256)) {
+                    hash_quad(outs, children);
+                }
+            } else {
+                write
+                    .par_chunks_mut(4)
+                    .zip(read_bytes.par_chunks(256))
+                    .for_each(|(outs, children)| hash_quad(outs, children));
+            }
+        }
+    }
 }
 
 /// Compute the Merkle root of `data` split into `num_leaves` equal-sized leaves.
@@ -134,14 +514,14 @@ pub fn hash_pair(left: &Hash, right: &Hash) -> Hash {
 /// Multi-threaded via rayon. `num_leaves` must be a power of two and divide
 /// `data.len()`. Returns the 32-byte root. The intermediate tree is allocated
 /// and dropped; if you need it for path opening, use [`merkle_tree`] instead.
-pub fn merkle_root(data: &[u8], num_leaves: usize) -> Hash {
-    let tree = merkle_tree(data, num_leaves);
+pub fn merkle_root(data: &[u8], num_leaves: usize, kind: HashKind) -> Hash {
+    let tree = merkle_tree(data, num_leaves, kind);
     tree[tree.len() - 1]
 }
 
 /// Compute the full Merkle tree (flat layout, see module docs) for `data`
-/// split into `num_leaves` equal-sized leaves.
-pub fn merkle_tree(data: &[u8], num_leaves: usize) -> Vec<Hash> {
+/// split into `num_leaves` equal-sized leaves, hashed under `kind`.
+pub fn merkle_tree(data: &[u8], num_leaves: usize, kind: HashKind) -> Vec<Hash> {
     assert!(
         num_leaves.is_power_of_two() && num_leaves > 0,
         "num_leaves must be power of 2"
@@ -159,50 +539,8 @@ pub fn merkle_tree(data: &[u8], num_leaves: usize) -> Vec<Hash> {
     // was just written) and writes itself.
     let mut tree: Vec<Hash> = crate::alloc_uninit_vec(total_nodes);
 
-    // 1. Leaves — fully parallel; 4-way interleaved SHA where available.
-    #[cfg(any(
-        all(target_arch = "aarch64", target_feature = "sha2"),
-        all(target_arch = "x86_64", target_feature = "sha")
-    ))]
-    {
-        tree[..num_leaves]
-            .par_chunks_mut(4)
-            .zip(data.par_chunks(4 * leaf_size))
-            .for_each(|(outs, leaves)| {
-                if outs.len() == 4 {
-                    #[cfg(feature = "hash-count")]
-                    {
-                        use std::sync::atomic::Ordering::Relaxed;
-                        hash_count::LEAF_CALLS.fetch_add(4, Relaxed);
-                        hash_count::LEAF_COMPRESSIONS
-                            .fetch_add(4 * hash_count::sha256_blocks(leaf_size), Relaxed);
-                    }
-                    sha256x4::hash4_equal_len(
-                        [
-                            &leaves[..leaf_size],
-                            &leaves[leaf_size..2 * leaf_size],
-                            &leaves[2 * leaf_size..3 * leaf_size],
-                            &leaves[3 * leaf_size..],
-                        ],
-                        outs,
-                    );
-                } else {
-                    for (out, leaf) in outs.iter_mut().zip(leaves.chunks(leaf_size)) {
-                        *out = hash_leaf(leaf);
-                    }
-                }
-            });
-    }
-    #[cfg(not(any(
-        all(target_arch = "aarch64", target_feature = "sha2"),
-        all(target_arch = "x86_64", target_feature = "sha")
-    )))]
-    {
-        tree[..num_leaves]
-            .par_iter_mut()
-            .zip(data.par_chunks(leaf_size))
-            .for_each(|(out, leaf)| *out = hash_leaf(leaf));
-    }
+    // 1. Leaves — fully parallel, SIMD-batched across leaves where possible.
+    hash_leaves(data, leaf_size, &mut tree[..num_leaves], kind);
 
     // 2. Internal levels — parallel within a level, sequential across levels.
     let mut read_start = 0usize;
@@ -214,62 +552,7 @@ pub fn merkle_tree(data: &[u8], num_leaves: usize) -> Vec<Hash> {
         let (read, rest) = tree[read_start..].split_at_mut(read_len);
         let write = &mut rest[..next_len];
 
-        // 4 parents at a time = 8 contiguous children = 256 contiguous bytes;
-        // each parent hashes its 64-byte child pair, interleaved 4-way.
-        #[cfg(any(
-            all(target_arch = "aarch64", target_feature = "sha2"),
-            all(target_arch = "x86_64", target_feature = "sha")
-        ))]
-        {
-            let read_bytes: &[u8] =
-                unsafe { core::slice::from_raw_parts(read.as_ptr() as *const u8, read.len() * 32) };
-            let hash_quad = |outs: &mut [Hash], children: &[u8]| {
-                if outs.len() == 4 {
-                    #[cfg(feature = "hash-count")]
-                    hash_count::PAIR_CALLS.fetch_add(4, std::sync::atomic::Ordering::Relaxed);
-                    sha256x4::hash4_equal_len(
-                        [
-                            &children[..64],
-                            &children[64..128],
-                            &children[128..192],
-                            &children[192..256],
-                        ],
-                        outs,
-                    );
-                } else {
-                    for (i, out) in outs.iter_mut().enumerate() {
-                        let l: &Hash = children[i * 64..i * 64 + 32].try_into().unwrap();
-                        let r: &Hash = children[i * 64 + 32..i * 64 + 64].try_into().unwrap();
-                        *out = hash_pair(l, r);
-                    }
-                }
-            };
-            // Small upper levels can't fill the cores (≤ SERIAL_LEVEL_NODES / 4
-            // SHA-x4 tasks), so a rayon dispatch per level costs more than the
-            // hashing itself (~3× at the top of a 2^18 tree). Hash them serially
-            // — still 4-way SIMD — and only fan out the wide lower levels.
-            const SERIAL_LEVEL_NODES: usize = 1024;
-            if write.len() <= SERIAL_LEVEL_NODES {
-                for (outs, children) in write.chunks_mut(4).zip(read_bytes.chunks(256)) {
-                    hash_quad(outs, children);
-                }
-            } else {
-                write
-                    .par_chunks_mut(4)
-                    .zip(read_bytes.par_chunks(256))
-                    .for_each(|(outs, children)| hash_quad(outs, children));
-            }
-        }
-        #[cfg(not(any(
-            all(target_arch = "aarch64", target_feature = "sha2"),
-            all(target_arch = "x86_64", target_feature = "sha")
-        )))]
-        {
-            write
-                .par_iter_mut()
-                .enumerate()
-                .for_each(|(i, out)| *out = hash_pair(&read[2 * i], &read[2 * i + 1]));
-        }
+        hash_pairs_level(read, write, kind);
 
         read_start += read_len;
         read_len = next_len;
@@ -280,7 +563,7 @@ pub fn merkle_tree(data: &[u8], num_leaves: usize) -> Vec<Hash> {
 
 /// Sequential (single-threaded) version of [`merkle_tree`]. Used for
 /// benchmark comparison and as the test oracle.
-pub fn merkle_tree_sequential(data: &[u8], num_leaves: usize) -> Vec<Hash> {
+pub fn merkle_tree_sequential(data: &[u8], num_leaves: usize, kind: HashKind) -> Vec<Hash> {
     assert!(num_leaves.is_power_of_two() && num_leaves > 0);
     assert_eq!(data.len() % num_leaves, 0);
 
@@ -289,7 +572,7 @@ pub fn merkle_tree_sequential(data: &[u8], num_leaves: usize) -> Vec<Hash> {
     let mut tree: Vec<Hash> = crate::alloc_uninit_vec(total_nodes);
 
     for (i, leaf) in data.chunks(leaf_size).enumerate() {
-        tree[i] = hash_leaf(leaf);
+        tree[i] = hash_leaf(leaf, kind);
     }
     let mut read_start = 0usize;
     let mut read_len = num_leaves;
@@ -298,7 +581,7 @@ pub fn merkle_tree_sequential(data: &[u8], num_leaves: usize) -> Vec<Hash> {
         for i in 0..next_len {
             let left = tree[read_start + 2 * i];
             let right = tree[read_start + 2 * i + 1];
-            tree[read_start + read_len + i] = hash_pair(&left, &right);
+            tree[read_start + read_len + i] = hash_pair(&left, &right, kind);
         }
         read_start += read_len;
         read_len = next_len;
@@ -341,7 +624,13 @@ pub fn merkle_proof(tree: &[Hash], num_leaves: usize, index: usize) -> Vec<Hash>
 
 /// Verify a Merkle opening: recomputes the root from `leaf_hash`, the path,
 /// and the leaf index. Returns true iff the recomputed root matches `root`.
-pub fn verify_merkle_proof(root: &Hash, leaf_hash: &Hash, index: usize, proof: &[Hash]) -> bool {
+pub fn verify_merkle_proof(
+    root: &Hash,
+    leaf_hash: &Hash,
+    index: usize,
+    proof: &[Hash],
+    kind: HashKind,
+) -> bool {
     let mut acc = *leaf_hash;
     let mut idx = index;
     for sibling in proof {
@@ -351,7 +640,7 @@ pub fn verify_merkle_proof(root: &Hash, leaf_hash: &Hash, index: usize, proof: &
         } else {
             (*sibling, acc)
         };
-        acc = hash_pair(&left, &right);
+        acc = hash_pair(&left, &right, kind);
         idx >>= 1;
     }
     &acc == root
@@ -429,6 +718,7 @@ pub fn verify_merkle_multi_proof(
     sorted_unique_positions: &[usize],
     leaf_hashes: &[Hash],
     proof: &[Hash],
+    kind: HashKind,
 ) -> bool {
     if !num_leaves.is_power_of_two() || num_leaves == 0 {
         return false;
@@ -483,7 +773,7 @@ pub fn verify_merkle_multi_proof(
                 i += 1;
                 if p & 1 == 0 { (h, sib) } else { (sib, h) }
             };
-            next.push((p >> 1, hash_pair(&left, &right)));
+            next.push((p >> 1, hash_pair(&left, &right, kind)));
         }
         active = next;
         level_len >>= 1;
@@ -501,27 +791,173 @@ pub fn verify_merkle_multi_proof(
 mod tests {
     use super::*;
 
+    /// Every structural test runs against both hashes: the tree, path and
+    /// multi-proof logic is hash-agnostic, so anything true of one must hold
+    /// for the other.
+    const KINDS: [HashKind; 2] = [HashKind::Sha256, HashKind::Blake3];
+
     #[test]
     fn two_leaves_matches_hand_computation() {
         // Two 8-byte leaves: [0,1,2,3,4,5,6,7] and [8,9,10,11,12,13,14,15].
         let data: Vec<u8> = (0..16).collect();
-        let tree = merkle_tree(&data, 2);
-        assert_eq!(tree.len(), 3); // 2 leaves + 1 root
+        for kind in KINDS {
+            let tree = merkle_tree(&data, 2, kind);
+            assert_eq!(tree.len(), 3); // 2 leaves + 1 root
 
-        let h0 = hash_leaf(&data[0..8]);
-        let h1 = hash_leaf(&data[8..16]);
-        let root = hash_pair(&h0, &h1);
+            let h0 = hash_leaf(&data[0..8], kind);
+            let h1 = hash_leaf(&data[8..16], kind);
+            let root = hash_pair(&h0, &h1, kind);
 
-        assert_eq!(tree[0], h0);
-        assert_eq!(tree[1], h1);
-        assert_eq!(tree[2], root);
+            assert_eq!(tree[0], h0, "{kind}");
+            assert_eq!(tree[1], h1, "{kind}");
+            assert_eq!(tree[2], root, "{kind}");
+        }
+    }
+
+    /// The primitives must agree with the reference APIs of the underlying
+    /// crates — this is what pins the digests to the real hash functions
+    /// rather than merely to themselves.
+    #[test]
+    fn primitives_match_reference_implementations() {
+        use blake3::hazmat::HasherExt;
+        let data: Vec<u8> = (0..=255u8).cycle().take(3000).collect();
+
+        // SHA-256: a plain one-shot digest.
+        assert_eq!(
+            hash_leaf(&data, HashKind::Sha256),
+            <[u8; 32]>::from(Sha256::digest(&data))
+        );
+        let (l, r) = ([7u8; 32], [9u8; 32]);
+        let cat: Vec<u8> = l.iter().chain(r.iter()).copied().collect();
+        assert_eq!(
+            hash_pair(&l, &r, HashKind::Sha256),
+            hash_leaf(&cat, HashKind::Sha256),
+            "sha256 pair hash is the digest of the concatenation"
+        );
+
+        // BLAKE3: non-root chaining values, per BLAKE3's own tree semantics.
+        assert_eq!(
+            hash_leaf(&data, HashKind::Blake3),
+            blake3::Hasher::new().update(&data).finalize_non_root()
+        );
+        assert_eq!(
+            hash_pair(&l, &r, HashKind::Blake3),
+            blake3::hazmat::merge_subtrees_non_root(&l, &r, blake3::hazmat::Mode::Hash)
+        );
+        // Deliberately NOT `blake3::hash` — that is the root finalization, and
+        // interior tree nodes must not be root hashes.
+        assert_ne!(
+            hash_leaf(&data, HashKind::Blake3),
+            *blake3::hash(&data).as_bytes(),
+            "leaf CVs must be non-root"
+        );
+    }
+
+    /// BLAKE3's PARENT flag domain-separates internal nodes from leaves, so a
+    /// parent hash is not reproducible as a leaf hash of the concatenation.
+    /// This is the second-preimage-via-reinterpretation gap that the SHA-256
+    /// construction (see module header) still has.
+    #[test]
+    fn blake3_separates_leaf_and_parent_domains() {
+        let (l, r) = ([7u8; 32], [9u8; 32]);
+        let cat: Vec<u8> = l.iter().chain(r.iter()).copied().collect();
+        assert_ne!(
+            hash_pair(&l, &r, HashKind::Blake3),
+            hash_leaf(&cat, HashKind::Blake3),
+            "PARENT flag must separate the two domains"
+        );
+        // The SHA-256 construction does not have this property. Asserted so the
+        // difference is recorded rather than assumed either way.
+        assert_eq!(
+            hash_pair(&l, &r, HashKind::Sha256),
+            hash_leaf(&cat, HashKind::Sha256),
+        );
+    }
+
+    /// The batched BLAKE3 path (`blake3::platform`, an unstable API) must agree
+    /// bit-for-bit with the stable `hazmat` spec. This is what makes depending
+    /// on that API safe: if a `blake3` update changes its semantics, this fails
+    /// rather than silently changing every commitment we produce.
+    #[test]
+    fn blake3_batched_matches_scalar_spec() {
+        // Node counts chosen around `BLAKE3_BATCH` (64): a single node, a
+        // partial batch, exactly one batch, one past it, and several batches
+        // with a partial tail. A width bug in the batch loop shows up here.
+        let counts = [1usize, 5, 63, 64, 65, 200];
+
+        // Parents.
+        for n in counts {
+            let children: Vec<u8> = (0..=255u8).cycle().take(n * 64).collect();
+            let mut batched = vec![[0u8; 32]; n];
+            blake3_hash_many_parents(&children, &mut batched);
+            for i in 0..n {
+                let l: &Hash = children[i * 64..i * 64 + 32].try_into().unwrap();
+                let r: &Hash = children[i * 64 + 32..i * 64 + 64].try_into().unwrap();
+                assert_eq!(batched[i], blake3_parent_cv(l, r), "parent {i} of {n}");
+            }
+        }
+
+        // Leaves, at every size the batched path claims to handle.
+        for leaf_size in [64usize, 128, 256, 512, 1024] {
+            for n in counts {
+                let data: Vec<u8> = (0..=255u8).cycle().take(n * leaf_size).collect();
+                let mut batched = vec![[0u8; 32]; n];
+                assert!(
+                    blake3_hash_many_leaves(&data, leaf_size, &mut batched),
+                    "size {leaf_size} should take the batched path"
+                );
+                for i in 0..n {
+                    assert_eq!(
+                        batched[i],
+                        blake3_leaf_cv(&data[i * leaf_size..(i + 1) * leaf_size]),
+                        "leaf {i} of {n} at size {leaf_size}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The cheap `blake3_leaf_size_is_batchable` predicate — which decides
+    /// which code path `hash_leaves` takes — must agree exactly with what
+    /// `blake3_hash_many_leaves` actually dispatches on. If they drift, leaves
+    /// either silently take the slow path or hit an unreachable arm.
+    #[test]
+    fn blake3_batch_dispatch_agrees() {
+        for leaf_size in [
+            1usize, 16, 32, 48, 63, 64, 65, 100, 128, 192, 256, 512, 1000, 1024, 1088, 2048,
+        ] {
+            let data = vec![0u8; leaf_size];
+            let mut out = [[0u8; 32]; 1];
+            let dispatched = blake3_hash_many_leaves(&data, leaf_size, &mut out);
+            assert_eq!(
+                dispatched,
+                blake3_leaf_size_is_batchable(leaf_size),
+                "predicate and dispatch disagree at leaf_size={leaf_size}"
+            );
+        }
+    }
+
+    /// The whole point of the option: the two hashes must actually produce
+    /// different commitments.
+    #[test]
+    fn the_two_kinds_produce_different_roots() {
+        let data = random_data(64, 32, 11);
+        assert_ne!(
+            merkle_root(&data, 64, HashKind::Sha256),
+            merkle_root(&data, 64, HashKind::Blake3)
+        );
     }
 
     #[test]
     fn one_leaf_root_is_the_leaf_hash() {
         let data: Vec<u8> = (0..32).collect();
-        let root = merkle_root(&data, 1);
-        assert_eq!(root, hash_leaf(&data));
+        for kind in KINDS {
+            assert_eq!(
+                merkle_root(&data, 1, kind),
+                hash_leaf(&data, kind),
+                "{kind}"
+            );
+        }
     }
 
     #[test]
@@ -534,25 +970,39 @@ mod tests {
         for (i, b) in data.iter_mut().enumerate() {
             *b = ((i.wrapping_mul(0x9E3779B9)) & 0xff) as u8;
         }
-        let par = merkle_tree(&data, n_leaves);
-        let seq = merkle_tree_sequential(&data, n_leaves);
-        assert_eq!(par, seq);
+        for kind in KINDS {
+            let par = merkle_tree(&data, n_leaves, kind);
+            let seq = merkle_tree_sequential(&data, n_leaves, kind);
+            assert_eq!(par, seq, "{kind}");
+        }
     }
 
     /// Leaf sizes chosen to hit every SHA-256 tail shape in the 4-way
     /// interleaved path: rem = 0 (block-aligned), rem < 56 (one tail block),
     /// and rem ≥ 56 (two tail blocks). Also a non-multiple-of-4 leaf count
-    /// for the remainder fallback.
+    /// for the remainder fallback, and — for BLAKE3 — leaf sizes either side
+    /// of its 1 KiB chunk boundary, where its internal chunk tree kicks in.
     #[test]
     fn parallel_matches_sequential_tail_shapes() {
-        for (n_leaves, leaf_size) in [(64, 1024), (64, 100), (64, 60), (64, 56), (2, 48), (16, 1)] {
+        for (n_leaves, leaf_size) in [
+            (64, 1024),
+            (64, 1025),
+            (64, 2048),
+            (64, 100),
+            (64, 60),
+            (64, 56),
+            (2, 48),
+            (16, 1),
+        ] {
             let mut data = vec![0u8; n_leaves * leaf_size];
             for (i, b) in data.iter_mut().enumerate() {
                 *b = ((i.wrapping_mul(0x6C8E944D)) & 0xff) as u8;
             }
-            let par = merkle_tree(&data, n_leaves);
-            let seq = merkle_tree_sequential(&data, n_leaves);
-            assert_eq!(par, seq, "n_leaves={n_leaves} leaf_size={leaf_size}");
+            for kind in KINDS {
+                let par = merkle_tree(&data, n_leaves, kind);
+                let seq = merkle_tree_sequential(&data, n_leaves, kind);
+                assert_eq!(par, seq, "{kind} n_leaves={n_leaves} leaf_size={leaf_size}");
+            }
         }
     }
 
@@ -564,28 +1014,33 @@ mod tests {
         for (i, b) in data.iter_mut().enumerate() {
             *b = (i as u8).wrapping_mul(31);
         }
-        let r0 = merkle_root(&data, n_leaves);
-        // Flip one bit deep in the buffer.
-        data[n_leaves * leaf_size - 1] ^= 0x01;
-        let r1 = merkle_root(&data, n_leaves);
-        assert_ne!(r0, r1, "single-bit change should change the root");
+        for kind in KINDS {
+            let r0 = merkle_root(&data, n_leaves, kind);
+            // Flip one bit deep in the buffer.
+            data[n_leaves * leaf_size - 1] ^= 0x01;
+            let r1 = merkle_root(&data, n_leaves, kind);
+            assert_ne!(r0, r1, "{kind}: single-bit change should change the root");
+            data[n_leaves * leaf_size - 1] ^= 0x01;
+        }
     }
 
     #[test]
     fn power_of_two_assertion() {
         let data = vec![0u8; 64];
         // Should not panic for power-of-two leaf counts.
-        let _ = merkle_root(&data, 1);
-        let _ = merkle_root(&data, 2);
-        let _ = merkle_root(&data, 4);
-        let _ = merkle_root(&data, 8);
+        for kind in KINDS {
+            let _ = merkle_root(&data, 1, kind);
+            let _ = merkle_root(&data, 2, kind);
+            let _ = merkle_root(&data, 4, kind);
+            let _ = merkle_root(&data, 8, kind);
+        }
     }
 
     #[test]
     #[should_panic(expected = "num_leaves must be power of 2")]
     fn rejects_non_power_of_two() {
         let data = vec![0u8; 30];
-        let _ = merkle_root(&data, 3);
+        let _ = merkle_root(&data, 3, HashKind::Sha256);
     }
 
     #[test]
@@ -596,16 +1051,42 @@ mod tests {
         for (i, b) in data.iter_mut().enumerate() {
             *b = ((i.wrapping_mul(0x9E3779B9)) & 0xff) as u8;
         }
-        let tree = merkle_tree(&data, n_leaves);
-        let root = *tree.last().unwrap();
+        for kind in KINDS {
+            let tree = merkle_tree(&data, n_leaves, kind);
+            let root = *tree.last().unwrap();
 
-        for i in 0..n_leaves {
-            let leaf_hash = hash_leaf(&data[i * leaf_size..(i + 1) * leaf_size]);
-            let proof = merkle_proof(&tree, n_leaves, i);
-            assert_eq!(proof.len(), 4); // log2(16) = 4
+            for i in 0..n_leaves {
+                let leaf_hash = hash_leaf(&data[i * leaf_size..(i + 1) * leaf_size], kind);
+                let proof = merkle_proof(&tree, n_leaves, i);
+                assert_eq!(proof.len(), 4); // log2(16) = 4
+                assert!(
+                    verify_merkle_proof(&root, &leaf_hash, i, &proof, kind),
+                    "{kind}: verify failed at i={i}"
+                );
+            }
+        }
+    }
+
+    /// A proof built under one hash must not verify under the other — the
+    /// hash choice is part of what the root commits to.
+    #[test]
+    fn merkle_proof_rejects_the_other_hash() {
+        let (n_leaves, leaf_size) = (16, 8);
+        let data = random_data(n_leaves, leaf_size, 77);
+        for kind in KINDS {
+            let other = match kind {
+                HashKind::Sha256 => HashKind::Blake3,
+                HashKind::Blake3 => HashKind::Sha256,
+            };
+            let tree = merkle_tree(&data, n_leaves, kind);
+            let root = *tree.last().unwrap();
+            let leaf_hash = hash_leaf(&data[0..leaf_size], kind);
+            let proof = merkle_proof(&tree, n_leaves, 0);
+
+            assert!(verify_merkle_proof(&root, &leaf_hash, 0, &proof, kind));
             assert!(
-                verify_merkle_proof(&root, &leaf_hash, i, &proof),
-                "verify failed at i={i}"
+                !verify_merkle_proof(&root, &leaf_hash, 0, &proof, other),
+                "{kind} proof must not verify as {other}"
             );
         }
     }
@@ -615,14 +1096,20 @@ mod tests {
         let n_leaves = 8;
         let leaf_size = 16;
         let data: Vec<u8> = (0..(n_leaves * leaf_size) as u8).collect();
-        let tree = merkle_tree(&data, n_leaves);
-        let root = *tree.last().unwrap();
+        for kind in KINDS {
+            let tree = merkle_tree(&data, n_leaves, kind);
+            let root = *tree.last().unwrap();
 
-        let leaf_hash = hash_leaf(&data[0..leaf_size]);
-        let proof = merkle_proof(&tree, n_leaves, 0);
+            let leaf_hash = hash_leaf(&data[0..leaf_size], kind);
+            let proof = merkle_proof(&tree, n_leaves, 0);
 
-        // Same proof, but claim it's for index 1 → should fail (different sibling structure).
-        assert!(!verify_merkle_proof(&root, &leaf_hash, 1, &proof));
+            // Same proof, but claim it's for index 1 → should fail (different
+            // sibling structure).
+            assert!(
+                !verify_merkle_proof(&root, &leaf_hash, 1, &proof, kind),
+                "{kind}"
+            );
+        }
     }
 
     #[test]
@@ -630,14 +1117,19 @@ mod tests {
         let n_leaves = 8;
         let leaf_size = 16;
         let data: Vec<u8> = (0..(n_leaves * leaf_size) as u8).collect();
-        let tree = merkle_tree(&data, n_leaves);
-        let root = *tree.last().unwrap();
+        for kind in KINDS {
+            let tree = merkle_tree(&data, n_leaves, kind);
+            let root = *tree.last().unwrap();
 
-        let leaf_hash = hash_leaf(&data[0..leaf_size]);
-        let mut proof = merkle_proof(&tree, n_leaves, 0);
-        // Flip a byte in the first sibling.
-        proof[0][0] ^= 1;
-        assert!(!verify_merkle_proof(&root, &leaf_hash, 0, &proof));
+            let leaf_hash = hash_leaf(&data[0..leaf_size], kind);
+            let mut proof = merkle_proof(&tree, n_leaves, 0);
+            // Flip a byte in the first sibling.
+            proof[0][0] ^= 1;
+            assert!(
+                !verify_merkle_proof(&root, &leaf_hash, 0, &proof, kind),
+                "{kind}"
+            );
+        }
     }
 
     fn random_data(n_leaves: usize, leaf_size: usize, seed: u64) -> Vec<u8> {
@@ -654,25 +1146,28 @@ mod tests {
     fn multi_proof_single_position_matches_single_proof() {
         let (n_leaves, leaf_size) = (16, 8);
         let data = random_data(n_leaves, leaf_size, 42);
-        let tree = merkle_tree(&data, n_leaves);
-        let root = *tree.last().unwrap();
+        for kind in KINDS {
+            let tree = merkle_tree(&data, n_leaves, kind);
+            let root = *tree.last().unwrap();
 
-        for i in 0..n_leaves {
-            let multi = merkle_multi_proof(&tree, n_leaves, &[i]);
-            let single = merkle_proof(&tree, n_leaves, i);
-            assert_eq!(
-                multi, single,
-                "multi-proof of [{i}] must equal single proof"
-            );
+            for i in 0..n_leaves {
+                let multi = merkle_multi_proof(&tree, n_leaves, &[i]);
+                let single = merkle_proof(&tree, n_leaves, i);
+                assert_eq!(
+                    multi, single,
+                    "{kind}: multi-proof of [{i}] must equal single proof"
+                );
 
-            let leaf_hash = hash_leaf(&data[i * leaf_size..(i + 1) * leaf_size]);
-            assert!(verify_merkle_multi_proof(
-                &root,
-                n_leaves,
-                &[i],
-                &[leaf_hash],
-                &multi
-            ));
+                let leaf_hash = hash_leaf(&data[i * leaf_size..(i + 1) * leaf_size], kind);
+                assert!(verify_merkle_multi_proof(
+                    &root,
+                    n_leaves,
+                    &[i],
+                    &[leaf_hash],
+                    &multi,
+                    kind
+                ));
+            }
         }
     }
 
@@ -683,27 +1178,30 @@ mod tests {
         let n_leaves = 8;
         let leaf_size = 4;
         let data = random_data(n_leaves, leaf_size, 7);
-        let tree = merkle_tree(&data, n_leaves);
-        let root = *tree.last().unwrap();
+        for kind in KINDS {
+            let tree = merkle_tree(&data, n_leaves, kind);
+            let root = *tree.last().unwrap();
 
-        let multi = merkle_multi_proof(&tree, n_leaves, &[0, 1]);
-        assert_eq!(
-            multi.len(),
-            2,
-            "sibling pair at leaves saves the leaf-level hash"
-        );
+            let multi = merkle_multi_proof(&tree, n_leaves, &[0, 1]);
+            assert_eq!(
+                multi.len(),
+                2,
+                "sibling pair at leaves saves the leaf-level hash"
+            );
 
-        let leaves: Vec<Hash> = [0usize, 1]
-            .iter()
-            .map(|&i| hash_leaf(&data[i * leaf_size..(i + 1) * leaf_size]))
-            .collect();
-        assert!(verify_merkle_multi_proof(
-            &root,
-            n_leaves,
-            &[0, 1],
-            &leaves,
-            &multi
-        ));
+            let leaves: Vec<Hash> = [0usize, 1]
+                .iter()
+                .map(|&i| hash_leaf(&data[i * leaf_size..(i + 1) * leaf_size], kind))
+                .collect();
+            assert!(verify_merkle_multi_proof(
+                &root,
+                n_leaves,
+                &[0, 1],
+                &leaves,
+                &multi,
+                kind
+            ));
+        }
     }
 
     #[test]
@@ -713,22 +1211,24 @@ mod tests {
         let n_leaves = 16;
         let leaf_size = 8;
         let data = random_data(n_leaves, leaf_size, 99);
-        let tree = merkle_tree(&data, n_leaves);
-        let root = *tree.last().unwrap();
+        for kind in KINDS {
+            let tree = merkle_tree(&data, n_leaves, kind);
+            let root = *tree.last().unwrap();
 
-        let positions: Vec<usize> = (0..n_leaves).collect();
-        let multi = merkle_multi_proof(&tree, n_leaves, &positions);
-        assert!(
-            multi.is_empty(),
-            "full-set multi-proof should have zero hashes"
-        );
+            let positions: Vec<usize> = (0..n_leaves).collect();
+            let multi = merkle_multi_proof(&tree, n_leaves, &positions);
+            assert!(
+                multi.is_empty(),
+                "full-set multi-proof should have zero hashes"
+            );
 
-        let leaves: Vec<Hash> = (0..n_leaves)
-            .map(|i| hash_leaf(&data[i * leaf_size..(i + 1) * leaf_size]))
-            .collect();
-        assert!(verify_merkle_multi_proof(
-            &root, n_leaves, &positions, &leaves, &multi
-        ));
+            let leaves: Vec<Hash> = (0..n_leaves)
+                .map(|i| hash_leaf(&data[i * leaf_size..(i + 1) * leaf_size], kind))
+                .collect();
+            assert!(verify_merkle_multi_proof(
+                &root, n_leaves, &positions, &leaves, &multi, kind
+            ));
+        }
     }
 
     #[test]
@@ -736,41 +1236,43 @@ mod tests {
         let n_leaves = 64;
         let leaf_size = 16;
         let data = random_data(n_leaves, leaf_size, 2024);
-        let tree = merkle_tree(&data, n_leaves);
-        let root = *tree.last().unwrap();
+        for kind in KINDS {
+            let tree = merkle_tree(&data, n_leaves, kind);
+            let root = *tree.last().unwrap();
 
-        let all_leaves: Vec<Hash> = (0..n_leaves)
-            .map(|i| hash_leaf(&data[i * leaf_size..(i + 1) * leaf_size]))
-            .collect();
+            let all_leaves: Vec<Hash> = (0..n_leaves)
+                .map(|i| hash_leaf(&data[i * leaf_size..(i + 1) * leaf_size], kind))
+                .collect();
 
-        let subsets: &[&[usize]] = &[
-            &[0],
-            &[63],
-            &[0, 63],
-            &[3, 17, 41],
-            &[10, 11, 12, 13],
-            &[0, 1, 2, 3, 60, 61, 62, 63],
-            &[5, 5, 5, 17, 17],
-            &[0, 8, 16, 24, 32, 40, 48, 56],
-        ];
-        for positions in subsets {
-            let multi = merkle_multi_proof(&tree, n_leaves, positions);
+            let subsets: &[&[usize]] = &[
+                &[0],
+                &[63],
+                &[0, 63],
+                &[3, 17, 41],
+                &[10, 11, 12, 13],
+                &[0, 1, 2, 3, 60, 61, 62, 63],
+                &[5, 5, 5, 17, 17],
+                &[0, 8, 16, 24, 32, 40, 48, 56],
+            ];
+            for positions in subsets {
+                let multi = merkle_multi_proof(&tree, n_leaves, positions);
 
-            let mut sorted: Vec<usize> = positions.to_vec();
-            sorted.sort_unstable();
-            sorted.dedup();
-            let leaves: Vec<Hash> = sorted.iter().map(|&p| all_leaves[p]).collect();
+                let mut sorted: Vec<usize> = positions.to_vec();
+                sorted.sort_unstable();
+                sorted.dedup();
+                let leaves: Vec<Hash> = sorted.iter().map(|&p| all_leaves[p]).collect();
 
-            assert!(
-                verify_merkle_multi_proof(&root, n_leaves, &sorted, &leaves, &multi),
-                "roundtrip failed for positions={positions:?}"
-            );
+                assert!(
+                    verify_merkle_multi_proof(&root, n_leaves, &sorted, &leaves, &multi, kind),
+                    "{kind}: roundtrip failed for positions={positions:?}"
+                );
 
-            let log_n = n_leaves.trailing_zeros() as usize;
-            assert!(
-                multi.len() <= sorted.len() * log_n,
-                "multi-proof can't exceed sum of independent paths"
-            );
+                let log_n = n_leaves.trailing_zeros() as usize;
+                assert!(
+                    multi.len() <= sorted.len() * log_n,
+                    "multi-proof can't exceed sum of independent paths"
+                );
+            }
         }
     }
 
@@ -778,98 +1280,107 @@ mod tests {
     fn multi_proof_rejects_wrong_leaf() {
         let (n_leaves, leaf_size) = (32, 8);
         let data = random_data(n_leaves, leaf_size, 1);
-        let tree = merkle_tree(&data, n_leaves);
-        let root = *tree.last().unwrap();
+        for kind in KINDS {
+            let tree = merkle_tree(&data, n_leaves, kind);
+            let root = *tree.last().unwrap();
 
-        let positions = vec![3usize, 7, 19, 28];
-        let multi = merkle_multi_proof(&tree, n_leaves, &positions);
-        let mut leaves: Vec<Hash> = positions
-            .iter()
-            .map(|&p| hash_leaf(&data[p * leaf_size..(p + 1) * leaf_size]))
-            .collect();
+            let positions = vec![3usize, 7, 19, 28];
+            let multi = merkle_multi_proof(&tree, n_leaves, &positions);
+            let mut leaves: Vec<Hash> = positions
+                .iter()
+                .map(|&p| hash_leaf(&data[p * leaf_size..(p + 1) * leaf_size], kind))
+                .collect();
 
-        assert!(verify_merkle_multi_proof(
-            &root, n_leaves, &positions, &leaves, &multi
-        ));
-        leaves[1][0] ^= 1;
-        assert!(!verify_merkle_multi_proof(
-            &root, n_leaves, &positions, &leaves, &multi
-        ));
+            assert!(verify_merkle_multi_proof(
+                &root, n_leaves, &positions, &leaves, &multi, kind
+            ));
+            leaves[1][0] ^= 1;
+            assert!(!verify_merkle_multi_proof(
+                &root, n_leaves, &positions, &leaves, &multi, kind
+            ));
+        }
     }
 
     #[test]
     fn multi_proof_rejects_tampered_proof_hash() {
         let (n_leaves, leaf_size) = (32, 8);
         let data = random_data(n_leaves, leaf_size, 2);
-        let tree = merkle_tree(&data, n_leaves);
-        let root = *tree.last().unwrap();
+        for kind in KINDS {
+            let tree = merkle_tree(&data, n_leaves, kind);
+            let root = *tree.last().unwrap();
 
-        let positions = vec![1usize, 14, 27];
-        let mut multi = merkle_multi_proof(&tree, n_leaves, &positions);
-        let leaves: Vec<Hash> = positions
-            .iter()
-            .map(|&p| hash_leaf(&data[p * leaf_size..(p + 1) * leaf_size]))
-            .collect();
+            let positions = vec![1usize, 14, 27];
+            let mut multi = merkle_multi_proof(&tree, n_leaves, &positions);
+            let leaves: Vec<Hash> = positions
+                .iter()
+                .map(|&p| hash_leaf(&data[p * leaf_size..(p + 1) * leaf_size], kind))
+                .collect();
 
-        assert!(verify_merkle_multi_proof(
-            &root, n_leaves, &positions, &leaves, &multi
-        ));
-        multi[0][0] ^= 1;
-        assert!(!verify_merkle_multi_proof(
-            &root, n_leaves, &positions, &leaves, &multi
-        ));
+            assert!(verify_merkle_multi_proof(
+                &root, n_leaves, &positions, &leaves, &multi, kind
+            ));
+            multi[0][0] ^= 1;
+            assert!(!verify_merkle_multi_proof(
+                &root, n_leaves, &positions, &leaves, &multi, kind
+            ));
+        }
     }
 
     #[test]
     fn multi_proof_rejects_extra_or_missing_hashes() {
         let (n_leaves, leaf_size) = (16, 8);
         let data = random_data(n_leaves, leaf_size, 3);
-        let tree = merkle_tree(&data, n_leaves);
-        let root = *tree.last().unwrap();
+        for kind in KINDS {
+            let tree = merkle_tree(&data, n_leaves, kind);
+            let root = *tree.last().unwrap();
 
-        let positions = vec![2usize, 11];
-        let multi = merkle_multi_proof(&tree, n_leaves, &positions);
-        let leaves: Vec<Hash> = positions
-            .iter()
-            .map(|&p| hash_leaf(&data[p * leaf_size..(p + 1) * leaf_size]))
-            .collect();
+            let positions = vec![2usize, 11];
+            let multi = merkle_multi_proof(&tree, n_leaves, &positions);
+            let leaves: Vec<Hash> = positions
+                .iter()
+                .map(|&p| hash_leaf(&data[p * leaf_size..(p + 1) * leaf_size], kind))
+                .collect();
 
-        let mut extra = multi.clone();
-        extra.push([0xaa; 32]);
-        assert!(!verify_merkle_multi_proof(
-            &root, n_leaves, &positions, &leaves, &extra
-        ));
+            let mut extra = multi.clone();
+            extra.push([0xaa; 32]);
+            assert!(!verify_merkle_multi_proof(
+                &root, n_leaves, &positions, &leaves, &extra, kind
+            ));
 
-        let mut short = multi.clone();
-        short.pop();
-        assert!(!verify_merkle_multi_proof(
-            &root, n_leaves, &positions, &leaves, &short
-        ));
+            let mut short = multi.clone();
+            short.pop();
+            assert!(!verify_merkle_multi_proof(
+                &root, n_leaves, &positions, &leaves, &short, kind
+            ));
+        }
     }
 
     #[test]
     fn multi_proof_rejects_unsorted_positions() {
         let (n_leaves, leaf_size) = (16, 8);
         let data = random_data(n_leaves, leaf_size, 5);
-        let tree = merkle_tree(&data, n_leaves);
-        let root = *tree.last().unwrap();
+        for kind in KINDS {
+            let tree = merkle_tree(&data, n_leaves, kind);
+            let root = *tree.last().unwrap();
 
-        let positions = vec![2usize, 11];
-        let multi = merkle_multi_proof(&tree, n_leaves, &positions);
-        let leaves: Vec<Hash> = positions
-            .iter()
-            .map(|&p| hash_leaf(&data[p * leaf_size..(p + 1) * leaf_size]))
-            .collect();
+            let positions = vec![2usize, 11];
+            let multi = merkle_multi_proof(&tree, n_leaves, &positions);
+            let leaves: Vec<Hash> = positions
+                .iter()
+                .map(|&p| hash_leaf(&data[p * leaf_size..(p + 1) * leaf_size], kind))
+                .collect();
 
-        let unsorted = vec![11usize, 2];
-        let unsorted_leaves = vec![leaves[1], leaves[0]];
-        assert!(!verify_merkle_multi_proof(
-            &root,
-            n_leaves,
-            &unsorted,
-            &unsorted_leaves,
-            &multi
-        ));
+            let unsorted = vec![11usize, 2];
+            let unsorted_leaves = vec![leaves[1], leaves[0]];
+            assert!(!verify_merkle_multi_proof(
+                &root,
+                n_leaves,
+                &unsorted,
+                &unsorted_leaves,
+                &multi,
+                kind
+            ));
+        }
     }
 
     #[test]
@@ -877,36 +1388,38 @@ mod tests {
         let n_leaves = 1024;
         let leaf_size = 8;
         let data = random_data(n_leaves, leaf_size, 4096);
-        let tree = merkle_tree(&data, n_leaves);
-        let root = *tree.last().unwrap();
         let log_n = n_leaves.trailing_zeros() as usize;
+        for kind in KINDS {
+            let tree = merkle_tree(&data, n_leaves, kind);
+            let root = *tree.last().unwrap();
 
-        let positions_raw: Vec<usize> = (0..100)
-            .map(|i| {
-                let mut z = (i as u64).wrapping_mul(0xDEAD_BEEF_F0F0_F0F0);
-                z ^= z >> 27;
-                (z as usize) & (n_leaves - 1)
-            })
-            .collect();
-        let multi = merkle_multi_proof(&tree, n_leaves, &positions_raw);
+            let positions_raw: Vec<usize> = (0..100)
+                .map(|i| {
+                    let mut z = (i as u64).wrapping_mul(0xDEAD_BEEF_F0F0_F0F0);
+                    z ^= z >> 27;
+                    (z as usize) & (n_leaves - 1)
+                })
+                .collect();
+            let multi = merkle_multi_proof(&tree, n_leaves, &positions_raw);
 
-        let mut positions = positions_raw.clone();
-        positions.sort_unstable();
-        positions.dedup();
-        let leaves: Vec<Hash> = positions
-            .iter()
-            .map(|&p| hash_leaf(&data[p * leaf_size..(p + 1) * leaf_size]))
-            .collect();
+            let mut positions = positions_raw.clone();
+            positions.sort_unstable();
+            positions.dedup();
+            let leaves: Vec<Hash> = positions
+                .iter()
+                .map(|&p| hash_leaf(&data[p * leaf_size..(p + 1) * leaf_size], kind))
+                .collect();
 
-        assert!(verify_merkle_multi_proof(
-            &root, n_leaves, &positions, &leaves, &multi
-        ));
-        assert!(
-            multi.len() < positions.len() * log_n,
-            "multi-proof should beat independent paths: got {} vs {} × {}",
-            multi.len(),
-            positions.len(),
-            log_n
-        );
+            assert!(verify_merkle_multi_proof(
+                &root, n_leaves, &positions, &leaves, &multi, kind
+            ));
+            assert!(
+                multi.len() < positions.len() * log_n,
+                "multi-proof should beat independent paths: got {} vs {} × {}",
+                multi.len(),
+                positions.len(),
+                log_n
+            );
+        }
     }
 }

--- a/crates/flock-core/src/pcs.rs
+++ b/crates/flock-core/src/pcs.rs
@@ -768,6 +768,7 @@ mod tests {
             log_inv_rate: 1,
             log_batch_size: initial_k,
             profile: Default::default(),
+            merkle_hash: Default::default(),
         };
         let z_packed = pack_witness(&z, m);
         let (commitment, prover_data) = commit(&z_packed, &params);
@@ -792,6 +793,7 @@ mod tests {
             grinding_bits: grinding_bits.clone(),
             fold_grinding_bits: vec![0; n_levels],
             ood_samples: vec![0; n_levels],
+            merkle_hash: Default::default(),
         };
         let lig_v_cfg = crate::pcs::ligerito::VerifierConfig {
             log_inv_rates,
@@ -805,6 +807,7 @@ mod tests {
             grinding_bits,
             fold_grinding_bits: vec![0; n_levels],
             ood_samples: vec![0; n_levels],
+            merkle_hash: Default::default(),
         };
 
         let mut ch_p = FsChallenger::new(b"flock-test-lig-v0");

--- a/crates/flock-core/src/pcs/commit.rs
+++ b/crates/flock-core/src/pcs/commit.rs
@@ -15,7 +15,7 @@
 //! Merkle leaf is **one** F_{2^128} element = 16 bytes.
 
 use crate::field::F128;
-use crate::merkle::{self, Hash};
+use crate::merkle::{self, Hash, HashKind};
 use crate::ntt::AdditiveNttF128;
 use crate::pcs::pack::LOG_PACKING;
 use serde::{Deserialize, Serialize};
@@ -40,6 +40,14 @@ pub struct PcsParams {
     /// (`profile.log_inv_rate() == log_inv_rate`). Defaults to `Fast`.
     #[serde(default)]
     pub profile: crate::pcs::ligerito::LigeritoProfile,
+    /// Hash backing the Merkle commitment. Defaults to SHA-256, so params
+    /// serialized before this option existed deserialize unchanged.
+    ///
+    /// The verifier must be given the same value the prover committed under —
+    /// it is carried in [`Commitment`] alongside the root for exactly that
+    /// reason.
+    #[serde(default)]
+    pub merkle_hash: HashKind,
 }
 
 impl PcsParams {
@@ -81,6 +89,37 @@ impl PcsParams {
     /// Merkle leaf size in bytes = `num_ntts() * 16`.
     pub fn leaf_size_bytes(&self) -> usize {
         16usize << self.log_leaf_f128_count()
+    }
+
+    /// Ligerito prover config for these params.
+    ///
+    /// Prefer this over calling [`ligerito::prover_config_for`] directly: the
+    /// embedded security config carries its own `hash` field, but the Merkle
+    /// hash the opening must use is the one the *commitment* was built under.
+    /// This stamps `self.merkle_hash` over it, so the L0 tree and every
+    /// recursive level cannot end up on different hashes.
+    ///
+    /// [`ligerito::prover_config_for`]: crate::pcs::ligerito::prover_config_for
+    pub fn ligerito_prover_config(&self) -> Result<crate::pcs::ligerito::ProverConfig, String> {
+        let mut cfg = crate::pcs::ligerito::prover_config_for(
+            self.log_msg_len(),
+            self.log_batch_size,
+            self.profile,
+        )?;
+        cfg.merkle_hash = self.merkle_hash;
+        Ok(cfg)
+    }
+
+    /// Verifier-side counterpart to [`Self::ligerito_prover_config`], stamped
+    /// with the same Merkle hash for the same reason.
+    pub fn ligerito_verifier_config(&self) -> Result<crate::pcs::ligerito::VerifierConfig, String> {
+        let mut cfg = crate::pcs::ligerito::verifier_config_for(
+            self.log_msg_len(),
+            self.log_batch_size,
+            self.profile,
+        )?;
+        cfg.merkle_hash = self.merkle_hash;
+        Ok(cfg)
     }
 
     fn validate(&self) {
@@ -254,7 +293,7 @@ fn finalize_commit(mut codeword: Vec<F128>, params: &PcsParams) -> (Commitment, 
     // Initial tree: one leaf per codeword position, each containing the
     // row-batch lanes (num_ntts F_{2^128} values = 2^log_batch_size). This is
     // Ligerito's L0 commitment.
-    let merkle_tree = merkle::merkle_tree(codeword_bytes, params.n_leaves());
+    let merkle_tree = merkle::merkle_tree(codeword_bytes, params.n_leaves(), params.merkle_hash);
     let root = *merkle_tree.last().expect("merkle tree non-empty");
     if timing {
         eprintln!(
@@ -358,12 +397,42 @@ mod tests {
         }
     }
 
+    /// The Ligerito configs derived from `PcsParams` must carry the params'
+    /// Merkle hash, not the embedded security config's `hash` field. If they
+    /// diverge, the L0 commitment and the recursive levels are built under
+    /// different hashes and nothing verifies — silently, and only at the
+    /// geometries that reach recursion.
+    #[test]
+    fn ligerito_configs_inherit_the_params_merkle_hash() {
+        let mut params = default_params(22);
+        params.log_batch_size = 6;
+
+        assert_eq!(params.merkle_hash, HashKind::Sha256);
+        assert_eq!(
+            params.ligerito_prover_config().unwrap().merkle_hash,
+            HashKind::Sha256
+        );
+
+        params.merkle_hash = HashKind::Blake3;
+        assert_eq!(
+            params.ligerito_prover_config().unwrap().merkle_hash,
+            HashKind::Blake3,
+            "prover config must follow PcsParams, not the embedded TOML"
+        );
+        assert_eq!(
+            params.ligerito_verifier_config().unwrap().merkle_hash,
+            HashKind::Blake3,
+            "verifier config must follow PcsParams, not the embedded TOML"
+        );
+    }
+
     fn default_params(m: usize) -> PcsParams {
         PcsParams {
             m,
             log_inv_rate: 1,
             log_batch_size: 1,
             profile: Default::default(),
+            merkle_hash: Default::default(),
         }
     }
 
@@ -381,6 +450,7 @@ mod tests {
                 log_inv_rate,
                 log_batch_size,
                 profile: Default::default(),
+                merkle_hash: Default::default(),
             };
             let z = rng.bits(1 << m);
             let z_packed = super::super::pack::pack_witness(&z, m);
@@ -400,9 +470,10 @@ mod tests {
             let oracle_bytes: &[u8] = unsafe {
                 core::slice::from_raw_parts(oracle.as_ptr() as *const u8, oracle.len() * 16)
             };
-            let oracle_root = *crate::merkle::merkle_tree(oracle_bytes, params.n_leaves())
-                .last()
-                .unwrap();
+            let oracle_root =
+                *crate::merkle::merkle_tree(oracle_bytes, params.n_leaves(), params.merkle_hash)
+                    .last()
+                    .unwrap();
             assert_eq!(
                 commitment.root, oracle_root,
                 "root mismatch at m={m} r={log_inv_rate}"

--- a/crates/flock-core/src/pcs/ligerito.rs
+++ b/crates/flock-core/src/pcs/ligerito.rs
@@ -32,7 +32,7 @@
 use crate::challenger::Challenger;
 use crate::field::F128;
 use crate::lincheck::build_eq_table;
-use crate::merkle::{self, Hash};
+use crate::merkle::{self, Hash, HashKind};
 use crate::ntt::additive_ntt_f128::AdditiveNttF128;
 use serde::{Deserialize, Serialize};
 
@@ -130,6 +130,10 @@ pub struct ProverConfig {
     /// L0 is bound by the opening's own (post-commit, random-point)
     /// evaluation claim. Length = recursive_steps + 1.
     pub ood_samples: Vec<usize>,
+    /// Hash backing every Merkle commitment this prover makes (L0 and each
+    /// recursive level). Comes from the `hash` field of the security config;
+    /// [`Default`] is SHA-256.
+    pub merkle_hash: HashKind,
 }
 
 #[derive(Clone, Debug)]
@@ -150,6 +154,10 @@ pub struct VerifierConfig {
     pub fold_grinding_bits: Vec<usize>,
     /// Per-commit-level OOD samples. Length = recursive_steps + 1.
     pub ood_samples: Vec<usize>,
+    /// Hash the prover's Merkle commitments were built under. Must match the
+    /// prover's — a mismatch makes every opening fail to verify, which is the
+    /// correct outcome: the root commits to the hash as much as to the data.
+    pub merkle_hash: HashKind,
 }
 
 /// Proximity loss `ε*` for the UDR (unique-decoding regime) analysis. It
@@ -260,6 +268,7 @@ pub fn default_config(
         grinding_bits,
         fold_grinding_bits: vec![0usize; n_levels],
         ood_samples: vec![0usize; n_levels],
+        merkle_hash: HashKind::default(),
     })
 }
 
@@ -440,6 +449,7 @@ pub fn default_verifier_config(
         grinding_bits: p.grinding_bits,
         fold_grinding_bits: p.fold_grinding_bits,
         ood_samples: p.ood_samples,
+        merkle_hash: p.merkle_hash,
     })
 }
 
@@ -603,7 +613,19 @@ pub struct LigeritoSecurityConfig {
     pub analysis_version: String,
     /// Field of the protocol. Example: `"f128"`.
     pub field: String,
-    /// Hash function used by Merkle + FS challenger. Example: `"sha256"`.
+    /// Hash function used by the Merkle commitments: `"sha256"` or
+    /// `"blake3"`. Read via [`LigeritoSecurityConfig::merkle_hash`] and
+    /// carried into the prover/verifier configs; [`validate`] rejects any
+    /// other value.
+    ///
+    /// This selects the **Merkle** hash only. The Fiat-Shamir transcript hash
+    /// is a separate, independent choice made where the challenger is built
+    /// ([`crate::challenger::FsChallenger::with_hash`]) — the challenger is
+    /// constructed by the caller, upstream of any PCS config, so there is
+    /// deliberately no field for it here rather than one that cannot drive
+    /// anything.
+    ///
+    /// [`validate`]: LigeritoSecurityConfig::validate
     pub hash: String,
     /// Where in the per-level FS transcript grinding is placed.
     pub grinding_step: GrindingStep,
@@ -881,6 +903,10 @@ impl LigeritoSecurityConfig {
                 self.log_n, self.m
             ));
         }
+
+        // Reject a `hash` we do not implement here, so a bad spelling is caught
+        // at config-load time rather than silently committing under SHA-256.
+        self.merkle_hash()?;
 
         // Recursion shape: initial_k + Σ k_recursive (L1+) + yr_log_n = log_n.
         let levels_recursive_sum: usize = self.levels.iter().skip(1).map(|lv| lv.k_recursive).sum();
@@ -1382,6 +1408,7 @@ impl LigeritoSecurityConfig {
     /// works unchanged.
     pub fn to_prover_verifier_configs(&self) -> Result<(ProverConfig, VerifierConfig), String> {
         self.validate()?;
+        let merkle_hash = self.merkle_hash()?;
         let log_inv_rates: Vec<usize> = self.levels.iter().map(|lv| lv.log_inv_rate).collect();
         let recursive_ks: Vec<usize> = self
             .levels
@@ -1412,6 +1439,7 @@ impl LigeritoSecurityConfig {
             grinding_bits: grinding_bits.clone(),
             fold_grinding_bits: fold_grinding_bits.clone(),
             ood_samples: ood_samples.clone(),
+            merkle_hash,
         };
         let verifier = VerifierConfig {
             log_inv_rates: log_inv_rates.clone(),
@@ -1425,8 +1453,19 @@ impl LigeritoSecurityConfig {
             grinding_bits,
             fold_grinding_bits,
             ood_samples,
+            merkle_hash,
         };
         Ok((prover, verifier))
+    }
+
+    /// The Merkle hash this config selects, parsed from its `hash` field.
+    ///
+    /// Errors on any spelling we do not implement rather than defaulting —
+    /// a config asking for a hash that is not wired up must fail loudly, not
+    /// silently produce SHA-256 proofs under a `hash = "…"` that says
+    /// otherwise.
+    pub fn merkle_hash(&self) -> Result<HashKind, String> {
+        HashKind::parse(&self.hash).map_err(|e| format!("security config `hash`: {e}"))
     }
 }
 
@@ -2308,6 +2347,7 @@ pub(crate) fn ligero_commit(
     log_num_interleaved: usize,
     log_inv_rate: usize,
     ntt: &AdditiveNttF128,
+    kind: HashKind,
 ) -> LigeroWitness {
     let msg_cols = 1usize << log_msg_cols;
     let num_interleaved = 1usize << log_num_interleaved;
@@ -2337,7 +2377,7 @@ pub(crate) fn ligero_commit(
         )
     };
     debug_assert_eq!(data_bytes.len(), block_len * leaf_size_bytes);
-    let tree = merkle::merkle_tree(data_bytes, block_len);
+    let tree = merkle::merkle_tree(data_bytes, block_len, kind);
 
     LigeroWitness {
         mat,
@@ -2842,7 +2882,14 @@ pub fn recursive_prover<Ch: Challenger>(
     let log_msg_cols_0 = log_n - initial_k;
     let ntt_0 = AdditiveNttF128::standard(log_msg_cols_0 + log_inv_rate_0);
     let t = std::time::Instant::now();
-    let wtns_0 = ligero_commit(poly, log_msg_cols_0, initial_k, log_inv_rate_0, &ntt_0);
+    let wtns_0 = ligero_commit(
+        poly,
+        log_msg_cols_0,
+        initial_k,
+        log_inv_rate_0,
+        &ntt_0,
+        config.merkle_hash,
+    );
     let t_l0 = t.elapsed();
     t_commits += t_l0;
     tlog!("  [ligerito]   L0 commit: {:.2?}", t_l0);
@@ -3122,6 +3169,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
         log_num_interleaved_1,
         log_inv_rate_1,
         &ntt_1,
+        config.merkle_hash,
     );
     if trace {
         t_commits += _t.elapsed();
@@ -3320,6 +3368,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
             log_num_interleaved_next,
             log_inv_rate_next,
             &ntt_next,
+            config.merkle_hash,
         );
         if trace {
             t_commits += _t.elapsed();
@@ -3571,6 +3620,7 @@ where
         &proof.initial_proof.opened_rows,
         num_interleaved_0,
         &proof.initial_proof.merkle_proof,
+        config.merkle_hash,
     ) {
         return false;
     }
@@ -3714,6 +3764,7 @@ where
                 &proof.final_proof.opened_rows,
                 prev_num_interleaved,
                 &proof.final_proof.merkle_proof,
+                config.merkle_hash,
             ) {
                 return false;
             }
@@ -3922,6 +3973,7 @@ where
             &rp.opened_rows,
             prev_num_interleaved,
             &rp.merkle_proof,
+            config.merkle_hash,
         ) {
             return false;
         }
@@ -4108,6 +4160,7 @@ pub fn recursive_verifier_with_basis<Ch: Challenger>(
         &proof.initial_proof.opened_rows,
         num_interleaved_0,
         &proof.initial_proof.merkle_proof,
+        config.merkle_hash,
     ) {
         return false;
     }
@@ -4232,6 +4285,7 @@ pub fn recursive_verifier_with_basis<Ch: Challenger>(
                 &proof.final_proof.opened_rows,
                 prev_num_interleaved,
                 &proof.final_proof.merkle_proof,
+                config.merkle_hash,
             ) {
                 return false;
             }
@@ -4351,6 +4405,7 @@ pub fn recursive_verifier_with_basis<Ch: Challenger>(
             &rp.opened_rows,
             prev_num_interleaved,
             &rp.merkle_proof,
+            config.merkle_hash,
         ) {
             return false;
         }
@@ -4444,6 +4499,7 @@ fn recursive_prover_inner<Ch: Challenger>(
         log_num_interleaved_1,
         log_inv_rate_1,
         &ntt_1,
+        config.merkle_hash,
     );
     let t_l1 = t.elapsed();
     t_commits += t_l1;
@@ -4571,6 +4627,7 @@ fn recursive_prover_inner<Ch: Challenger>(
             log_num_interleaved_next,
             log_inv_rate_next,
             &ntt_next,
+            config.merkle_hash,
         );
         let t_li = t.elapsed();
         t_commits += t_li;
@@ -4629,6 +4686,7 @@ fn verify_level_opens(
     opened_rows: &[Vec<F128>],
     expected_num_interleaved: usize,
     multi_proof: &[Hash],
+    kind: HashKind,
 ) -> bool {
     if queries.len() != opened_rows.len() {
         return false;
@@ -4644,9 +4702,9 @@ fn verify_level_opens(
                 row.len() * core::mem::size_of::<F128>(),
             )
         };
-        leaf_hashes.push(merkle::hash_leaf(bytes));
+        leaf_hashes.push(merkle::hash_leaf(bytes, kind));
     }
-    merkle::verify_merkle_multi_proof(root, block_len, queries, &leaf_hashes, multi_proof)
+    merkle::verify_merkle_multi_proof(root, block_len, queries, &leaf_hashes, multi_proof, kind)
 }
 
 /// Verifier counterpart to [`recursive_prover`]. Supports arbitrary `R ≥ 1`.
@@ -4699,6 +4757,7 @@ pub fn recursive_verifier<Ch: Challenger>(
         &proof.initial_proof.opened_rows,
         num_interleaved_0,
         &proof.initial_proof.merkle_proof,
+        config.merkle_hash,
     ) {
         return false;
     }
@@ -4810,6 +4869,7 @@ pub fn recursive_verifier<Ch: Challenger>(
                 &proof.final_proof.opened_rows,
                 prev_num_interleaved,
                 &proof.final_proof.merkle_proof,
+                config.merkle_hash,
             ) {
                 return false;
             }
@@ -4886,6 +4946,7 @@ pub fn recursive_verifier<Ch: Challenger>(
             &rp.opened_rows,
             prev_num_interleaved,
             &rp.merkle_proof,
+            config.merkle_hash,
         ) {
             return false;
         }
@@ -5128,6 +5189,54 @@ mod tests {
             .unwrap_or_else(|e| panic!("validate failed: {e}"));
     }
 
+    /// The config's `hash` field selects the Merkle hash and reaches both
+    /// derived configs — this is the knob the option is exposed through.
+    #[test]
+    fn ligerito_security_config_hash_field_selects_merkle_hash() {
+        let mut cfg = blake3_m29_udr_example();
+        assert_eq!(cfg.hash, "sha256", "example config baseline");
+        let (p, v) = cfg.to_prover_verifier_configs().expect("sha256 configs");
+        assert_eq!(p.merkle_hash, HashKind::Sha256);
+        assert_eq!(v.merkle_hash, HashKind::Sha256);
+
+        cfg.hash = "blake3".into();
+        let (p, v) = cfg.to_prover_verifier_configs().expect("blake3 configs");
+        assert_eq!(p.merkle_hash, HashKind::Blake3);
+        assert_eq!(v.merkle_hash, HashKind::Blake3);
+
+        // Survives a TOML round-trip, so the option is settable from a file.
+        cfg.validate().expect("blake3 config validates");
+        let back = LigeritoSecurityConfig::from_toml_str(&cfg.to_toml_string().unwrap())
+            .expect("toml roundtrip");
+        assert_eq!(back.merkle_hash().unwrap(), HashKind::Blake3);
+    }
+
+    /// A `hash` we do not implement must fail at validation rather than
+    /// silently committing under SHA-256.
+    #[test]
+    fn ligerito_security_config_rejects_unknown_hash() {
+        let mut cfg = blake3_m29_udr_example();
+        cfg.hash = "keccak256".into();
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.contains("hash") && err.contains("keccak256"),
+            "err = {err}"
+        );
+        assert!(cfg.to_prover_verifier_configs().is_err());
+    }
+
+    /// Every embedded config must name a hash we actually implement — a typo
+    /// in a checked-in TOML should fail here, not at proving time.
+    #[test]
+    fn embedded_configs_all_declare_a_supported_hash() {
+        for &((m, profile), toml) in EMBEDDED_CONFIGS {
+            let cfg = LigeritoSecurityConfig::from_toml_str(toml)
+                .unwrap_or_else(|e| panic!("m{m} {profile:?}: {e}"));
+            cfg.merkle_hash()
+                .unwrap_or_else(|e| panic!("m{m} {profile:?}: {e}"));
+        }
+    }
+
     /// Lowering a level's expected_eps_query_bits below the required
     /// (target − grinding) is caught by validation.
     #[test]
@@ -5261,11 +5370,19 @@ mod tests {
             grinding_bits: grinding_bits.clone(),
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
 
         let log_msg_cols_0 = log_n - initial_k;
         let ntt_0 = AdditiveNttF128::standard(log_msg_cols_0 + log_inv_rate);
-        let wtns_0 = ligero_commit(&poly, log_msg_cols_0, initial_k, log_inv_rate, &ntt_0);
+        let wtns_0 = ligero_commit(
+            &poly,
+            log_msg_cols_0,
+            initial_k,
+            log_inv_rate,
+            &ntt_0,
+            HashKind::Sha256,
+        );
         let initial_root = wtns_0.root();
 
         let mut p_ch = crate::challenger::FsChallenger::new(b"pow-test");
@@ -5292,6 +5409,7 @@ mod tests {
             grinding_bits,
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
         let mut v_ch = crate::challenger::FsChallenger::new(b"pow-test");
         let ok =
@@ -5719,7 +5837,14 @@ mod tests {
 
         // Encode via ligero_commit (so we use the same matrix layout).
         let ntt = AdditiveNttF128::standard(log_msg + log_inv_rate);
-        let w = ligero_commit(&poly, log_msg, log_interleaved, log_inv_rate, &ntt);
+        let w = ligero_commit(
+            &poly,
+            log_msg,
+            log_interleaved,
+            log_inv_rate,
+            &ntt,
+            HashKind::Sha256,
+        );
         assert_eq!(w.block_len, block_len);
 
         let num_queries = 5;
@@ -5793,6 +5918,7 @@ mod tests {
             grinding_bits: grinding_bits.clone(),
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
         let verifier_cfg = VerifierConfig {
             log_inv_rates: log_inv_rates.clone(),
@@ -5806,6 +5932,7 @@ mod tests {
             grinding_bits,
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
         let _ = num_queries; // queries derived per-level from log_inv_rates now
 
@@ -5872,6 +5999,7 @@ mod tests {
             grinding_bits: grinding_bits.clone(),
             fold_grinding_bits: vec![0; r + 1],
             ood_samples: vec![0; r + 1],
+            merkle_hash: Default::default(),
         };
         let v_cfg = VerifierConfig {
             log_inv_rates: log_inv_rates.clone(),
@@ -5885,6 +6013,7 @@ mod tests {
             grinding_bits,
             fold_grinding_bits: vec![0; r + 1],
             ood_samples: vec![0; r + 1],
+            merkle_hash: Default::default(),
         };
 
         // Time the prover, best of 3.
@@ -6237,6 +6366,7 @@ mod tests {
             grinding_bits: vec![0; log_inv_rates.len()],
             fold_grinding_bits: vec![0; 3],
             ood_samples: vec![0; 3],
+            merkle_hash: Default::default(),
         };
         let v_cfg = VerifierConfig {
             log_inv_rates: log_inv_rates.clone(),
@@ -6250,6 +6380,7 @@ mod tests {
             grinding_bits: vec![0; log_inv_rates.len()],
             fold_grinding_bits: vec![0; 3],
             ood_samples: vec![0; 3],
+            merkle_hash: Default::default(),
         };
 
         let mut p_ch = crate::challenger::FsChallenger::new(b"test-r2");
@@ -6293,6 +6424,7 @@ mod tests {
             grinding_bits: vec![0; log_inv_rates.len()],
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
         let mut p_ch = crate::challenger::FsChallenger::new(b"serde");
         let proof = recursive_prover(&cfg, &poly, &z, v, &mut p_ch);
@@ -6338,11 +6470,19 @@ mod tests {
             grinding_bits: vec![0; log_inv_rates.len()],
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
 
         let log_msg_cols_0 = log_n - initial_k;
         let ntt_0 = AdditiveNttF128::standard(log_msg_cols_0 + log_inv_rate);
-        let wtns_0 = ligero_commit(&poly, log_msg_cols_0, initial_k, log_inv_rate, &ntt_0);
+        let wtns_0 = ligero_commit(
+            &poly,
+            log_msg_cols_0,
+            initial_k,
+            log_inv_rate,
+            &ntt_0,
+            HashKind::Sha256,
+        );
         let initial_root = wtns_0.root();
 
         let mut p_ch = crate::challenger::FsChallenger::new(b"basis-test");
@@ -6368,6 +6508,7 @@ mod tests {
             grinding_bits: vec![0; log_inv_rates.len()],
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
         let mut v_ch = crate::challenger::FsChallenger::new(b"basis-test");
         let ok =
@@ -6469,7 +6610,7 @@ mod tests {
         // num_interleaved = 1 ⇒ no lane fold (level_rs empty) ⇒ yr == the message.
         let yr: Vec<F128> = (0..msg_cols).map(|_| rng.sample_f128()).collect();
         let ntt = AdditiveNttF128::standard(log_msg_cols + log_inv_rate);
-        let wtns = ligero_commit(&yr, log_msg_cols, 0, log_inv_rate, &ntt);
+        let wtns = ligero_commit(&yr, log_msg_cols, 0, log_inv_rate, &ntt, HashKind::Sha256);
 
         // Distinct query positions (the protocol always samples distinct ones).
         let mut queries: Vec<usize> = Vec::new();
@@ -6561,11 +6702,19 @@ mod tests {
             grinding_bits: vec![0; log_inv_rates.len()],
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
 
         let log_msg_cols_0 = log_n - initial_k;
         let ntt_0 = AdditiveNttF128::standard(log_msg_cols_0 + log_inv_rate);
-        let wtns_0 = ligero_commit(&poly, log_msg_cols_0, initial_k, log_inv_rate, &ntt_0);
+        let wtns_0 = ligero_commit(
+            &poly,
+            log_msg_cols_0,
+            initial_k,
+            log_inv_rate,
+            &ntt_0,
+            HashKind::Sha256,
+        );
         let initial_root = wtns_0.root();
 
         let mut p_ch = crate::challenger::FsChallenger::new(b"succ-cmp");
@@ -6591,6 +6740,7 @@ mod tests {
             grinding_bits: vec![0; log_inv_rates.len()],
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
 
         // Dense verifier
@@ -6663,6 +6813,7 @@ mod tests {
             grinding_bits: grinding_bits.clone(),
             fold_grinding_bits: fold_grinding_bits.clone(),
             ood_samples: ood_samples.clone(),
+            merkle_hash: Default::default(),
         };
         let v = VerifierConfig {
             log_inv_rates,
@@ -6676,6 +6827,7 @@ mod tests {
             grinding_bits,
             fold_grinding_bits,
             ood_samples,
+            merkle_hash: Default::default(),
         };
         (p, v)
     }
@@ -6706,7 +6858,14 @@ mod tests {
 
         let log_msg_cols_0 = log_n - initial_k;
         let ntt_0 = AdditiveNttF128::standard(log_msg_cols_0 + 1);
-        let wtns_0 = ligero_commit(&poly, log_msg_cols_0, initial_k, 1, &ntt_0);
+        let wtns_0 = ligero_commit(
+            &poly,
+            log_msg_cols_0,
+            initial_k,
+            1,
+            &ntt_0,
+            HashKind::Sha256,
+        );
         let initial_root = wtns_0.root();
 
         let mut p_ch = crate::challenger::FsChallenger::new(b"ood-test");
@@ -6815,7 +6974,14 @@ mod tests {
 
         let log_msg_cols_0 = log_n - initial_k;
         let ntt_0 = AdditiveNttF128::standard(log_msg_cols_0 + 1);
-        let wtns_0 = ligero_commit(&poly, log_msg_cols_0, initial_k, 1, &ntt_0);
+        let wtns_0 = ligero_commit(
+            &poly,
+            log_msg_cols_0,
+            initial_k,
+            1,
+            &ntt_0,
+            HashKind::Sha256,
+        );
         let initial_root = wtns_0.root();
 
         let mut p_ch = crate::challenger::FsChallenger::new(b"m22-fast");
@@ -6834,6 +7000,164 @@ mod tests {
             recursive_verifier_with_basis(&v_cfg, &proof, &b, target, &initial_root, &mut v_ch),
             "m22 fast profile proof must verify"
         );
+    }
+
+    /// End-to-end under BLAKE3: the same recursion, every Merkle commitment
+    /// (L0 and each recursive level) built and checked with the other hash.
+    /// Also pins the failure mode of a hash mismatch — a verifier configured
+    /// for the wrong hash must reject, since the roots commit to the hash.
+    #[test]
+    fn ligerito_m22_roundtrip_under_blake3() {
+        use crate::challenger::Challenger;
+        let m = 22usize;
+        let log_n = m - crate::pcs::LOG_PACKING;
+        let initial_k = 6;
+        let mut p_cfg = prover_config_for(log_n, initial_k, LigeritoProfile::Fast)
+            .expect("m22 fast prover config");
+        let mut v_cfg = verifier_config_for(log_n, initial_k, LigeritoProfile::Fast)
+            .expect("m22 fast verifier config");
+        // The embedded configs all declare sha256; override to exercise the
+        // other arm of the option end to end.
+        assert_eq!(p_cfg.merkle_hash, HashKind::Sha256);
+        p_cfg.merkle_hash = HashKind::Blake3;
+        v_cfg.merkle_hash = HashKind::Blake3;
+
+        let mut rng = crate::challenger::RandomChallenger::new(0xB1A5_E300);
+        let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
+        let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
+        let b = build_eq_table(&z);
+        let target: F128 = poly
+            .iter()
+            .zip(b.iter())
+            .map(|(&a, &c)| a * c)
+            .fold(F128::ZERO, |a, x| a + x);
+
+        let log_msg_cols_0 = log_n - initial_k;
+        let ntt_0 = AdditiveNttF128::standard(log_msg_cols_0 + 1);
+        let wtns_0 = ligero_commit(
+            &poly,
+            log_msg_cols_0,
+            initial_k,
+            1,
+            &ntt_0,
+            HashKind::Blake3,
+        );
+        let initial_root = wtns_0.root();
+
+        let mut p_ch = crate::challenger::FsChallenger::new(b"m22-blake3");
+        let proof = recursive_prover_with_basis(
+            &p_cfg,
+            poly,
+            b.clone(),
+            target,
+            &wtns_0.mat,
+            &wtns_0.tree,
+            &mut p_ch,
+        );
+
+        let mut v_ch = crate::challenger::FsChallenger::new(b"m22-blake3");
+        assert!(
+            recursive_verifier_with_basis(&v_cfg, &proof, &b, target, &initial_root, &mut v_ch),
+            "blake3 Merkle proof must verify"
+        );
+
+        // Same proof, verifier configured for SHA-256 → every opening's
+        // recomputed root disagrees, so it must reject.
+        let mut wrong_cfg = v_cfg.clone();
+        wrong_cfg.merkle_hash = HashKind::Sha256;
+        let mut w_ch = crate::challenger::FsChallenger::new(b"m22-blake3");
+        assert!(
+            !recursive_verifier_with_basis(
+                &wrong_cfg,
+                &proof,
+                &b,
+                target,
+                &initial_root,
+                &mut w_ch
+            ),
+            "a sha256-configured verifier must reject a blake3 proof"
+        );
+    }
+
+    /// The Merkle hash and the Fiat-Shamir transcript hash are independent
+    /// options: all four combinations must prove and verify. Also pins the
+    /// failure mode of a transcript-hash mismatch, the FS analogue of the
+    /// Merkle mismatch checked above.
+    #[test]
+    fn ligerito_m22_roundtrip_over_hash_matrix() {
+        use crate::challenger::Challenger;
+        const KINDS: [HashKind; 2] = [HashKind::Sha256, HashKind::Blake3];
+        let log_n = 22usize - crate::pcs::LOG_PACKING;
+        let initial_k = 6;
+
+        for merkle_hash in KINDS {
+            for fs_hash in KINDS {
+                let mut p_cfg = prover_config_for(log_n, initial_k, LigeritoProfile::Fast).unwrap();
+                let mut v_cfg =
+                    verifier_config_for(log_n, initial_k, LigeritoProfile::Fast).unwrap();
+                p_cfg.merkle_hash = merkle_hash;
+                v_cfg.merkle_hash = merkle_hash;
+
+                let mut rng = crate::challenger::RandomChallenger::new(0x4A11_0000);
+                let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
+                let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
+                let b = build_eq_table(&z);
+                let target: F128 = poly
+                    .iter()
+                    .zip(b.iter())
+                    .map(|(&a, &c)| a * c)
+                    .fold(F128::ZERO, |a, x| a + x);
+
+                let log_msg_cols_0 = log_n - initial_k;
+                let ntt_0 = AdditiveNttF128::standard(log_msg_cols_0 + 1);
+                let wtns_0 =
+                    ligero_commit(&poly, log_msg_cols_0, initial_k, 1, &ntt_0, merkle_hash);
+                let initial_root = wtns_0.root();
+
+                let mut p_ch = crate::challenger::FsChallenger::with_hash(b"m22-matrix", fs_hash);
+                let proof = recursive_prover_with_basis(
+                    &p_cfg,
+                    poly,
+                    b.clone(),
+                    target,
+                    &wtns_0.mat,
+                    &wtns_0.tree,
+                    &mut p_ch,
+                );
+
+                let mut v_ch = crate::challenger::FsChallenger::with_hash(b"m22-matrix", fs_hash);
+                assert!(
+                    recursive_verifier_with_basis(
+                        &v_cfg,
+                        &proof,
+                        &b,
+                        target,
+                        &initial_root,
+                        &mut v_ch
+                    ),
+                    "merkle={merkle_hash} fs={fs_hash} must verify"
+                );
+
+                // Verifier on the other transcript hash: challenges diverge
+                // from the first sample, so it must reject.
+                let other_fs = match fs_hash {
+                    HashKind::Sha256 => HashKind::Blake3,
+                    HashKind::Blake3 => HashKind::Sha256,
+                };
+                let mut w_ch = crate::challenger::FsChallenger::with_hash(b"m22-matrix", other_fs);
+                assert!(
+                    !recursive_verifier_with_basis(
+                        &v_cfg,
+                        &proof,
+                        &b,
+                        target,
+                        &initial_root,
+                        &mut w_ch
+                    ),
+                    "merkle={merkle_hash}: an {other_fs} transcript must reject an {fs_hash} proof"
+                );
+            }
+        }
     }
 
     /// Multi-claim batched basis: `b = γ_1·eq(z_1, ·) + γ_2·eq(z_2, ·)`,
@@ -6885,11 +7209,19 @@ mod tests {
             grinding_bits: vec![0; log_inv_rates.len()],
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
 
         let log_msg_cols_0 = log_n - initial_k;
         let ntt_0 = AdditiveNttF128::standard(log_msg_cols_0 + log_inv_rate);
-        let wtns_0 = ligero_commit(&poly, log_msg_cols_0, initial_k, log_inv_rate, &ntt_0);
+        let wtns_0 = ligero_commit(
+            &poly,
+            log_msg_cols_0,
+            initial_k,
+            log_inv_rate,
+            &ntt_0,
+            HashKind::Sha256,
+        );
         let initial_root = wtns_0.root();
 
         let mut p_ch = crate::challenger::FsChallenger::new(b"batched");
@@ -6915,6 +7247,7 @@ mod tests {
             grinding_bits: vec![0; log_inv_rates.len()],
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
         let mut v_ch = crate::challenger::FsChallenger::new(b"batched");
         let ok =
@@ -6956,6 +7289,7 @@ mod tests {
             grinding_bits: vec![0; log_inv_rates.len()],
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
 
         // Path 1: built-in L0 commit.
@@ -6965,8 +7299,14 @@ mod tests {
         // Path 2: build L0 externally via ligero_commit, then call _with_l0.
         let log_msg_cols_0 = log_n - initial_k;
         let ntt_0 = AdditiveNttF128::standard(log_msg_cols_0 + log_inv_rate);
-        let mut wtns_0_external =
-            ligero_commit(&poly, log_msg_cols_0, initial_k, log_inv_rate, &ntt_0);
+        let mut wtns_0_external = ligero_commit(
+            &poly,
+            log_msg_cols_0,
+            initial_k,
+            log_inv_rate,
+            &ntt_0,
+            HashKind::Sha256,
+        );
         let mut p_ch_b = crate::challenger::FsChallenger::new(b"l0-test");
         let proof_b = recursive_prover_with_l0(
             &cfg,
@@ -7007,6 +7347,7 @@ mod tests {
             grinding_bits: vec![0; log_inv_rates.len()],
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
         let mut v_ch = crate::challenger::FsChallenger::new(b"l0-test");
         assert!(recursive_verifier(&v_cfg, &proof_b, &z, v, &mut v_ch));
@@ -7046,6 +7387,7 @@ mod tests {
             grinding_bits: vec![0; log_inv_rates.len()],
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
         let verifier_cfg = VerifierConfig {
             log_inv_rates: log_inv_rates.clone(),
@@ -7059,6 +7401,7 @@ mod tests {
             grinding_bits: vec![0; log_inv_rates.len()],
             fold_grinding_bits: vec![0; 2],
             ood_samples: vec![0; 2],
+            merkle_hash: Default::default(),
         };
 
         let mut p_ch = crate::challenger::FsChallenger::new(b"test-mut");
@@ -7092,7 +7435,14 @@ mod tests {
             .collect();
 
         let ntt = AdditiveNttF128::standard(log_msg + log_inv_rate);
-        let w = ligero_commit(&poly, log_msg, log_interleaved, log_inv_rate, &ntt);
+        let w = ligero_commit(
+            &poly,
+            log_msg,
+            log_interleaved,
+            log_inv_rate,
+            &ntt,
+            HashKind::Sha256,
+        );
         assert_eq!(w.block_len, block_len);
         assert_eq!(w.num_interleaved, num_interleaved);
         assert_eq!(w.mat.len(), block_len * num_interleaved);
@@ -7122,7 +7472,14 @@ mod tests {
 
         // Merkle root is deterministic: re-running the same commit yields the
         // same root.
-        let w2 = ligero_commit(&poly, log_msg, log_interleaved, log_inv_rate, &ntt);
+        let w2 = ligero_commit(
+            &poly,
+            log_msg,
+            log_interleaved,
+            log_inv_rate,
+            &ntt,
+            HashKind::Sha256,
+        );
         assert_eq!(w.root(), w2.root());
     }
 }

--- a/crates/flock-core/src/permutation.rs
+++ b/crates/flock-core/src/permutation.rs
@@ -289,6 +289,7 @@ fn pcs_params(num_vars: usize) -> PcsParams {
         log_inv_rate: PCS_LOG_INV_RATE,
         log_batch_size: PCS_LOG_BATCH_SIZE,
         profile: Default::default(),
+        merkle_hash: Default::default(),
     }
 }
 

--- a/crates/flock-core/src/verifier.rs
+++ b/crates/flock-core/src/verifier.rs
@@ -112,13 +112,9 @@ fn verify_claims_ligerito_inner<Ch: Challenger>(
         })
         .collect();
     let x_refs: Vec<&[F128]> = x_fulls.iter().map(|v| v.as_slice()).collect();
-    let log_n = pcs_params.m - pcs::LOG_PACKING;
-    let lig_v_config = crate::pcs::ligerito::verifier_config_for(
-        log_n,
-        pcs_params.log_batch_size,
-        pcs_params.profile,
-    )
-    .expect("Ligerito default verifier config");
+    let lig_v_config = pcs_params
+        .ligerito_verifier_config()
+        .expect("Ligerito default verifier config");
     pcs::verify_opening_batch_ligerito_mixed(
         commitment,
         &values,

--- a/crates/flock-prover/Cargo.toml
+++ b/crates/flock-prover/Cargo.toml
@@ -208,3 +208,11 @@ harness = false
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "blake3_node_probe"
+harness = false
+
+[[bench]]
+name = "fs_challenger"
+harness = false

--- a/crates/flock-prover/benches/blake3_node_probe.rs
+++ b/crates/flock-prover/benches/blake3_node_probe.rs
@@ -1,0 +1,259 @@
+//! Where BLAKE3's Merkle cost actually goes, and which of the crate's entry
+//! points is fastest for our two node shapes.
+//!
+//! `benches/merkle.rs` showed BLAKE3 losing to the four-way hardware SHA-256
+//! path by 1.6–2.25×. This probe isolates why, by timing the candidate
+//! primitives for the two things `merkle_tree` does:
+//!
+//! - **Parent nodes** (two 32-byte CVs → 32 bytes), `num_leaves − 1` of them:
+//!   1. `blake3::hash(l || r)` — what the naive port does: a full `Hasher`
+//!      setup, one chunk, one compression.
+//!   2. `hazmat::merge_subtrees_non_root` — BLAKE3's own parent-node
+//!      compression. Stable public API, one compression, no chunk state.
+//!   3. `platform::hash_many` with PARENT flags — the same compression, but
+//!      four (NEON) at a time. `#[doc(hidden)]` "unstable, benchmarks only".
+//!
+//! - **Leaves** (`leaf_size` bytes → 32 bytes), `num_leaves` of them:
+//!   1. `blake3::hash(leaf)` — one at a time.
+//!   2. `platform::hash_many` with chunk flags — batched, but only usable when
+//!      `leaf_size` is a multiple of 64 and ≤ 1024 (so: the default 512-byte
+//!      `log_batch_size = 5` geometry yes, 16-byte leaves no).
+//!
+//! Run: `cargo bench --bench blake3_node_probe`
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use blake3::IncrementCounter;
+use blake3::hazmat::{Mode, merge_subtrees_non_root};
+use blake3::platform::{Platform, le_bytes_from_words_32, words_from_le_bytes_32};
+
+/// BLAKE3 domain flags (blake3 does not re-export these; they are fixed by the
+/// spec: CHUNK_START = 1, CHUNK_END = 2, PARENT = 4).
+const CHUNK_START: u8 = 1;
+const CHUNK_END: u8 = 2;
+const PARENT: u8 = 4;
+
+/// BLAKE3's IV, the key words for unkeyed hashing.
+const IV: [u32; 8] = [
+    0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
+];
+
+fn rep(label: &str, secs: f64, n: u64) {
+    println!(
+        "  {:<52}  {:>8.2} ms  {:>7.2} ns/node  {:>7.2} Mnode/s",
+        label,
+        secs * 1e3,
+        secs * 1e9 / n as f64,
+        n as f64 / secs / 1e6,
+    );
+}
+
+fn pattern(bytes: usize, seed: u64) -> Vec<u8> {
+    let mut buf = vec![0u8; bytes];
+    let mut s = seed;
+    for c in buf.chunks_mut(8) {
+        s = s.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = s;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        let v = z ^ (z >> 31);
+        let n = c.len().min(8);
+        c[..n].copy_from_slice(&v.to_le_bytes()[..n]);
+    }
+    buf
+}
+
+/// Parent nodes: `n` pairs of 32-byte children, three ways.
+fn bench_parents(n: usize) {
+    println!("\n===== Parent nodes ({n} × 64 B → 32 B) =====");
+    let children = pattern(n * 64, 0xA11CE);
+    let plat = Platform::detect();
+    println!(
+        "  (platform: {plat:?}, simd_degree = {})",
+        plat.simd_degree()
+    );
+
+    // 1. blake3::hash over the 64-byte concatenation.
+    let t = Instant::now();
+    let mut acc = 0u64;
+    for pair in children.chunks_exact(64) {
+        let h = blake3::hash(pair);
+        acc ^= u64::from_le_bytes(h.as_bytes()[..8].try_into().unwrap());
+    }
+    rep("blake3::hash(l || r)", t.elapsed().as_secs_f64(), n as u64);
+    black_box(acc);
+
+    // 2. hazmat parent-node compression (stable API, scalar).
+    let t = Instant::now();
+    let mut acc = 0u64;
+    for pair in children.chunks_exact(64) {
+        let l: &[u8; 32] = pair[..32].try_into().unwrap();
+        let r: &[u8; 32] = pair[32..].try_into().unwrap();
+        let cv = merge_subtrees_non_root(l, r, Mode::Hash);
+        acc ^= u64::from_le_bytes(cv[..8].try_into().unwrap());
+    }
+    rep(
+        "hazmat::merge_subtrees_non_root (stable)",
+        t.elapsed().as_secs_f64(),
+        n as u64,
+    );
+    black_box(acc);
+
+    // 3. hash_many with PARENT flags — N-at-a-time, N = simd_degree.
+    let deg = plat.simd_degree();
+    let mut out = vec![0u8; deg * 32];
+    let t = Instant::now();
+    let mut acc = 0u64;
+    for group in children.chunks(deg * 64) {
+        let blocks: Vec<&[u8; 64]> = group
+            .chunks_exact(64)
+            .map(|b| <&[u8; 64]>::try_from(b).unwrap())
+            .collect();
+        plat.hash_many(
+            &blocks,
+            &IV,
+            0,
+            IncrementCounter::No,
+            PARENT,
+            0,
+            0,
+            &mut out[..blocks.len() * 32],
+        );
+        acc ^= u64::from_le_bytes(out[..8].try_into().unwrap());
+    }
+    rep(
+        &format!("platform::hash_many PARENT ({deg}-way, unstable)"),
+        t.elapsed().as_secs_f64(),
+        n as u64,
+    );
+    black_box(acc);
+}
+
+/// Leaves of `LEAF` bytes, scalar vs batched. `LEAF` must be a multiple of 64
+/// and ≤ 1024 for the batched path to apply.
+fn bench_leaves<const LEAF: usize>(n: usize) {
+    println!("\n===== Leaves ({n} × {LEAF} B → 32 B) =====");
+    let data = pattern(n * LEAF, 0xB0B);
+    let plat = Platform::detect();
+
+    // 1. One at a time.
+    let t = Instant::now();
+    let mut acc = 0u64;
+    for leaf in data.chunks_exact(LEAF) {
+        let h = blake3::hash(leaf);
+        acc ^= u64::from_le_bytes(h.as_bytes()[..8].try_into().unwrap());
+    }
+    rep("blake3::hash(leaf)", t.elapsed().as_secs_f64(), n as u64);
+    black_box(acc);
+
+    // 2. Batched via hash_many, one chunk per leaf (CHUNK_START | CHUNK_END).
+    let deg = plat.simd_degree();
+    let mut out = vec![0u8; deg * 32];
+    let t = Instant::now();
+    let mut acc = 0u64;
+    for group in data.chunks(deg * LEAF) {
+        let leaves: Vec<&[u8; LEAF]> = group
+            .chunks_exact(LEAF)
+            .map(|b| <&[u8; LEAF]>::try_from(b).unwrap())
+            .collect();
+        plat.hash_many(
+            &leaves,
+            &IV,
+            0,
+            IncrementCounter::No,
+            0,
+            CHUNK_START,
+            CHUNK_END,
+            &mut out[..leaves.len() * 32],
+        );
+        acc ^= u64::from_le_bytes(out[..8].try_into().unwrap());
+    }
+    rep(
+        &format!("platform::hash_many chunk ({deg}-way, unstable)"),
+        t.elapsed().as_secs_f64(),
+        n as u64,
+    );
+    black_box(acc);
+}
+
+/// Sanity: the batched parent path must agree with the stable scalar one.
+fn check_parent_agreement() {
+    let plat = Platform::detect();
+    let children = pattern(4 * 64, 7);
+    let blocks: Vec<&[u8; 64]> = children
+        .chunks_exact(64)
+        .map(|b| <&[u8; 64]>::try_from(b).unwrap())
+        .collect();
+    let mut out = [0u8; 4 * 32];
+    plat.hash_many(
+        &blocks,
+        &IV,
+        0,
+        IncrementCounter::No,
+        PARENT,
+        0,
+        0,
+        &mut out,
+    );
+    for (i, pair) in children.chunks_exact(64).enumerate() {
+        let l: &[u8; 32] = pair[..32].try_into().unwrap();
+        let r: &[u8; 32] = pair[32..].try_into().unwrap();
+        let want = merge_subtrees_non_root(l, r, Mode::Hash);
+        assert_eq!(
+            &out[i * 32..(i + 1) * 32],
+            &want[..],
+            "hash_many PARENT disagrees with hazmat at lane {i}"
+        );
+    }
+    // Round-trip the word helpers so an API change here is caught loudly.
+    let w = words_from_le_bytes_32(&[0xAB; 32]);
+    assert_eq!(le_bytes_from_words_32(&w), [0xAB; 32]);
+    println!("(batched PARENT path agrees with hazmat::merge_subtrees_non_root)");
+
+    // And the batched chunk path must agree with `finalize_non_root`, the
+    // stable-API definition of a non-root leaf CV, for every leaf size that
+    // fits in one chunk. That equality is what lets the fast path exist.
+    check_leaf_agreement::<64>();
+    check_leaf_agreement::<512>();
+    check_leaf_agreement::<1024>();
+    println!("(batched chunk path agrees with HasherExt::finalize_non_root)");
+}
+
+fn check_leaf_agreement<const LEAF: usize>() {
+    use blake3::hazmat::HasherExt;
+    let plat = Platform::detect();
+    let data = pattern(4 * LEAF, 99);
+    let leaves: Vec<&[u8; LEAF]> = data
+        .chunks_exact(LEAF)
+        .map(|b| <&[u8; LEAF]>::try_from(b).unwrap())
+        .collect();
+    let mut out = [0u8; 4 * 32];
+    plat.hash_many(
+        &leaves,
+        &IV,
+        0,
+        IncrementCounter::No,
+        0,
+        CHUNK_START,
+        CHUNK_END,
+        &mut out,
+    );
+    for (i, leaf) in data.chunks_exact(LEAF).enumerate() {
+        let want: [u8; 32] = blake3::Hasher::new().update(leaf).finalize_non_root();
+        assert_eq!(
+            &out[i * 32..(i + 1) * 32],
+            &want[..],
+            "hash_many chunk disagrees with finalize_non_root at LEAF={LEAF} lane {i}"
+        );
+    }
+}
+
+fn main() {
+    check_parent_agreement();
+    // ~2^22 nodes keeps each measurement in the tens of ms.
+    bench_parents(1 << 22);
+    bench_leaves::<64>(1 << 22);
+    bench_leaves::<512>(1 << 19);
+    bench_leaves::<1024>(1 << 18);
+}

--- a/crates/flock-prover/benches/blake3_proof.rs
+++ b/crates/flock-prover/benches/blake3_proof.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use flock_prover::challenger::FsChallenger;
+use flock_prover::merkle::HashKind;
 use flock_prover::r1cs_hashes::blake3::{Blake3Setup, Compression, K_LOG, min_n_blocks_log};
 
 // Peak-heap tracker (wraps System), as in keccak_proof/sha2_proof — lets the
@@ -95,11 +96,31 @@ fn bench_one(n_blocks: usize, n_runs: usize) {
     );
 
     // BLAKE3_BATCH_MAJOR=1 switches the witness layout (WitnessLayout::BatchMajor).
-    let setup = if std::env::var_os("BLAKE3_BATCH_MAJOR").is_some() {
+    let mut setup = if std::env::var_os("BLAKE3_BATCH_MAJOR").is_some() {
         Blake3Setup::new_batch_major(n_blocks)
     } else {
         Blake3Setup::new(n_blocks)
     };
+    // FLOCK_MERKLE_HASH=sha256|blake3 selects the PCS Merkle hash (default
+    // sha256). Setting it on `pcs_params` is enough: the Ligerito prover and
+    // verifier configs are derived from those params, so the L0 commitment and
+    // every recursive level follow.
+    if let Ok(h) = std::env::var("FLOCK_MERKLE_HASH") {
+        setup.pcs_params.merkle_hash =
+            HashKind::parse(&h).expect("FLOCK_MERKLE_HASH must be sha256 or blake3");
+    }
+    let setup = setup;
+    // FLOCK_FS_HASH=sha256|blake3 selects the Fiat-Shamir transcript hash
+    // (default sha256), independently of the Merkle hash above.
+    let fs_hash = match std::env::var("FLOCK_FS_HASH") {
+        Ok(h) => HashKind::parse(&h).expect("FLOCK_FS_HASH must be sha256 or blake3"),
+        Err(_) => HashKind::default(),
+    };
+    let fs = || FsChallenger::with_hash(b"flock-bench-v0", fs_hash);
+    println!(
+        "  merkle hash: {}   fs hash: {}",
+        setup.pcs_params.merkle_hash, fs_hash
+    );
     // Generate n_runs + 2 distinct block vectors so each run hits a fresh
     // witness (and therefore a fresh Fiat-Shamir transcript). The first is
     // used for warm-up; the rest for measurements + one spare.
@@ -115,7 +136,7 @@ fn bench_one(n_blocks: usize, n_runs: usize) {
 
     // Warm-up.
     {
-        let mut ch_p = FsChallenger::new(b"flock-bench-v0");
+        let mut ch_p = fs();
         let (p, _, _) = setup.prove_fast(&block_sets[0], &mut ch_p);
         black_box(&p);
     }
@@ -125,7 +146,7 @@ fn bench_one(n_blocks: usize, n_runs: usize) {
     let mut best_fast = f64::INFINITY;
     for run in 0..n_runs {
         let blocks = &block_sets[run + 1];
-        let mut ch_p = FsChallenger::new(b"flock-bench-v0");
+        let mut ch_p = fs();
         let t0 = Instant::now();
         let (p, _, _) = setup.prove_fast(blocks, &mut ch_p);
         let elapsed = t0.elapsed().as_secs_f64();
@@ -150,11 +171,11 @@ fn bench_one(n_blocks: usize, n_runs: usize) {
     {
         let blocks_v = &block_sets[0];
         reset_peak();
-        let mut ch_p = FsChallenger::new(b"flock-bench-v0");
+        let mut ch_p = fs();
         let (proof, commitment, _) = setup.prove_fast(blocks_v, &mut ch_p);
         println!("  peak memory: {:>8.2} MB", peak_mb());
 
-        let mut ch_v = FsChallenger::new(b"flock-bench-v0");
+        let mut ch_v = fs();
         let t = Instant::now();
         let _ = setup
             .verify(&commitment, &proof, &mut ch_v)
@@ -175,7 +196,7 @@ fn bench_one(n_blocks: usize, n_runs: usize) {
     // zerocheck + lincheck + recursive PCS open) via prove_fast_timed, so the
     // phases decompose exactly the prover the headline number runs.
     println!("  [prove_fast breakdown]");
-    let mut ch = FsChallenger::new(b"flock-bench-v0");
+    let mut ch = fs();
     let (proof, _commitment, _claim, tm) = setup.prove_fast_timed(blocks, &mut ch);
     println!(
         "    {:32} {}",

--- a/crates/flock-prover/benches/fs_challenger.rs
+++ b/crates/flock-prover/benches/fs_challenger.rs
@@ -1,0 +1,203 @@
+//! Fiat-Shamir transcript cost, per hash.
+//!
+//! End-to-end prove timings cannot resolve the FS hash choice: the transcript
+//! is a low-single-digit percentage of a proof, which is the same order as
+//! run-to-run noise on this machine (and smaller than the position bias you
+//! get from benchmarking configurations in a fixed order). This measures the
+//! challenger directly instead, where the work is deterministic and the signal
+//! is clean.
+//!
+//! Three measurements per hash:
+//! 1. **Absorption** — `observe_f128`, the transcript's bulk input.
+//! 2. **Squeezing** — `sample_f128` and `sample_f128_vec`. This is where the
+//!    two genuinely differ: SHA-256 is not an XOF so it re-finalizes per
+//!    32 bytes (`SHA256(state ‖ ctr)`), while BLAKE3 finalizes once into an
+//!    XOF reader. The gap should widen with the squeeze length.
+//! 3. **PoW inner loop** — one hash of the 40-byte `state ‖ nonce` pre-image,
+//!    the operation `grind_pow` repeats ~2^bits times.
+//!
+//! Run: `cargo bench --bench fs_challenger`
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use flock_core::challenger::{Challenger, FsChallenger};
+use flock_core::field::F128;
+use flock_core::hash::HashKind;
+use sha2::{Digest, Sha256};
+
+const KINDS: [HashKind; 2] = [HashKind::Sha256, HashKind::Blake3];
+
+/// Repeats per measurement; reported as best-of, which is the run least
+/// perturbed by other work on the machine.
+const REPS: usize = 7;
+
+fn best<T>(mut f: impl FnMut() -> T) -> f64 {
+    // Warm-up.
+    black_box(f());
+    let mut b = f64::INFINITY;
+    for _ in 0..REPS {
+        let t = Instant::now();
+        black_box(f());
+        b = b.min(t.elapsed().as_secs_f64());
+    }
+    b
+}
+
+fn report(label: &str, secs: f64, ops: u64) {
+    println!(
+        "  {:<44}  {:>9.3} ms  {:>9.1} ns/op  {:>10.2} Mop/s",
+        label,
+        secs * 1e3,
+        secs * 1e9 / ops as f64,
+        ops as f64 / secs / 1e6,
+    );
+}
+
+fn main() {
+    println!("Fiat-Shamir transcript cost by hash (best of {REPS}).");
+
+    // ---- 1. Absorption.
+    println!("\n===== observe_f128 (transcript absorption) =====");
+    const N_OBSERVE: usize = 1 << 16;
+    for kind in KINDS {
+        let secs = best(|| {
+            let mut ch = FsChallenger::with_hash(b"fs-bench", kind);
+            for i in 0..N_OBSERVE {
+                ch.observe_f128(F128 {
+                    lo: i as u64,
+                    hi: !(i as u64),
+                });
+            }
+            ch.sample_f128()
+        });
+        report(
+            &format!("{kind}: {N_OBSERVE} × observe_f128"),
+            secs,
+            N_OBSERVE as u64,
+        );
+    }
+
+    // ---- 2. Squeezing, scalar.
+    println!("\n===== sample_f128 (16-byte squeeze each) =====");
+    const N_SAMPLE: usize = 1 << 14;
+    for kind in KINDS {
+        let secs = best(|| {
+            let mut ch = FsChallenger::with_hash(b"fs-bench", kind);
+            let mut acc = F128::ZERO;
+            for _ in 0..N_SAMPLE {
+                acc += ch.sample_f128();
+            }
+            acc
+        });
+        report(
+            &format!("{kind}: {N_SAMPLE} × sample_f128"),
+            secs,
+            N_SAMPLE as u64,
+        );
+    }
+
+    // ---- 2b. Squeezing, vector. SHA-256 pays one finalize per 32 output
+    // bytes here; BLAKE3 pays one finalize total, so the gap should grow with
+    // the request size.
+    println!("\n===== sample_f128_vec (one squeeze of 16n bytes) =====");
+    for n in [4usize, 16, 64, 256] {
+        for kind in KINDS {
+            const CALLS: usize = 1 << 10;
+            let secs = best(|| {
+                let mut ch = FsChallenger::with_hash(b"fs-bench", kind);
+                let mut acc = F128::ZERO;
+                for _ in 0..CALLS {
+                    acc += ch.sample_f128_vec(n)[0];
+                }
+                acc
+            });
+            report(
+                &format!(
+                    "{kind}: {CALLS} × sample_f128_vec({n})  [{} B/squeeze]",
+                    n * 16
+                ),
+                secs,
+                CALLS as u64,
+            );
+        }
+    }
+
+    // ---- 3. PoW inner loop, one nonce at a time. The pre-image length is
+    // per-hash: SHA-256 uses 40 bytes (one compression), BLAKE3 uses a padded
+    // 64-byte whole block so the search can be SIMD-batched.
+    println!("\n===== PoW inner loop, scalar (one nonce at a time) =====");
+    const N_POW: usize = 1 << 20;
+    let state = [0xA5u8; 32];
+    for kind in KINDS {
+        let secs = best(|| {
+            let mut acc = 0u8;
+            for nonce in 0..N_POW as u64 {
+                let h: [u8; 32] = match kind {
+                    HashKind::Sha256 => {
+                        let mut pre = [0u8; 40];
+                        pre[..32].copy_from_slice(&state);
+                        pre[32..].copy_from_slice(&nonce.to_le_bytes());
+                        Sha256::digest(pre).into()
+                    }
+                    HashKind::Blake3 => {
+                        let mut pre = [0u8; 64];
+                        pre[..32].copy_from_slice(&state);
+                        pre[32..40].copy_from_slice(&nonce.to_le_bytes());
+                        *blake3::hash(&pre).as_bytes()
+                    }
+                };
+                acc ^= h[0];
+            }
+            acc
+        });
+        report(
+            &format!("{kind}: {N_POW} × H(pre-image)"),
+            secs,
+            N_POW as u64,
+        );
+    }
+
+    // ---- 3b. The real thing: `grind_pow` at the bit levels the m=30 fast
+    // profile actually uses (fold_grinding_bits [17,12,9,6,4]). Deterministic
+    // per (domain, script, bits): the same transcript finds the same nonce and
+    // therefore does the same work every run.
+    println!("\n===== grind_pow (search for a satisfying nonce) =====");
+    for bits in [9u32, 12, 15, 17] {
+        for kind in KINDS {
+            let secs = best(|| {
+                let mut ch = FsChallenger::with_hash(b"fs-bench-grind", kind);
+                ch.observe_bytes(b"root");
+                ch.grind_pow(bits)
+            });
+            // Report against expected attempts (2^bits) rather than 1 op, so
+            // ns/op is the effective per-nonce cost including parallelism.
+            let expected = 1u64 << bits;
+            report(&format!("{kind}: grind_pow({bits})"), secs, expected);
+        }
+    }
+
+    // ---- 4. A transcript shaped like a real proof: interleaved observes and
+    // samples, which is what the sumcheck rounds actually do.
+    println!("\n===== mixed script (2 observes + 1 sample, ×N) =====");
+    const N_MIXED: usize = 1 << 14;
+    for kind in KINDS {
+        let secs = best(|| {
+            let mut ch = FsChallenger::with_hash(b"fs-bench", kind);
+            let mut acc = F128::ZERO;
+            for i in 0..N_MIXED {
+                ch.observe_f128(F128 {
+                    lo: i as u64,
+                    hi: 0,
+                });
+                ch.observe_f128(F128 {
+                    lo: 0,
+                    hi: i as u64,
+                });
+                acc += ch.sample_f128();
+            }
+            acc
+        });
+        report(&format!("{kind}: {N_MIXED} rounds"), secs, N_MIXED as u64);
+    }
+}

--- a/crates/flock-prover/benches/merkle.rs
+++ b/crates/flock-prover/benches/merkle.rs
@@ -1,21 +1,31 @@
-//! SHA-256 + Merkle-tree throughput sanity check.
+//! Hash + Merkle-tree throughput sanity check, run for **both** Merkle hashes
+//! so the `merkle_hash` config option can be chosen on measurements rather
+//! than on folklore.
 //!
-//! Three measurements:
-//! 1. **Raw streaming SHA-256**: one `Sha256` finalize over a large contiguous
-//!    buffer. Reports the per-byte cost of the hash itself — should hit
+//! Three measurements, each repeated per hash:
+//! 1. **Raw streaming hash**: one finalize over a large contiguous buffer.
+//!    Reports the per-byte cost of the hash itself — SHA-256 should hit
 //!    ~2.6 GB/s on M4 Max with HW acceleration, ~0.5 GB/s on the software
 //!    fallback (footgun: needs `features = ["asm"]` in Cargo.toml).
-//! 2. **Per-leaf SHA-256**: digest one 16-byte leaf at a time, summed over
-//!    many leaves (= what `merkle_tree`'s leaf level does sequentially).
+//! 2. **Per-leaf hash**: digest one leaf at a time, summed over many leaves
+//!    (= what `merkle_tree`'s leaf level does sequentially).
 //! 3. **Merkle tree (parallel)**: full tree build over a buffer matching the
 //!    PCS commit @ m=29 leaf count.
+//!
+//! The two hashes are not expected to win uniformly: SHA-256 has the four-way
+//! hardware path and BLAKE3 does not, but BLAKE3 costs one compression per
+//! 64-byte internal node against SHA-256's two, and SIMD-parallelizes within
+//! leaves past 1 KiB. Leaf size is what decides it, so the tree bench sweeps
+//! 16 B (one F128) through 512 B (the default `log_batch_size = 5` geometry).
 //!
 //! Run: `cargo bench --bench merkle`
 
 use std::time::Instant;
 
-use flock_prover::merkle::{hash_leaf, merkle_tree};
+use flock_prover::merkle::{HashKind, hash_leaf, merkle_tree};
 use sha2::{Digest, Sha256};
+
+const KINDS: [HashKind; 2] = [HashKind::Sha256, HashKind::Blake3];
 
 fn fmt_secs(s: f64) -> String {
     if s < 1e-3 {
@@ -74,18 +84,24 @@ fn alloc_pattern(bytes: usize, seed: u64) -> Vec<u8> {
     buf
 }
 
-/// Raw SHA-256: one `digest` over the whole buffer.
-fn bench_streaming_sha256(bytes: usize) {
+/// Raw one-shot hash over the whole buffer.
+fn bench_streaming(bytes: usize, kind: HashKind) {
     let data = alloc_pattern(bytes, 0xCAFE);
+    let once = |d: &[u8]| -> [u8; 32] {
+        match kind {
+            HashKind::Sha256 => Sha256::digest(d).into(),
+            HashKind::Blake3 => *blake3::hash(d).as_bytes(),
+        }
+    };
     // Warm-up.
-    let _ = Sha256::digest(&data);
+    let _ = once(&data);
 
     let t0 = Instant::now();
-    let digest = Sha256::digest(&data);
+    let digest = once(&data);
     let secs = t0.elapsed().as_secs_f64();
     let cs: u64 = u64::from_le_bytes(digest[..8].try_into().unwrap());
     report(
-        &format!("streaming Sha256::digest ({})", fmt_bytes(bytes as u64)),
+        &format!("streaming {kind} ({})", fmt_bytes(bytes as u64)),
         secs,
         bytes as u64,
         1,
@@ -94,26 +110,26 @@ fn bench_streaming_sha256(bytes: usize) {
     eprintln!("  (digest cs: {:016x})", cs);
 }
 
-/// Per-leaf SHA-256: call `hash_leaf` once per 16-byte leaf, sequentially.
-/// This is what the Merkle leaf level does (modulo parallelism).
-fn bench_per_leaf_sha256(num_leaves: usize, leaf_size: usize) {
+/// Per-leaf hash: call `hash_leaf` once per leaf, sequentially. This is what
+/// the Merkle leaf level does (modulo parallelism).
+fn bench_per_leaf(num_leaves: usize, leaf_size: usize, kind: HashKind) {
     let total = num_leaves * leaf_size;
     let data = alloc_pattern(total, 0xBEEF);
     // Warm-up: hash a few leaves.
     for chunk in data.chunks(leaf_size).take(8) {
-        let _ = hash_leaf(chunk);
+        let _ = hash_leaf(chunk, kind);
     }
 
     let mut cs: u64 = 0;
     let t0 = Instant::now();
     for chunk in data.chunks(leaf_size) {
-        let h = hash_leaf(chunk);
+        let h = hash_leaf(chunk, kind);
         cs ^= u64::from_le_bytes(h[..8].try_into().unwrap());
     }
     let secs = t0.elapsed().as_secs_f64();
     report(
         &format!(
-            "per-leaf hash_leaf (sequential, {} × {})",
+            "per-leaf hash_leaf {kind} (sequential, {} × {})",
             num_leaves,
             fmt_bytes(leaf_size as u64)
         ),
@@ -124,34 +140,45 @@ fn bench_per_leaf_sha256(num_leaves: usize, leaf_size: usize) {
     eprintln!("  (leaves cs: {:016x})", cs);
 }
 
+/// How many timed tree builds to run per configuration. A single shot is far
+/// too noisy to compare hashes with — run-to-run spread on an otherwise idle
+/// M4 Max is ~10-15% — so take the best of several, which is the run least
+/// perturbed by other work on the machine.
+const TREE_RUNS: usize = 7;
+
 /// Parallel Merkle tree (matches what `pcs::commit` calls at m=29).
-fn bench_merkle_tree(num_leaves: usize, leaf_size: usize) {
+/// Returns the *minimum* elapsed seconds over [`TREE_RUNS`] builds, so `main`
+/// can print a head-to-head ratio that is not dominated by scheduling noise.
+fn bench_merkle_tree(num_leaves: usize, leaf_size: usize, kind: HashKind) -> f64 {
     let total = num_leaves * leaf_size;
     let data = alloc_pattern(total, 0xDEAD);
-    // Warm-up: small tree.
-    {
-        let small = &data[..1024.min(total)];
-        let _ = merkle_tree(small, 16);
-    }
+    // Warm-up: one full build, so page faults and thread-pool spin-up are not
+    // charged to the first measurement.
+    let warm = merkle_tree(&data, num_leaves, kind);
+    let cs: u64 = u64::from_le_bytes(warm.last().unwrap()[..8].try_into().unwrap());
+    drop(warm);
 
-    let t0 = Instant::now();
-    let tree = merkle_tree(&data, num_leaves);
-    let secs = t0.elapsed().as_secs_f64();
-    let root = *tree.last().unwrap();
-    let cs: u64 = u64::from_le_bytes(root[..8].try_into().unwrap());
+    let mut best = f64::INFINITY;
+    for _ in 0..TREE_RUNS {
+        let t0 = Instant::now();
+        let tree = merkle_tree(&data, num_leaves, kind);
+        best = best.min(t0.elapsed().as_secs_f64());
+        std::hint::black_box(&tree);
+    }
     // Tree work = leaves + internal nodes; internal = num_leaves - 1 hashes.
     let total_hashes = (2 * num_leaves - 1) as u64;
     report(
         &format!(
-            "merkle_tree (rayon, {} leaves × {})",
+            "merkle_tree {kind} (rayon, {} leaves × {})",
             num_leaves,
             fmt_bytes(leaf_size as u64)
         ),
-        secs,
+        best,
         total as u64,
         total_hashes,
     );
     eprintln!("  (root cs: {:016x})", cs);
+    best
 }
 
 fn main() {
@@ -166,15 +193,43 @@ fn main() {
     )))]
     println!("(target: software fallback path — HW SHA-256 NOT active)");
 
-    header("Streaming SHA-256 (single digest over a large buffer)");
-    bench_streaming_sha256(64 * 1024); // 64 KB — fits in L1
-    bench_streaming_sha256(8 * 1024 * 1024); // 8 MB — DRAM-ish
-    bench_streaming_sha256(128 * 1024 * 1024); // 128 MB — matches PCS m=29 codeword
+    header("Streaming hash (single digest over a large buffer)");
+    for kind in KINDS {
+        bench_streaming(64 * 1024, kind); // 64 KB — fits in L1
+        bench_streaming(8 * 1024 * 1024, kind); // 8 MB — DRAM-ish
+        bench_streaming(128 * 1024 * 1024, kind); // 128 MB — PCS m=29 codeword
+    }
 
-    header("Per-leaf SHA-256 (one call per 16-B leaf — leaf level cost)");
-    bench_per_leaf_sha256(8 * 1024 * 1024, 16); // 8M leaves × 16 B = 128 MB
+    header("Per-leaf hash (one call per 16-B leaf — leaf level cost)");
+    for kind in KINDS {
+        bench_per_leaf(8 * 1024 * 1024, 16, kind); // 8M leaves × 16 B = 128 MB
+    }
 
     header("Merkle tree (parallel, matches PCS commit @ m=29 geometry)");
-    // m=29: codeword = 2^23 F128 = 128 MB. Leaves are 1 F128 = 16 B each, 2^23 leaves.
-    bench_merkle_tree(1 << 23, 16);
+    // m=29: codeword = 2^23 F128 = 128 MB. Sweep leaf size, since that is what
+    // decides which hash wins: 16 B = one F128 per leaf, 512 B / 1 KB = the
+    // log_batch_size = 5 / 6 geometries `pcs::commit` actually uses, 4 KB =
+    // past BLAKE3's 1 KiB chunk boundary, where its leaves stop batching.
+    for (num_leaves, leaf_size) in [
+        (1usize << 23, 16usize),
+        (1 << 18, 512),
+        (1 << 17, 1024),
+        (1 << 15, 4096),
+    ] {
+        let mut secs = [0.0f64; KINDS.len()];
+        for (i, kind) in KINDS.into_iter().enumerate() {
+            secs[i] = bench_merkle_tree(num_leaves, leaf_size, kind);
+        }
+        let (sha, blake) = (secs[0], secs[1]);
+        let (faster, ratio) = if blake < sha {
+            ("blake3", sha / blake)
+        } else {
+            ("sha256", blake / sha)
+        };
+        println!(
+            "  → {} leaves × {}: {faster} faster by {ratio:.2}×",
+            num_leaves,
+            fmt_bytes(leaf_size as u64)
+        );
+    }
 }

--- a/crates/flock-prover/benches/merkle_probe.rs
+++ b/crates/flock-prover/benches/merkle_probe.rs
@@ -4,14 +4,15 @@
 //!
 //! Usage:
 //!   cargo bench --bench merkle_probe --no-run
-//!   RAYON_NUM_THREADS=1 samply record -- ./target/release/deps/merkle_probe-<hash> [n_runs] [m]
+//!   RAYON_NUM_THREADS=1 samply record -- ./target/release/deps/merkle_probe-<hash> [n_runs] [m] [hash]
 //!
-//! Default: 50 runs at m=29 (~3 sec ST).
+//! Default: 50 runs at m=29 (~3 sec ST) under sha256. Pass `blake3` as the
+//! third argument to profile the other Merkle hash.
 
 use std::hint::black_box;
 use std::time::Instant;
 
-use flock_prover::merkle;
+use flock_prover::merkle::{self, HashKind};
 
 struct Rng(u64);
 impl Rng {
@@ -37,6 +38,10 @@ fn main() {
         .nth(2)
         .and_then(|s| s.parse().ok())
         .unwrap_or(29);
+    let kind = match std::env::args().nth(3) {
+        Some(s) => HashKind::parse(&s).expect("third arg must be sha256 or blake3"),
+        None => HashKind::Sha256,
+    };
     // Same shape as pcs::commit at this m: 128 MB codeword bytes, 262144 leaves of 1 KB each.
     let log_msg_len = m - 7;
     let log_batch_size = 6usize;
@@ -48,7 +53,7 @@ fn main() {
     let n_leaves = 1usize << k_code;
 
     println!(
-        "Merkle probe: m={m}, codeword {} MB ({} F128), leaves {}",
+        "Merkle probe: m={m}, hash={kind}, codeword {} MB ({} F128), leaves {}",
         codeword_bytes / (1024 * 1024),
         codeword_f128,
         n_leaves
@@ -62,13 +67,13 @@ fn main() {
     }
 
     // Warm-up.
-    let _ = merkle::merkle_tree(&data, n_leaves);
+    let _ = merkle::merkle_tree(&data, n_leaves, kind);
 
     let t0 = Instant::now();
     let mut times = Vec::with_capacity(n_runs);
     for _ in 0..n_runs {
         let t = Instant::now();
-        let tree = merkle::merkle_tree(&data, n_leaves);
+        let tree = merkle::merkle_tree(&data, n_leaves, kind);
         times.push(t.elapsed().as_secs_f64() * 1e3);
         black_box(&tree);
     }

--- a/crates/flock-prover/benches/pcs_commit.rs
+++ b/crates/flock-prover/benches/pcs_commit.rs
@@ -81,6 +81,7 @@ fn bench_commit_breakdown(m: usize) {
         log_inv_rate: 1,
         log_batch_size: 6,
         profile: Default::default(),
+        merkle_hash: Default::default(),
     };
     let n_bits = 1usize << m;
     let n_packed = 1usize << params.log_msg_len();
@@ -131,7 +132,8 @@ fn bench_commit_breakdown(m: usize) {
 
     // ---- 5. Merkle tree (leaves of num_ntts × 16 bytes).
     let t0 = Instant::now();
-    let merkle_tree = merkle::merkle_tree(&codeword_bytes, params.n_positions());
+    let merkle_tree =
+        merkle::merkle_tree(&codeword_bytes, params.n_positions(), params.merkle_hash);
     let secs_merkle = t0.elapsed().as_secs_f64();
     let _root = merkle_tree.last().unwrap();
     let leaf_bytes = params.leaf_size_bytes();
@@ -215,6 +217,7 @@ fn bench_commit_packed_only(m: usize) {
         log_inv_rate: 1,
         log_batch_size: 6,
         profile: Default::default(),
+        merkle_hash: Default::default(),
     };
     let n_packed = 1usize << params.log_msg_len();
     let n_code = params.codeword_len_f128();
@@ -268,6 +271,7 @@ fn bench_commit_packed_breakdown(m: usize) {
         log_inv_rate: 1,
         log_batch_size: 6,
         profile: Default::default(),
+        merkle_hash: Default::default(),
     };
     let n_packed = 1usize << params.log_msg_len();
     let n_code = params.codeword_len_f128();
@@ -314,7 +318,7 @@ fn bench_commit_packed_breakdown(m: usize) {
 
     // ---- 4. Merkle tree.
     let t0 = Instant::now();
-    let merkle_tree = merkle::merkle_tree(codeword_bytes, params.n_positions());
+    let merkle_tree = merkle::merkle_tree(codeword_bytes, params.n_positions(), params.merkle_hash);
     let secs_merkle = t0.elapsed().as_secs_f64();
     let _root = merkle_tree.last().unwrap();
 

--- a/crates/flock-prover/src/prover.rs
+++ b/crates/flock-prover/src/prover.rs
@@ -108,10 +108,9 @@ pub fn prove_ligerito<Ch: Challenger>(
     assert_eq!(z_packed.len(), 1usize << (r1cs.m - 7));
     assert_eq!(pcs_params.m, r1cs.m);
 
-    let log_n = r1cs.m - pcs::LOG_PACKING;
-    let lig_config =
-        pcs::ligerito::prover_config_for(log_n, pcs_params.log_batch_size, pcs_params.profile)
-            .expect("Ligerito default config; bump m for tiny instances");
+    let lig_config = pcs_params
+        .ligerito_prover_config()
+        .expect("Ligerito default config; bump m for tiny instances");
 
     let (commitment, prover_data) = pcs::commit(&z_packed, pcs_params);
     bind_statement(challenger, r1cs, &commitment);
@@ -211,10 +210,9 @@ pub fn prove_fast_ligerito_from_witness<Ch: Challenger>(
     prefaulted_codeword: Option<Vec<F128>>,
     challenger: &mut Ch,
 ) -> (R1csProofLigerito, Commitment, R1csClaim) {
-    let log_n = r1cs.m - pcs::LOG_PACKING;
-    let lig_config =
-        pcs::ligerito::prover_config_for(log_n, pcs_params.log_batch_size, pcs_params.profile)
-            .expect("Ligerito default config; bump m for tiny instances");
+    let lig_config = pcs_params
+        .ligerito_prover_config()
+        .expect("Ligerito default config; bump m for tiny instances");
 
     let ProveCore {
         zc_proof,
@@ -460,10 +458,9 @@ pub fn prove_fast_ligerito_timed<Ch: Challenger>(
     use std::time::Instant;
     let mut t = ProvePhaseTimings::default();
 
-    let log_n = r1cs.m - pcs::LOG_PACKING;
-    let lig_config =
-        pcs::ligerito::prover_config_for(log_n, pcs_params.log_batch_size, pcs_params.profile)
-            .expect("Ligerito default config; bump m for tiny instances");
+    let lig_config = pcs_params
+        .ligerito_prover_config()
+        .expect("Ligerito default config; bump m for tiny instances");
 
     // --- PCS commit ---
     let t0 = Instant::now();

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -1333,6 +1333,7 @@ impl Blake3Setup {
             log_inv_rate,
             log_batch_size: 6,
             profile,
+            merkle_hash: Default::default(),
         };
         Self {
             n_blocks,

--- a/crates/flock-prover/src/r1cs_hashes/chain_common.rs
+++ b/crates/flock-prover/src/r1cs_hashes/chain_common.rs
@@ -279,13 +279,9 @@ pub fn prove_chain_ligerito_generic<Ch: Challenger>(
     lincheck_circuit: &dyn flock_core::lincheck::LincheckCircuit,
     challenger: &mut Ch,
 ) -> (ChainProofLigerito, Commitment) {
-    let log_n = r1cs.m - flock_core::pcs::LOG_PACKING;
-    let lig_config = flock_core::pcs::ligerito::prover_config_for(
-        log_n,
-        pcs_params.log_batch_size,
-        pcs_params.profile,
-    )
-    .expect("Ligerito default config for chain prove; bump m for tiny instances");
+    let lig_config = pcs_params
+        .ligerito_prover_config()
+        .expect("Ligerito default config for chain prove; bump m for tiny instances");
 
     let core = crate::prover::prove_fast_core(
         r1cs,
@@ -387,13 +383,9 @@ pub fn verify_chain_ligerito_generic<Ch: Challenger>(
         value: claims.value,
     };
 
-    let log_n = r1cs.m - flock_core::pcs::LOG_PACKING;
-    let lig_v_config = flock_core::pcs::ligerito::verifier_config_for(
-        log_n,
-        pcs_params.log_batch_size,
-        pcs_params.profile,
-    )
-    .expect("Ligerito default verifier config for chain verify");
+    let lig_v_config = pcs_params
+        .ligerito_verifier_config()
+        .expect("Ligerito default verifier config for chain verify");
 
     flock_core::pcs::verify_opening_batch_ligerito_mixed(
         commitment,

--- a/crates/flock-prover/src/r1cs_hashes/keccak.rs
+++ b/crates/flock-prover/src/r1cs_hashes/keccak.rs
@@ -905,6 +905,7 @@ impl KeccakSetup {
             log_inv_rate,
             log_batch_size: 6,
             profile,
+            merkle_hash: Default::default(),
         };
         Self {
             n_keccaks,

--- a/crates/flock-prover/src/r1cs_hashes/keccak3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/keccak3.rs
@@ -531,6 +531,7 @@ impl KeccakSetup {
             log_inv_rate,
             log_batch_size: 6,
             profile,
+            merkle_hash: Default::default(),
         };
         Self {
             n_keccaks,

--- a/crates/flock-prover/src/r1cs_hashes/merkle_path_common.rs
+++ b/crates/flock-prover/src/r1cs_hashes/merkle_path_common.rs
@@ -326,13 +326,9 @@ pub fn prove_merkle_paths_ligerito_generic<Ch: Challenger>(
 ) -> (MerklePathProofLigerito, Commitment) {
     let trace = std::env::var("MERKLE_TRACE").is_ok();
 
-    let log_n = r1cs.m - LOG_PACKING;
-    let lig_config = flock_core::pcs::ligerito::prover_config_for(
-        log_n,
-        pcs_params.log_batch_size,
-        pcs_params.profile,
-    )
-    .expect("Ligerito config for merkle-path prove; bump m for tiny instances");
+    let lig_config = pcs_params
+        .ligerito_prover_config()
+        .expect("Ligerito config for merkle-path prove; bump m for tiny instances");
 
     // ---- Core: commit → zerocheck → lincheck.
     let t = if trace {
@@ -521,13 +517,9 @@ pub fn verify_merkle_paths_ligerito_generic<Ch: Challenger>(
         value: claims.value,
     };
 
-    let log_n = r1cs.m - LOG_PACKING;
-    let lig_v_config = flock_core::pcs::ligerito::verifier_config_for(
-        log_n,
-        pcs_params.log_batch_size,
-        pcs_params.profile,
-    )
-    .expect("Ligerito verifier config for merkle-path verify");
+    let lig_v_config = pcs_params
+        .ligerito_verifier_config()
+        .expect("Ligerito verifier config for merkle-path verify");
 
     flock_core::pcs::verify_opening_batch_ligerito_mixed(
         commitment,

--- a/crates/flock-prover/src/r1cs_hashes/sha2.rs
+++ b/crates/flock-prover/src/r1cs_hashes/sha2.rs
@@ -1319,6 +1319,7 @@ impl Sha256HybridSetup {
             log_inv_rate,
             log_batch_size: 6,
             profile,
+            merkle_hash: Default::default(),
         };
         Self {
             n_compressions,

--- a/crates/flock-prover/tests/verifier_roundtrip.rs
+++ b/crates/flock-prover/tests/verifier_roundtrip.rs
@@ -73,6 +73,7 @@ fn r1cs_prove_verify_roundtrip_ligerito() {
         log_inv_rate: 1,
         log_batch_size: 6,
         profile: Default::default(),
+        merkle_hash: Default::default(),
     };
     let mut ch_p = FsChallenger::new(b"flock-lig-r1cs-v0");
     let z_packed = pcs::pack_witness(&z, r1cs.m);


### PR DESCRIPTION
Two independent runtime options for which hash backs which component, both defaulting to SHA-256. Every existing config, serialized `PcsParams` and challenger call site keeps its current behaviour and produces identical digests.

```rust
params.merkle_hash = HashKind::Blake3;                    // Merkle commitments
FsChallenger::with_hash(domain, HashKind::Blake3)          // FS transcript
```

The Ligerito security config's `hash` field — previously documentation-only, `"sha256"` in all 42 embedded TOMLs — now actually drives the Merkle choice, and `validate()` rejects a spelling we don't implement instead of silently falling back.

## Reviewing this

It's large, but it splits into three parts:

1. **`hash.rs` + `merkle.rs`** — the `HashKind` enum and the BLAKE3 Merkle implementation. The substantive design is here.
2. **`pcs/commit.rs`, `pcs/ligerito.rs`, `prover.rs`, `verifier.rs`, `*_common.rs`** — plumbing, plus the source-of-truth fix below.
3. **`challenger.rs`** — the Fiat-Shamir option and the batched PoW search.

The rest is mechanical: a `merkle_hash: Default::default()` field in struct literals, and a threaded parameter.

## Design notes worth a look

**BLAKE3 Merkle uses BLAKE3's own tree semantics** — a leaf is a non-root chaining value, an internal node is a PARENT-flagged compression — rather than `blake3::hash` over concatenated bytes. Interior nodes shouldn't be root hashes, and the PARENT flag gives leaf/internal domain separation for free, which is the gap `merkle.rs`'s header calls out in the SHA-256 construction. A test records that difference explicitly.

Note this **deliberately diverges from `TomWambsgans/flock` `blake3-pcs`**, which defines a leaf as `blake3::hash(x)` and a parent as `blake3::hash(l ‖ r)`. That contract is simpler and reproducible with plain `blake3::hash`; this one buys domain separation instead. The two produce *different digests*, so the choice has to be made once, project-wide — flagging it for reconciliation. That branch also replaces SHA-256 outright and deletes the hand-written 4-way kernels; this keeps both hashes so they can be compared and so no-HW-SHA targets have a choice.

**A latent hazard is fixed here.** `PcsParams::merkle_hash` and the Ligerito prover/verifier configs were independent sources of truth: setting the former would have built the L0 commitment under one hash and the recursive levels under another — silently, and only at geometries deep enough to reach recursion. `PcsParams::ligerito_{prover,verifier}_config` are now the single entry point and stamp the params' hash over the embedded config's.

**`blake3::platform::hash_many` is `#[doc(hidden)]` and documented as "unstable, for benchmarks only".** This is a deliberate dependency: it's the only public route to the crate's SIMD-batched compression, and the alternative is hand-writing a 4-way NEON BLAKE3 next to `merkle/aarch64.rs`. The exposure is bounded — every batched result is asserted equal to the stable `hazmat` / `blake3::hash` spec, so an upstream semantic change fails the suite rather than silently altering commitments, and a removal fails the build. Reverting to the scalar `hazmat` path costs the batching but keeps the construction, if the dependency isn't wanted.

## Performance

On M4 Max. SHA-256 Merkle stays ahead — hardware SHA-2 plus the existing 4-way kernels beat BLAKE3 in the vector units. BLAKE3 is the portability / no-HW-SHA choice, not the fast one.

m=30 BLAKE3 R1CS proof, all four combinations prove **and verify**:

| merkle / fs | best prove |
|---|---|
| sha256 / sha256 | 105.6 ms |
| sha256 / blake3 | 106.1 ms |
| blake3 / sha256 | 108.1 ms |
| blake3 / blake3 | 109.7 ms |

Merkle tree alone, best-of-7 at the production 1 KB-leaf geometry: sha256 4.80 ms vs blake3 6.78 ms. Merkle is ~14% of commit at m=29 (5.01 of 36.53 ms), behind NTT and serialize.

BLAKE3's PoW nonce search is SIMD-batched (32/call): ~2.2× at 17 bits versus unbatched, which matters because the m30_fast profile grinds ~800k hashes. End-to-end that's ~1 ms of ~110 ms, i.e. below the bench's noise floor — the win is real at the primitive, not visible in a prove timing.

Two benchmarking notes for anyone reproducing these: single-shot tree timings swing 10–15% here, so `benches/merkle.rs` takes best-of-7; and benchmarking configurations in a fixed order produces a position bias that made blake3/blake3 look ~9 ms slow until the order was reversed.

## Testing

291 + 59 tests, clippy clean, fmt clean. New coverage:

- Every structural Merkle test and all 11 `FsChallenger` property tests now run under **both** hashes.
- Batched paths asserted equal to their stable-API scalar specs, at node counts either side of the batch boundary.
- Full Ligerito prove/verify over the 2×2 hash matrix, plus the rejection cases: a mismatched Merkle hash and a mismatched transcript hash must each fail to verify.
- `grind_pow` returns the globally smallest nonce on both the sequential and parallel paths, under both hashes — proof determinism depends on it.
- Every embedded TOML must name a hash we implement.

One caveat: during this work a single `cargo test --workspace` run reported `flock-prover --lib` failing with no test named in the captured output. It did not reproduce in five subsequent runs (three targeted, two full workspace), so I could not diagnose it. Flagging rather than calling the suite unconditionally green.

Also fixed along the way: `challenger.rs` and `flock-core/Cargo.toml` both claimed Fiat-Shamir was BLAKE3-based when it was SHA-256 throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
