### PR TITLE
zerocheck: port the AG-skip zerocheck and wire it end to end

### DIFF
--- a/crates/flock-core/src/challenger.rs
+++ b/crates/flock-core/src/challenger.rs
@@ -86,6 +86,15 @@ pub trait Challenger: Send {
     fn verify_pow(&mut self, _nonce: u64, _bits: u32) -> bool {
         true
     }
+
+    /// The hash backing this transcript, for protocol components that derive
+    /// auxiliary randomness outside the challenger itself (e.g. the AG-skip
+    /// `r₁` nonce-grind DRBG) and must follow the transcript's hash choice so
+    /// no second primitive enters the soundness argument. Default SHA-256
+    /// (`RandomChallenger` and legacy implementations inherit it).
+    fn hash_kind(&self) -> HashKind {
+        HashKind::Sha256
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -321,6 +330,10 @@ impl FsChallenger {
 }
 
 impl Challenger for FsChallenger {
+    fn hash_kind(&self) -> HashKind {
+        FsChallenger::hash_kind(self)
+    }
+
     fn observe_label(&mut self, label: &[u8]) {
         self.absorb(&[OP_LABEL]);
         self.absorb(&(label.len() as u64).to_le_bytes());

--- a/crates/flock-core/src/genus95_curve_code/mod.rs
+++ b/crates/flock-core/src/genus95_curve_code/mod.rs
@@ -45,7 +45,7 @@ pub use field::F128;
 pub use messages::{BaseMessage, ProductMessage};
 pub use product::product_code_message;
 pub use rand_core::RngCore;
-pub use rng::Sha256Rng;
+pub use rng::{Blake3Rng, FsRng, Sha256Rng};
 pub use sampling::{
     SAMPLE_ATTEMPT_BUDGET, SampleError, evaluation_point_from_nonce,
     sample_random_evaluation_point, try_evaluation_point,

--- a/crates/flock-core/src/genus95_curve_code/rng.rs
+++ b/crates/flock-core/src/genus95_curve_code/rng.rs
@@ -73,3 +73,82 @@ impl RngCore for Sha256Rng {
         }
     }
 }
+
+/// BLAKE3-XOF sibling of [`Sha256Rng`]: the stream is the XOF of
+/// `blake3(seed)`. Used when the Fiat-Shamir transcript runs BLAKE3
+/// ([`crate::hash::HashKind::Blake3`]) so the sampler's expander follows the
+/// transcript's hash and no second primitive enters the soundness argument.
+pub struct Blake3Rng {
+    reader: blake3::OutputReader,
+}
+
+impl Blake3Rng {
+    pub fn new(seed: [u8; 32]) -> Self {
+        let mut h = blake3::Hasher::new();
+        h.update(&seed);
+        Self {
+            reader: h.finalize_xof(),
+        }
+    }
+}
+
+impl RngCore for Blake3Rng {
+    fn next_u32(&mut self) -> u32 {
+        let mut b = [0u8; 4];
+        self.fill_bytes(&mut b);
+        u32::from_le_bytes(b)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut b = [0u8; 8];
+        self.fill_bytes(&mut b);
+        u64::from_le_bytes(b)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.reader.fill(dest);
+    }
+}
+
+/// Hash-dispatched DRBG over the two transcript hashes: SHA-256 counter mode
+/// or BLAKE3 XOF, seeded from 32 bytes. Protocol components that expand
+/// transcript squeezes (the AG-skip `r₁` derivation, the lincheck AG
+/// skip-point sampler) pick the arm from the challenger's
+/// [`hash_kind`](crate::challenger::Challenger::hash_kind), so the expander
+/// always matches the Fiat-Shamir hash.
+pub enum FsRng {
+    Sha256(Sha256Rng),
+    Blake3(Blake3Rng),
+}
+
+impl FsRng {
+    pub fn new(kind: crate::hash::HashKind, seed: [u8; 32]) -> Self {
+        match kind {
+            crate::hash::HashKind::Sha256 => FsRng::Sha256(Sha256Rng::new(seed)),
+            crate::hash::HashKind::Blake3 => FsRng::Blake3(Blake3Rng::new(seed)),
+        }
+    }
+}
+
+impl RngCore for FsRng {
+    fn next_u32(&mut self) -> u32 {
+        match self {
+            FsRng::Sha256(r) => r.next_u32(),
+            FsRng::Blake3(r) => r.next_u32(),
+        }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        match self {
+            FsRng::Sha256(r) => r.next_u64(),
+            FsRng::Blake3(r) => r.next_u64(),
+        }
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        match self {
+            FsRng::Sha256(r) => r.fill_bytes(dest),
+            FsRng::Blake3(r) => r.fill_bytes(dest),
+        }
+    }
+}

--- a/crates/flock-core/src/genus95_curve_code/sampling.rs
+++ b/crates/flock-core/src/genus95_curve_code/sampling.rs
@@ -2,7 +2,6 @@ use super::artin_schreier::ArtinSchreierSolver;
 use super::constants::{BASE_Y_DEGREE, SAMPLE_X_POWER_COUNT};
 use super::evaluator::{EvaluationPoint, eval_poly_mask, x_powers, y_powers};
 use super::field::{F128, F128Ext};
-use super::rng::Sha256Rng;
 #[cfg(test)]
 use super::tables::RationalMask;
 use super::tables::TABLES;
@@ -32,15 +31,32 @@ pub fn sample_random_evaluation_point(
 }
 
 /// One attempt from a 32-byte transcript seed and a grinding nonce: the
-/// attempt's DRBG is `Sha256Rng::new(SHA-256(seed ‖ LE32(nonce)))`, so each
-/// nonce yields an independent uniform draw. `None` = this nonce is rejected.
-pub fn evaluation_point_from_nonce(seed: &[u8; 32], nonce: u32) -> Option<EvaluationPoint> {
-    let mut h = Sha256::new();
-    h.update(seed);
-    h.update(nonce.to_le_bytes());
+/// attempt's DRBG is `FsRng::new(kind, H(seed ‖ LE32(nonce)))` where `H` and
+/// the DRBG follow the transcript hash `kind` (SHA-256 counter mode or BLAKE3
+/// XOF — see [`super::rng::FsRng`]), so each nonce yields an independent
+/// uniform draw and no second primitive enters the soundness argument.
+/// `None` = this nonce is rejected.
+pub fn evaluation_point_from_nonce(
+    seed: &[u8; 32],
+    nonce: u32,
+    kind: crate::hash::HashKind,
+) -> Option<EvaluationPoint> {
     let mut nonce_seed = [0u8; 32];
-    nonce_seed.copy_from_slice(&h.finalize());
-    try_evaluation_point(&mut Sha256Rng::new(nonce_seed))
+    match kind {
+        crate::hash::HashKind::Sha256 => {
+            let mut h = Sha256::new();
+            h.update(seed);
+            h.update(nonce.to_le_bytes());
+            nonce_seed.copy_from_slice(&h.finalize());
+        }
+        crate::hash::HashKind::Blake3 => {
+            let mut h = blake3::Hasher::new();
+            h.update(seed);
+            h.update(&nonce.to_le_bytes());
+            nonce_seed.copy_from_slice(h.finalize().as_bytes());
+        }
+    }
+    try_evaluation_point(&mut super::rng::FsRng::new(kind, nonce_seed))
 }
 
 /// One rejection-sampling attempt: draw `x` and lift `(y, z1, z2, z3)`,

--- a/crates/flock-core/src/lincheck.rs
+++ b/crates/flock-core/src/lincheck.rs
@@ -118,6 +118,7 @@
 
 use crate::challenger::Challenger;
 use crate::field::F128;
+use crate::genus95_curve_code::{EvaluationPoint, base_evaluation_functional};
 use crate::r1cs::SparseBinaryMatrix;
 use crate::zerocheck::multilinear::lagrange_weights_naive;
 use serde::{Deserialize, Serialize};
@@ -359,8 +360,10 @@ impl LincheckCircuit for CscCircuit {
 /// zerocheck's extract_c output uses.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct QuirkyPoint {
-    /// Univariate-skip challenge ∈ F₁₂₈. Binds all `k_skip` skip variables.
-    pub z_skip: F128,
+    /// Univariate-skip challenge. Binds all `k_skip` skip variables. φ₈ point
+    /// (`SkipPoint::Phi8`) for the RS path, AG `EvaluationPoint`
+    /// (`SkipPoint::Ag`) for the AG zerocheck's claims.
+    pub z_skip: SkipPoint,
     /// Multilinear coords for the inner dims *after* the skip block. Length
     /// `k_log − k_skip`.
     pub x_inner_rest: Vec<F128>,
@@ -392,8 +395,8 @@ pub struct LincheckProof {
 /// (publicly known to the caller).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LincheckClaim {
-    /// Univariate-skip post-vector random sample.
-    pub r_inner_skip: F128,
+    /// Univariate-skip post-vector random sample (same basis as the input skip).
+    pub r_inner_skip: SkipPoint,
     /// Multilinear post-vector random sample, length `k_log − k_skip`.
     pub r_inner_rest: Vec<F128>,
     /// `ẑ((r_inner_skip, r_inner_rest), x_ab.x_outer)` — the single
@@ -830,35 +833,113 @@ pub fn pack_z_lincheck_from_packed(
     z_packed
 }
 
-/// Build the **quirky eq table** for a claim point on the inner half:
+/// A univariate-skip evaluation point in one of the two supported bases. Both
+/// yield the length-`2^k_skip` skip evaluation functional via
+/// [`SkipPoint::weights`], which feeds [`build_quirky_eq_table_from_weights`]
+/// (the AB claim's input skip) and the lincheck output z-claim value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SkipPoint {
+    /// RS / φ₈ basis: a single field point; weights via `lagrange_weights_naive`.
+    Phi8(F128),
+    /// AG multiplication-code basis: a genus-95 curve point; weights via the
+    /// base-code evaluation functional. Always `k_skip = 6` (64 base coords).
+    Ag(EvaluationPoint),
+}
+
+impl SkipPoint {
+    /// The length-`2^k_skip` skip evaluation functional at this point.
+    pub fn weights(&self, k_skip: usize) -> Vec<F128> {
+        match self {
+            SkipPoint::Phi8(z) => lagrange_weights_naive(k_skip, *z),
+            SkipPoint::Ag(p) => {
+                debug_assert_eq!(
+                    k_skip,
+                    crate::zerocheck::ag_skip::K_SKIP,
+                    "AG base code is k_skip=6 only"
+                );
+                let bf = base_evaluation_functional(p)
+                    .expect("AG base evaluation functional: denominator nonzero at point");
+                (0..(1usize << k_skip)).map(|i| bf[i]).collect()
+            }
+        }
+    }
+
+    /// Sample a fresh skip point of the **same basis** as `self` from the
+    /// challenger. Call AFTER observing the preceding prover message (e.g.
+    /// `z_partial`) so the point is post-commitment for Schwartz-Zippel. The AG
+    /// arm seeds a hash-matched DRBG (`FsRng`, following the transcript hash)
+    /// from two F128 squeezes and replays the rejection sampler on both sides (unlike the zerocheck's `r₁`, which now uses the
+    /// prover-side nonce grind — see `ag_skip::sample_r1_prover`).
+    pub fn sample_fresh<Ch: crate::challenger::Challenger>(&self, ch: &mut Ch) -> SkipPoint {
+        match self {
+            SkipPoint::Phi8(_) => SkipPoint::Phi8(ch.sample_f128()),
+            SkipPoint::Ag(_) => {
+                ch.observe_label(b"flock-lincheck-ag-skip-point");
+                let s0 = ch.sample_f128();
+                let s1 = ch.sample_f128();
+                let mut seed = [0u8; 32];
+                seed[0..8].copy_from_slice(&s0.lo.to_le_bytes());
+                seed[8..16].copy_from_slice(&s0.hi.to_le_bytes());
+                seed[16..24].copy_from_slice(&s1.lo.to_le_bytes());
+                seed[24..32].copy_from_slice(&s1.hi.to_le_bytes());
+                let p = crate::genus95_curve_code::sample_random_evaluation_point(
+                    &mut crate::genus95_curve_code::FsRng::new(ch.hash_kind(), seed),
+                )
+                .unwrap_or_else(|_| crate::zerocheck::ag_skip::fallback_point());
+                SkipPoint::Ag(p)
+            }
+        }
+    }
+
+    /// Extract the φ₈ field point. Panics on an AG point — used at RS PCS-verify
+    /// boundaries that still operate on a single `F128 z_skip` and have not been
+    /// generalized to the AG clear-tail eval (#6). Keeps the RS path's `F128`
+    /// interface unchanged while the claim types carry `SkipPoint`.
+    pub fn phi8(&self) -> F128 {
+        match self {
+            SkipPoint::Phi8(z) => *z,
+            SkipPoint::Ag(_) => {
+                panic!(
+                    "SkipPoint::phi8 on an AG point — the AG PCS clear-tail path (#6) is not wired"
+                )
+            }
+        }
+    }
+}
+
+/// Build the **quirky eq table** from a precomputed skip-weight vector tensored
+/// with `eq(x_inner_rest)`:
 ///
 ///   `out[i_skip + i_inner_rest · 2^k_skip]
-///     = L_{i_skip}(z_skip)  ·  eq(x_inner_rest, i_inner_rest)`
+///     = skip_weights[i_skip] · eq(x_inner_rest, i_inner_rest)`
 ///
-/// where `L_{i_skip}` are Lagrange weights at `z_skip` for the φ_8 basis
-/// over `{0, …, 2^k_skip − 1}`. Length: `2^k_log`.
-///
-/// Encoding: the skip dim occupies the **low** `k_skip` bits of the table
-/// index (matches z_packed's stripe layout / zerocheck's LSB-first
-/// univariate-skip variable ordering). The `k_log − k_skip` multilinear
-/// inner-rest dims occupy the next bits.
-///
-/// Cost: 64 (Lagrange) + 32 (eq) + 2048 outer products ≈ tiny.
-pub fn build_quirky_eq_table(z_skip: F128, x_inner_rest: &[F128], k_skip: usize) -> Vec<F128> {
-    let ell_skip = 1usize << k_skip;
-    let ell_rest = 1usize << x_inner_rest.len();
-    let lambda_skip = lagrange_weights_naive(k_skip, z_skip);
+/// `skip_weights` (length `2^k_skip`) is the skip dimension's **evaluation
+/// functional** at its challenge: φ₈ Lagrange (`lagrange_weights_naive`, the RS
+/// path) or the AG base-code functional (`genus95_curve_code::
+/// base_evaluation_functional`, the native-`c` path). Encoding: the skip dim is
+/// the **low** `k_skip` table-index bits, the `inner_rest` dims the next bits.
+pub fn build_quirky_eq_table_from_weights(
+    skip_weights: &[F128],
+    x_inner_rest: &[F128],
+) -> Vec<F128> {
     let eq_rest = build_eq_table(x_inner_rest);
-    let total = ell_skip * ell_rest;
+    let total = skip_weights.len() * eq_rest.len();
     let mut out = Vec::with_capacity(total);
     // Layout: index = i_skip + i_inner_rest · 2^k_skip  ⇒  i_skip is low bits.
     for &er in &eq_rest {
-        for &ls in &lambda_skip {
+        for &ls in skip_weights {
             out.push(ls * er);
         }
     }
     debug_assert_eq!(out.len(), total);
     out
+}
+
+/// φ₈ (RS-path) quirky eq table: `skip_weights = L_{i_skip}(z_skip)` for the
+/// φ₈ basis over `{0,…,2^k_skip−1}`. Thin wrapper over
+/// [`build_quirky_eq_table_from_weights`]. Cost ≈ tiny.
+pub fn build_quirky_eq_table(z_skip: F128, x_inner_rest: &[F128], k_skip: usize) -> Vec<F128> {
+    build_quirky_eq_table_from_weights(&lagrange_weights_naive(k_skip, z_skip), x_inner_rest)
 }
 
 /// Dot product of two equal-length F128 slices.
@@ -1234,7 +1315,8 @@ fn prove_padded_inner<Ch: Challenger>(
     } else {
         None
     };
-    let eq_inner = build_quirky_eq_table(x_ab.z_skip, &x_ab.x_inner_rest, k_skip);
+    let eq_inner =
+        build_quirky_eq_table_from_weights(&x_ab.z_skip.weights(k_skip), &x_ab.x_inner_rest);
     if let Some(t) = t {
         eprintln!(
             "[lc] {:<26} {:>7.2} ms",
@@ -1339,12 +1421,12 @@ fn prove_padded_inner<Ch: Challenger>(
 
     // 7. Sample fresh z_skip AFTER observing z_partial — gives Schwartz-Zippel
     //    soundness on the φ8 (univariate-skip) dim.
-    let r_inner_skip = challenger.sample_f128();
+    let r_inner_skip = x_ab.z_skip.sample_fresh(challenger);
 
     // 8. Output claim's value: φ8 Lagrange combination of z_partial at z_skip.
     //    Equals ẑ_φ8(z_skip, r_rest, x_outer) when z_partial is honest; the
     //    PCS catches mismatches downstream.
-    let lambda = lagrange_weights_naive(k_skip, r_inner_skip);
+    let lambda = r_inner_skip.weights(k_skip);
     let w = inner_product(&lambda, &z_partial);
 
     // 9. Convert sumcheck challenges to LSB-first `x_inner_rest` order. The
@@ -1443,7 +1525,8 @@ pub fn verify<Ch: Challenger>(
     //    the prover made — sparse default delegates to the fused row-fold;
     //    per-hash impls walk the constraint graph directly).
     let t = std::time::Instant::now();
-    let eq_inner = build_quirky_eq_table(x_ab.z_skip, &x_ab.x_inner_rest, k_skip);
+    let eq_inner =
+        build_quirky_eq_table_from_weights(&x_ab.z_skip.weights(k_skip), &x_ab.x_inner_rest);
     if trace {
         eprintln!(
             "        [lcv] build_quirky_eq_table (2^{k_log}): {}",
@@ -1509,13 +1592,13 @@ pub fn verify<Ch: Challenger>(
     }
 
     // 6. Sample fresh z_skip AFTER z_partial — gives SZ on the φ8 dim.
-    let r_inner_skip = challenger.sample_f128();
+    let r_inner_skip = x_ab.z_skip.sample_fresh(challenger);
 
     // 7. Derive output claim value via φ8 Lagrange on z_partial at z_skip.
     //    Equals ẑ_φ8(z_skip, r_rest, x_outer) when z_partial is honest;
     //    PCS catches mismatches downstream.
     let t = std::time::Instant::now();
-    let lambda = lagrange_weights_naive(k_skip, r_inner_skip);
+    let lambda = r_inner_skip.weights(k_skip);
     let w = inner_product(&lambda, &proof.z_partial);
     if trace {
         eprintln!(
@@ -1591,7 +1674,7 @@ mod tests {
     /// x_inner_rest of length `k_log − k_skip`, x_outer of length `n_log`.
     fn random_quirky_point(m: usize, k_log: usize, k_skip: usize, rng: &mut Rng) -> QuirkyPoint {
         QuirkyPoint {
-            z_skip: rng.f128(),
+            z_skip: SkipPoint::Phi8(rng.f128()),
             x_inner_rest: rng.f128_vec(k_log - k_skip),
             x_outer: rng.f128_vec(m - k_log),
         }
@@ -1619,7 +1702,7 @@ mod tests {
         let n_outer = 1usize << (m - k_log);
         assert_eq!(f.len(), 1 << m);
 
-        let lambda = crate::zerocheck::multilinear::lagrange_weights_naive(k_skip, point.z_skip);
+        let lambda = point.z_skip.weights(k_skip);
         let eq_rest = build_eq_table(&point.x_inner_rest);
         let eq_outer = build_eq_table(&point.x_outer);
         debug_assert_eq!(lambda.len(), k_skip_dim);
@@ -2117,7 +2200,8 @@ mod tests {
 
         // Pick a mutation position where BOTH row vectors are nonzero so the
         // mutation guarantees both checks would diverge.
-        let eq_inner = build_quirky_eq_table(x_ab.z_skip, &x_ab.x_inner_rest, k_skip);
+        let eq_inner =
+            build_quirky_eq_table_from_weights(&x_ab.z_skip.weights(k_skip), &x_ab.x_inner_rest);
         let row_a = sparse_row_fold(&a_0, &eq_inner);
         let row_b = sparse_row_fold(&b_0, &eq_inner);
         let idx = (0..k)

--- a/crates/flock-core/src/pcs.rs
+++ b/crates/flock-core/src/pcs.rs
@@ -563,7 +563,7 @@ pub struct PackedDirectClaimRef<'a> {
 pub fn verify_opening_batch_ligerito_mixed<Ch: Challenger>(
     commitment: &Commitment,
     claims: &[F128],
-    z_skips: &[F128],
+    skip_weights: &[&[F128]],
     x_outers: &[&[F128]],
     packed_direct: &[PackedDirectClaimRef<'_>],
     proof: &BatchOpeningProofLigerito,
@@ -572,7 +572,7 @@ pub fn verify_opening_batch_ligerito_mixed<Ch: Challenger>(
 ) -> Result<(), VerifyError> {
     let n_rs = claims.len();
     let n_pd = packed_direct.len();
-    assert_eq!(z_skips.len(), n_rs);
+    assert_eq!(skip_weights.len(), n_rs);
     assert_eq!(x_outers.len(), n_rs);
     assert_eq!(proof.ring_switches.len(), n_rs);
     assert!(n_rs + n_pd > 0);
@@ -586,7 +586,7 @@ pub fn verify_opening_batch_ligerito_mixed<Ch: Challenger>(
     for i in 0..n_rs {
         let out = ring_switch::verify_succinct(
             claims[i],
-            z_skips[i],
+            skip_weights[i],
             x_outers[i],
             &proof.ring_switches[i],
             challenger,
@@ -827,7 +827,7 @@ mod tests {
         verify_opening_batch_ligerito_mixed(
             &commitment,
             &[rs_claim],
-            &[z_skip],
+            &[&lagrange_weights_naive(6, z_skip)],
             &[x_outer.as_slice()],
             &[],
             &proof,

--- a/crates/flock-core/src/pcs/ring_switch.rs
+++ b/crates/flock-core/src/pcs/ring_switch.rs
@@ -124,21 +124,24 @@ impl ChunkPadding {
 }
 
 /// Build the 128-entry weights vector for the verifier's ring-switching claim
-/// check, given the zerocheck's `z_skip` (univariate-skip coord, absorbs 6
-/// boolean coords via the φ_8 basis) and `x_outer_0` (the 7th prefix bit, a
-/// fresh F_{2^128} multilinear coord).
+/// check from a precomputed 64-entry **skip evaluation functional** and
+/// `x_outer_0` (the 7th packing-prefix bit, a multilinear coord).
 ///
 /// ```text
-/// weights[i] = ν_φ8(i & 63)(z_skip) · eq(x_outer_0, (i >> 6) & 1)
+/// weights[i] = skip_weights[i & 63] · eq(x_outer_0, (i >> 6) & 1)
 ///            for i ∈ {0..128}
 /// ```
 ///
-/// `i & 63` selects the low 6 bits (LCH dimensions); `(i >> 6) & 1` is the 7th
-/// bit (a standard multilinear coord).
-pub fn build_claim_weights(z_skip: F128, x_outer_0: F128) -> Vec<F128> {
+/// `i & 63` selects the low 6 bits (the skip dimension); `(i >> 6) & 1` is the
+/// 7th packing bit. `skip_weights` is the skip dim's evaluation functional at
+/// its challenge in EITHER basis: φ₈ Lagrange (`lagrange_weights_naive`, the RS
+/// path — see [`build_claim_weights`]) or the AG base-code functional
+/// (`genus95_curve_code::base_evaluation_functional`, the AG-skip path). The
+/// skip stays inside the packing prefix in both bases; the ring-switch suffix
+/// machinery (`fold_b128` / `eval_rs_eq`) never sees it, so it is untouched.
+pub fn build_claim_weights_from_skip(skip_weights: &[F128], x_outer_0: F128) -> Vec<F128> {
     const K_SKIP: usize = 6;
-    let lambda = lagrange_weights_naive(K_SKIP, z_skip); // length 64
-    debug_assert_eq!(lambda.len(), 1 << K_SKIP);
+    debug_assert_eq!(skip_weights.len(), 1 << K_SKIP);
 
     let eq_lo = F128::ONE + x_outer_0; // eq(x_outer_0, 0)
     let eq_hi = x_outer_0; // eq(x_outer_0, 1)
@@ -150,9 +153,17 @@ pub fn build_claim_weights(z_skip: F128, x_outer_0: F128) -> Vec<F128> {
         let i_lo = i & 63;
         let bit_6 = (i >> 6) & 1;
         let eq_b6 = if bit_6 == 1 { eq_hi } else { eq_lo };
-        weights.push(lambda[i_lo] * eq_b6);
+        weights.push(skip_weights[i_lo] * eq_b6);
     }
     weights
+}
+
+/// φ₈ (RS-path) wrapper over [`build_claim_weights_from_skip`]: derives the
+/// length-64 skip functional from a single field point `z_skip` via the φ₈
+/// Lagrange basis over `{0,…,63}`.
+pub fn build_claim_weights(z_skip: F128, x_outer_0: F128) -> Vec<F128> {
+    const K_SKIP: usize = 6;
+    build_claim_weights_from_skip(&lagrange_weights_naive(K_SKIP, z_skip), x_outer_0)
 }
 
 /// Batched version of [`fold_1b_rows_naive`]: compute `s_hat_v_k` for each
@@ -2566,7 +2577,8 @@ pub fn prove_batched_padded_with_precomputed<Ch: Challenger>(
 ///
 /// Inputs:
 /// - `claim`: the zerocheck's claim value `ẑ_skip(z_skip, x_outer)`.
-/// - `z_skip` ∈ F_{2^128}: the univariate-skip coord.
+/// - `skip_weights` (length 64): the skip dim's evaluation functional at its
+///   challenge — φ₈ Lagrange (RS) or AG base-code (`base_evaluation_functional`).
 /// - `x_outer` (length m − 6): the multilinear coords.
 /// - `proof`: the prover's `s_hat_v` message.
 /// - `challenger` for sampling `r''` in lockstep with the prover.
@@ -2575,7 +2587,7 @@ pub fn prove_batched_padded_with_precomputed<Ch: Challenger>(
 /// `ClaimMismatch` error if `weights · s_hat_v ≠ claim`.
 pub fn verify<Ch: Challenger>(
     claim: F128,
-    z_skip: F128,
+    skip_weights: &[F128],
     x_outer: &[F128],
     proof: &RingSwitchProof,
     challenger: &mut Ch,
@@ -2589,8 +2601,8 @@ pub fn verify<Ch: Challenger>(
     // Verifier observes s_hat_v.
     challenger.observe_f128_slice(&proof.s_hat_v);
 
-    // Check the claim against ν_φ8 ⊗ eq weights.
-    let weights = build_claim_weights(z_skip, x_outer[0]);
+    // Check the claim against skip ⊗ eq weights.
+    let weights = build_claim_weights_from_skip(skip_weights, x_outer[0]);
     if claim_check(&weights, &proof.s_hat_v) != claim {
         return Err(VerifyError::ClaimMismatch);
     }
@@ -2635,7 +2647,7 @@ pub struct RingSwitchVerifierOutput {
 /// instead of `O(2^(m−7))`.
 pub fn verify_succinct<Ch: Challenger>(
     claim: F128,
-    z_skip: F128,
+    skip_weights: &[F128],
     x_outer: &[F128],
     proof: &RingSwitchProof,
     challenger: &mut Ch,
@@ -2646,7 +2658,7 @@ pub fn verify_succinct<Ch: Challenger>(
     challenger.observe_label(b"flock-ring-switch-v0");
     challenger.observe_f128_slice(&proof.s_hat_v);
 
-    let weights = build_claim_weights(z_skip, x_outer[0]);
+    let weights = build_claim_weights_from_skip(skip_weights, x_outer[0]);
     if claim_check(&weights, &proof.s_hat_v) != claim {
         return Err(VerifyError::ClaimMismatch);
     }
@@ -2954,8 +2966,14 @@ mod tests {
 
             // Verifier (matched challenger).
             let mut ch_v = FsChallenger::new(b"flock-test-v0");
-            let out_v = verify(claim, z_skip, &x_outer, &proof, &mut ch_v)
-                .unwrap_or_else(|e| panic!("verify rejected honest at m={m}: {e:?}"));
+            let out_v = verify(
+                claim,
+                &lagrange_weights_naive(6, z_skip),
+                &x_outer,
+                &proof,
+                &mut ch_v,
+            )
+            .unwrap_or_else(|e| panic!("verify rejected honest at m={m}: {e:?}"));
 
             assert_eq!(
                 out_p.sumcheck_claim, out_v.sumcheck_claim,
@@ -3006,7 +3024,13 @@ mod tests {
         proof.s_hat_v[0].lo ^= 1;
 
         let mut ch_v = FsChallenger::new(b"flock-test-v0");
-        let res = verify(claim, z_skip, &x_outer, &proof, &mut ch_v);
+        let res = verify(
+            claim,
+            &lagrange_weights_naive(6, z_skip),
+            &x_outer,
+            &proof,
+            &mut ch_v,
+        );
         assert!(matches!(res, Err(VerifyError::ClaimMismatch)));
     }
 

--- a/crates/flock-core/src/proof.rs
+++ b/crates/flock-core/src/proof.rs
@@ -21,6 +21,20 @@ pub struct R1csProofLigerito {
     pub pcs_open: pcs::BatchOpeningProofLigerito,
 }
 
+/// Top-level R1CS proof with the **AG-skip** zerocheck + Ligerito PCS backend.
+/// Identical downstream of the zerocheck (lincheck + the same standard
+/// ring-switch open on the std pack); only round 1 of the zerocheck differs
+/// (the genus-95 AG multiplication code replaces the RS additive-NTT skip), so
+/// `ag` carries the AG round messages instead of a `ZerocheckProof`. The skip
+/// stays in the packing prefix `[skip 6 | bit6]`, so both `(ab, c)` claims open
+/// via the unchanged RS path with AG base-code skip weights.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct R1csProofLigeritoAg {
+    pub ag: zerocheck::ag_skip::AgProof,
+    pub lincheck: lincheck::LincheckProof,
+    pub pcs_open: pcs::BatchOpeningProofLigerito,
+}
+
 /// A claim of the form `ẑ(point) = value` for the witness `z`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ZClaim {

--- a/crates/flock-core/src/r1cs.rs
+++ b/crates/flock-core/src/r1cs.rs
@@ -245,7 +245,7 @@ impl BlockR1cs {
     /// being `[dim6, chunk…]`.
     pub fn x_ab_from_mlv(
         &self,
-        z_skip: crate::field::F128,
+        z_skip: crate::lincheck::SkipPoint,
         mlv: &[crate::field::F128],
     ) -> crate::lincheck::QuirkyPoint {
         let inner_rest_len = self.k_log - self.k_skip;
@@ -279,7 +279,7 @@ impl BlockR1cs {
     /// See [`WitnessLayout`] for the BatchMajor point convention.
     pub fn ab_claim_point(
         &self,
-        r_inner_skip: crate::field::F128,
+        r_inner_skip: crate::lincheck::SkipPoint,
         r_inner_rest: &[crate::field::F128],
         x_outer: &[crate::field::F128],
     ) -> crate::lincheck::QuirkyPoint {
@@ -306,7 +306,7 @@ impl BlockR1cs {
     /// `r_rest` (which is address-ordered in both layouts).
     pub fn c_claim_point(
         &self,
-        z_skip: crate::field::F128,
+        z_skip: crate::lincheck::SkipPoint,
         r_rest: &[crate::field::F128],
     ) -> crate::lincheck::QuirkyPoint {
         let inner_rest_len = self.k_log - self.k_skip;

--- a/crates/flock-core/src/verifier.rs
+++ b/crates/flock-core/src/verifier.rs
@@ -6,6 +6,7 @@
 use crate::challenger::Challenger;
 use crate::field::F128;
 use crate::lincheck;
+use crate::lincheck::SkipPoint;
 use crate::pcs::{self, Commitment};
 use crate::proof::{R1csClaim, R1csProofLigerito, ZClaim};
 use crate::r1cs::BlockR1cs;
@@ -14,6 +15,8 @@ use crate::zerocheck;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum VerifyError {
     Zerocheck(zerocheck::VerifyError),
+    /// AG-skip zerocheck round replay failed (`verify_core_ag`).
+    Ag(zerocheck::ag_skip::AgVerifyError),
     Lincheck(lincheck::VerifyError),
     PcsAb(pcs::VerifyError),
     PcsC(pcs::VerifyError),
@@ -77,6 +80,108 @@ pub fn verify_ligerito<Ch: Challenger>(
     Ok(R1csClaim { ab, c })
 }
 
+/// AG-skip mirror of [`verify_ligerito`]: replays the AG zerocheck
+/// ([`zerocheck::ag_skip::verify`], including the single-attempt r₁ nonce
+/// re-derivation) + lincheck → base claims, then the standard ring-switch
+/// Ligerito open with AG base-code skip weights. Counterpart of
+/// `flock_prover::prover::prove_fast_ligerito_ag_from_witness`.
+pub fn verify_ligerito_ag<Ch: Challenger>(
+    r1cs: &BlockR1cs,
+    commitment: &Commitment,
+    proof: &crate::proof::R1csProofLigeritoAg,
+    lincheck_circuit: &dyn lincheck::LincheckCircuit,
+    pcs_params: &crate::pcs::PcsParams,
+    challenger: &mut Ch,
+) -> Result<R1csClaim, VerifyError> {
+    let (ab, c) = verify_core_ag(
+        r1cs,
+        &proof.ag,
+        &proof.lincheck,
+        commitment,
+        lincheck_circuit,
+        challenger,
+    )?;
+    verify_claims_ligerito(
+        commitment,
+        &[ab.clone(), c.clone()],
+        &proof.pcs_open,
+        pcs_params,
+        challenger,
+    )
+    .map_err(VerifyError::PcsAb)?;
+    Ok(R1csClaim { ab, c })
+}
+
+/// AG-skip mirror of [`verify_core`]: replay bind → AG zerocheck → lincheck
+/// and reconstruct the two base z-claims, stopping before the PCS open.
+pub fn verify_core_ag<Ch: Challenger>(
+    r1cs: &BlockR1cs,
+    ag_proof: &zerocheck::ag_skip::AgProof,
+    lincheck_proof: &lincheck::LincheckProof,
+    commitment: &Commitment,
+    lincheck_circuit: &dyn lincheck::LincheckCircuit,
+    challenger: &mut Ch,
+) -> Result<(ZClaim, ZClaim), VerifyError> {
+    verifier_pool().install(move || {
+        verify_core_ag_inner(
+            r1cs,
+            ag_proof,
+            lincheck_proof,
+            commitment,
+            lincheck_circuit,
+            challenger,
+        )
+    })
+}
+
+fn verify_core_ag_inner<Ch: Challenger>(
+    r1cs: &BlockR1cs,
+    ag_proof: &zerocheck::ag_skip::AgProof,
+    lincheck_proof: &lincheck::LincheckProof,
+    commitment: &Commitment,
+    lincheck_circuit: &dyn lincheck::LincheckCircuit,
+    challenger: &mut Ch,
+) -> Result<(ZClaim, ZClaim), VerifyError> {
+    assert_eq!(
+        r1cs.k_skip,
+        zerocheck::ag_skip::K_SKIP,
+        "AG skip is k_skip=6"
+    );
+
+    // ---- Bind FS transcript to the statement (mirrors the AG prover).
+    crate::proof::bind_statement(challenger, r1cs, commitment);
+
+    // ---- Replay the AG-skip zerocheck rounds.
+    let ag_claim =
+        zerocheck::ag_skip::verify(r1cs.m, ag_proof, challenger).map_err(VerifyError::Ag)?;
+
+    // ---- Lincheck on the AG quirky point (layout-aware constructors).
+    let x_ab = r1cs.x_ab_from_mlv(SkipPoint::Ag(ag_claim.r1), &ag_claim.mlv_challenges);
+    let lc_claim = lincheck::verify(
+        r1cs.m,
+        r1cs.k_log,
+        r1cs.k_skip,
+        lincheck_circuit,
+        &x_ab,
+        ag_claim.a_eval,
+        ag_claim.b_eval,
+        lincheck_proof,
+        challenger,
+    )
+    .map_err(VerifyError::Lincheck)?;
+
+    // ---- Build the two z-claims (must match what the AG prover returned).
+    let ab = ZClaim {
+        point: r1cs.ab_claim_point(lc_claim.r_inner_skip, &lc_claim.r_inner_rest, &x_ab.x_outer),
+        value: lc_claim.w,
+    };
+    let c = ZClaim {
+        point: r1cs.c_claim_point(SkipPoint::Ag(ag_claim.r1), &ag_claim.r_rest),
+        value: ag_claim.c_eval,
+    };
+    Ok((ab, c))
+}
+
 /// Verify a batched PCS opening over an arbitrary list of `ẑ`-claims — the
 /// mirror of `flock_prover::prover::open_claims_with_precomputed_ligerito`.
 /// Relation wrappers (e.g. the hash chain) reuse this with their own appended
@@ -101,7 +206,11 @@ fn verify_claims_ligerito_inner<Ch: Challenger>(
     pcs_params: &crate::pcs::PcsParams,
     challenger: &mut Ch,
 ) -> Result<(), pcs::VerifyError> {
-    let z_skips: Vec<F128> = claims.iter().map(|c| c.point.z_skip).collect();
+    let skip_weight_vecs: Vec<Vec<F128>> = claims
+        .iter()
+        .map(|c| c.point.z_skip.weights(pcs::LOG_PACKING - 1))
+        .collect();
+    let skip_weights: Vec<&[F128]> = skip_weight_vecs.iter().map(|v| v.as_slice()).collect();
     let values: Vec<F128> = claims.iter().map(|c| c.value).collect();
     let x_fulls: Vec<Vec<F128>> = claims
         .iter()
@@ -118,7 +227,7 @@ fn verify_claims_ligerito_inner<Ch: Challenger>(
     pcs::verify_opening_batch_ligerito_mixed(
         commitment,
         &values,
-        &z_skips,
+        &skip_weights,
         &x_refs,
         &[],
         pcs_open,
@@ -193,7 +302,7 @@ fn verify_core_inner<Ch: Challenger>(
 
     // ---- Build lincheck's shared quirky point from the zerocheck output
     // (layout-aware: the mlv challenges are address-ordered).
-    let x_ab = r1cs.x_ab_from_mlv(zc_claim.z, &zc_claim.mlv_challenges);
+    let x_ab = r1cs.x_ab_from_mlv(SkipPoint::Phi8(zc_claim.z), &zc_claim.mlv_challenges);
 
     // ---- Lincheck. v_a, v_b come from the zerocheck's final â, b̂ evals.
     let t = std::time::Instant::now();
@@ -224,7 +333,7 @@ fn verify_core_inner<Ch: Challenger>(
     };
     // c-claim is already a z-claim since `C = I` ⇒ ĉ = ẑ.
     let c = ZClaim {
-        point: r1cs.c_claim_point(zc_claim.z, &zc_claim.r_rest),
+        point: r1cs.c_claim_point(SkipPoint::Phi8(zc_claim.z), &zc_claim.r_rest),
         value: zc_claim.c_eval,
     };
 

--- a/crates/flock-core/src/zerocheck.rs
+++ b/crates/flock-core/src/zerocheck.rs
@@ -20,6 +20,12 @@ use crate::field::{F8, F128};
 use crate::ntt::{AdditiveNttGf8, InvNttTableByteSingleGf8};
 use serde::{Deserialize, Serialize};
 
+// The AG-skip prover half (round-1 kernel drivers, friendly-Horner tail,
+// r1 nonce grind) is only reachable from aarch64-gated entry points; the
+// verifier half is cross-arch. Silence the resulting dead-code cascade on
+// non-aarch64 lint legs at the module level — aarch64 keeps full detection.
+#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
+pub mod ag_skip;
 pub mod multilinear;
 pub mod univariate_skip;
 pub mod univariate_skip_deg4;

--- a/crates/flock-core/src/zerocheck/ag_skip.rs
+++ b/crates/flock-core/src/zerocheck/ag_skip.rs
@@ -1,0 +1,1992 @@
+//! AG-skip zerocheck PIOP (M3) — the algebraic-geometry analog of the
+//! Reed–Solomon univariate skip in [`super::univariate_skip_optimized`], built
+//! on the genus-95 product-code kernel ([`crate::genus95_curve_code::round1`])
+//! and the arbitrary-point evaluator ([`crate::genus95_curve_code`]).
+//!
+//! Assembled incrementally. So far it provides the two primitives unique to the
+//! AG path:
+//!   - the geometric-progression *friendly challenges* over γ for all `N_INNER`
+//!     inner dims, and the constant `D = ∏(1+γ^{2^j})` they introduce, and
+//!   - the grinding-style derivation of the post-round-1 evaluation point `r₁`:
+//!     the PROVER rejection-samples by scanning nonces (each seeding a
+//!     one-attempt SHA-256 DRBG from the transcript squeeze) and ships the
+//!     first working nonce in the proof; the VERIFIER re-derives the point with
+//!     a single attempt ([`sample_r1_prover`] / [`replay_r1_verifier`]). The
+//!     DRBG reuses the transcript's own hash (the
+//!     [`crate::challenger::FsChallenger`] is SHA-256), so no second
+//!     cryptographic primitive enters the soundness argument.
+
+use super::multilinear::{
+    fold_and_compute_round_pair_into, fold_in_place_pair, fold1_lookahead_into,
+    fold2_lookahead_into, lookahead_msg_first, lookahead_msg_second, round_pair_naive,
+};
+use crate::challenger::Challenger;
+use crate::field::{F128, F256Unreduced, mul_by_x};
+use crate::genus95_curve_code::{
+    EvaluationPoint, base_evaluation_functional, product_evaluation_functional,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Bench-only A/B toggle: when set, [`prove`]'s tail uses the general
+/// `fold_and_compute_round_pair_into` for *every* round instead of the
+/// friendly-Horner kernel on rounds 1..=5. Lets one process time both paths
+/// back-to-back so thermal drift cancels (the friendly win is small vs the
+/// cross-process noise floor). Output is bit-identical either way.
+pub static DISABLE_FRIENDLY_HORNER: AtomicBool = AtomicBool::new(false);
+
+/// Bench-only A/B toggle: when set, the tail's ping-pong buffers `a_nxt`/`b_nxt`
+/// are `vec![F128::ZERO; n_in/2]` (the old serial-zero-filled, non-pooled path)
+/// instead of uninit pooled `take_f128`. Lets one process time both back-to-back.
+pub static NXT_ZEROFILL: AtomicBool = AtomicBool::new(false);
+
+/// Bench-only A/B toggle: when set, round 1 uses the unfused
+/// [`crate::genus95_curve_code::round1::round1_slp_packed_banks`] instead of the
+/// fused/lazy-reduction [`round1_slp_packed_banks_fused`]. Lets one process time
+/// both back-to-back so thermal drift cancels. Output is bit-identical either way.
+pub static ROUND1_UNFUSED: AtomicBool = AtomicBool::new(false);
+
+/// A/B toggle: when set, the mlv tail runs the classic one-round-per-pass loop
+/// (friendly-Horner + general fused kernels) instead of sumcheck LOOKAHEAD
+/// ([`super::multilinear::fold2_lookahead_into`]) — one pass per TWO rounds,
+/// deriving the second message from the bivariate Q. The proof is bit-identical
+/// either way (see `lookahead_matches_classic`); lookahead cuts tail traffic
+/// by ~44%.
+pub static LOOKAHEAD_DISABLE: AtomicBool = AtomicBool::new(false);
+
+/// Opt-in toggle: when set, lookahead iterations i=1,3 use the friendly-Horner
+/// Q accumulation ([`lookahead_friendly_pass`]) instead of the general eq
+/// multiply. Bit-identical output. OFF by default: on M-series Air it measures
+/// −1.5% (the 8×256-bit Horner accumulators spill — 32 GPRs — and the wide
+/// shifts on spilled accs cost more than the 8 PMULLs they replace, which hide
+/// under memory traffic anyway). Re-evaluate on M4 Max, where higher DRAM
+/// bandwidth may expose the mult savings.
+pub static LOOKAHEAD_FRIENDLY: AtomicBool = AtomicBool::new(false);
+
+/// AG-code message-dimension exponent: `2^K_SKIP = 64` base-code coordinates.
+pub const K_SKIP: usize = 6;
+/// Friendly inner dimensions folded by the kernel's within-block `γ^b`
+/// reinterpret (matches the RS path's `N_INNER`, but all over `γ`).
+pub const N_INNER: usize = 7;
+
+/// `γ^b ∈ F128` (the GHASH generator to the `b`-th power). For `b < 128` this is
+/// the element with bit `b` set; computed via `mul_by_x` for clarity/reduction.
+pub fn gamma_pow(b: usize) -> F128 {
+    let mut g = F128::ONE;
+    for _ in 0..b {
+        g = mul_by_x(g);
+    }
+    g
+}
+
+/// The `N_INNER` geometric-progression friendly challenges over `γ`:
+/// `r_j = γ^{2^j} / (1 + γ^{2^j})`, chosen so that
+/// `eq(r_inner, b) = γ^{int(b)} / D` with `D = ∏_j (1 + γ^{2^j})`.
+/// The verifier pins `r[K_SKIP .. K_SKIP+N_INNER]` to these constants.
+pub fn friendly_challenges() -> [F128; N_INNER] {
+    let mut out = [F128::ZERO; N_INNER];
+    for j in 0..N_INNER {
+        let g = gamma_pow(1 << j);
+        out[j] = g * (F128::ONE + g).inv();
+    }
+    out
+}
+
+/// `D = ∏_{j=0}^{N_INNER-1} (1 + γ^{2^j})` — the normalizing constant the
+/// kernel's raw `γ^b` reinterpret omits (`kernel_output = D · true_message`).
+pub fn d_const() -> F128 {
+    let mut d = F128::ONE;
+    for j in 0..N_INNER {
+        d *= F128::ONE + gamma_pow(1 << j);
+    }
+    d
+}
+
+/// `D⁻¹`: the per-coordinate rescale applied to the kernel output to recover the
+/// true eq-weighted round-1 message (the AG analog of restoring the RS `C_s`).
+pub fn d_inv() -> F128 {
+    d_const().inv()
+}
+
+// ---------------------------------------------------------------------------
+// Round 1: prover message + verifier evaluation at r₁.
+// ---------------------------------------------------------------------------
+
+/// The round-1 wire message in canonical (`D⁻¹`-scaled) form, evaluator basis.
+pub struct Round1Message {
+    /// `P^{ab}` fresh coords (158): kernel fresh slot `s` ↦ evaluator product
+    /// coord `64 + s`. (Garbage kernel slots 158/159 dropped.)
+    pub ab_fresh: Vec<F128>,
+    /// The folded c message `w̄ = Σ_x eq(r_rest, x)·c(·, x)` (64). For an honest
+    /// witness this equals `P^{ab}`'s value (order0) section (systematic
+    /// vanishing: `P^{ab} − P^{c} = 0` on the value coords), so the verifier
+    /// reuses it to reconstruct `P^{ab}`'s value rather than receiving it.
+    pub c_msg: Vec<F128>,
+}
+
+/// Prover round 1: run the kernel on the packed witness, rescale by `D⁻¹`, and
+/// split into the canonical `(P^{ab}` fresh, `w̄)`. `eq` holds one outer weight
+/// per 1024-byte block.
+#[cfg(target_arch = "aarch64")]
+pub fn prove_round1(
+    a_packed: &[u8],
+    b_packed: &[u8],
+    c_packed: &[u8],
+    eq: &[F128],
+) -> Round1Message {
+    let (res_ab, wbar) =
+        crate::genus95_curve_code::round1::round1_slp_packed(a_packed, b_packed, c_packed, eq);
+    let di = d_inv();
+    Round1Message {
+        ab_fresh: (0..158).map(|s| di * res_ab[s]).collect(),
+        c_msg: (0..64).map(|i| di * wbar[i]).collect(),
+    }
+}
+
+/// Verifier: `P^{ab}(r₁) = ⟨E(r₁), [w̄ | P^{ab}_fresh]⟩` — a 222-term F128 inner
+/// product over the product-code evaluation functional. The value (order0)
+/// section is reconstructed as `w̄` via systematic vanishing; the fresh coords
+/// map by the identity bridge (kernel slot `s` ↦ coord `64+s`).
+pub fn eval_ab_at(msg: &Round1Message, point: &EvaluationPoint) -> F128 {
+    let pf = product_evaluation_functional(point).expect("denominator nonzero at r1");
+    let mut acc = F128::ZERO;
+    for i in 0..64 {
+        acc += pf[i] * msg.c_msg[i];
+    }
+    for s in 0..158 {
+        acc += pf[64 + s] * msg.ab_fresh[s];
+    }
+    acc
+}
+
+/// Verifier: `ĉ(r₁, r_rest) = ⟨base(r₁), w̄⟩` via the 64-coord base functional.
+pub fn eval_c_at(msg: &Round1Message, point: &EvaluationPoint) -> F128 {
+    let bf = base_evaluation_functional(point).expect("denominator nonzero at r1");
+    let mut acc = F128::ZERO;
+    for i in 0..64 {
+        acc += bf[i] * msg.c_msg[i];
+    }
+    acc
+}
+
+/// 8×256 byte-dot tables for the base functional `w` (64 coords): `table[pos][byte]`
+/// = Σ of `w[pos*8+bit]` over the set bits of `byte`. A message's `â(r₁,·)` is then
+/// `Σ_pos table[pos][byte_pos]` — 8 lookups + 7 adds instead of ~32 set-bit adds.
+pub(super) fn build_w_tables(w: &[F128]) -> Vec<[F128; 256]> {
+    assert_eq!(w.len(), 64, "base functional has 64 coords");
+    let mut table = vec![[F128::ZERO; 256]; 8];
+    for pos in 0..8 {
+        for bit in 0..8 {
+            let coord = w[pos * 8 + bit];
+            let bm = 1usize << bit;
+            for v in 0..bm {
+                table[pos][bm | v] = table[pos][v] + coord;
+            }
+        }
+    }
+    table
+}
+
+/// `â(r₁, rest=r) = ⟨w, message_r⟩` via the byte-dot tables. Unchecked: the
+/// caller guarantees `r*8+7 < packed.len()` and `table.len() == 8`; the byte
+/// indices are in range because they come from `u8` extractions.
+///
+/// The 8 index bytes are fetched as ONE unaligned `u64` load and extracted in
+/// registers (shifts), not 8 separate byte loads: in the fused fold the load
+/// ports are contended by the message mults and the `a_mlv` stores, and the
+/// 28-fewer-loads-per-pair relief measures +12% (m=28) / +19% (m=30) on the
+/// whole phase (paired A/B; lookups-only microbench shows only ~4% — the win
+/// is contention relief, not raw lookup speed). Tree-associated adds shorten
+/// the XOR chain from depth 7 to 3. Output bit-identical.
+#[inline]
+pub(super) fn byte_dot(packed: &[u8], r: usize, table: &[[F128; 256]]) -> F128 {
+    unsafe {
+        let v = (packed.as_ptr().add(r * 8) as *const u64).read_unaligned();
+        byte_dot_u64(v, table)
+    }
+}
+
+/// [`byte_dot`] on a pre-loaded (possibly pre-combined) 64-bit message. Lets
+/// the tensor fold dot `m₀⊕m₁` without a memory round-trip.
+#[inline]
+pub(super) fn byte_dot_u64(v: u64, table: &[[F128; 256]]) -> F128 {
+    unsafe {
+        let t0 = *table.get_unchecked(0).get_unchecked((v & 0xFF) as usize);
+        let t1 = *table
+            .get_unchecked(1)
+            .get_unchecked(((v >> 8) & 0xFF) as usize);
+        let t2 = *table
+            .get_unchecked(2)
+            .get_unchecked(((v >> 16) & 0xFF) as usize);
+        let t3 = *table
+            .get_unchecked(3)
+            .get_unchecked(((v >> 24) & 0xFF) as usize);
+        let t4 = *table
+            .get_unchecked(4)
+            .get_unchecked(((v >> 32) & 0xFF) as usize);
+        let t5 = *table
+            .get_unchecked(5)
+            .get_unchecked(((v >> 40) & 0xFF) as usize);
+        let t6 = *table
+            .get_unchecked(6)
+            .get_unchecked(((v >> 48) & 0xFF) as usize);
+        let t7 = *table.get_unchecked(7).get_unchecked((v >> 56) as usize);
+        ((t0 + t1) + (t2 + t3)) + ((t4 + t5) + (t6 + t7))
+    }
+}
+
+/// Fold the witness's skip dimension at `r₁`, producing `â(r₁, rest)` for every
+/// rest position — the AG analog of the RS `UniSkipFoldTable(z)` fold. Witness
+/// order is skip = low 6 bits, rest = high, so rest position `r`'s 64-bit message
+/// is the 8 bytes at offset `r*8`. Parallel byte-dot.
+pub fn fold_witness_at_r1(packed: &[u8], w: &[F128]) -> Vec<F128> {
+    use rayon::prelude::*;
+    assert_eq!(
+        packed.len() % 8,
+        0,
+        "witness must be a whole number of 64-bit messages"
+    );
+    let table = build_w_tables(w);
+    (0..packed.len() / 8)
+        .into_par_iter()
+        .map(|r| byte_dot(packed, r, &table))
+        .collect()
+}
+
+/// One wide-Horner step: `acc << 2` (256-bit) then XOR the reduced product `p`
+/// into the low 128 bits. Multiplying by `γ² = x²` is a pure 2-bit shift, so the
+/// geometric inner sum `Σ (γ²)^i pᵢ` accumulates with no field multiplies and no
+/// per-step reduction — the caller reduces the 256-bit total once. (A log-depth
+/// XOR tree was tried and is slower: the chain is already hidden by across-block
+/// parallelism, and the tree's 64-wide working set adds L1 traffic.)
+#[inline]
+pub(super) fn shl2_xor(acc: F256Unreduced, p: F128) -> F256Unreduced {
+    F256Unreduced {
+        r0: (acc.r0 << 2) ^ p.lo,
+        r1: ((acc.r1 << 2) | (acc.r0 >> 62)) ^ p.hi,
+        r2: (acc.r2 << 2) | (acc.r1 >> 62),
+        r3: (acc.r3 << 2) | (acc.r2 >> 62),
+    }
+}
+
+/// Fused fold + first multilinear message — the AG analog of RS's
+/// `uni_skip_fold_and_round_pair`, parallel over the `2^(m-13)` outer blocks.
+/// Each block folds its 128 messages at `r₁` (byte-dot) AND accumulates round 0's
+/// `(G(1), G(∞))`.
+///
+/// The first round binds inner-bit-0; the *remaining* friendly dims
+/// (`r_rest[1..N_INNER]`, the 64 inner positions per block) are `γ²`-geometric, so
+/// their eq-weighted inner sum is a **Horner in `γ²`** — shift-reduce, no field
+/// multiplies for the weighting. Only the **outer** eq is general
+/// (`build_eq(r_rest[N_INNER..])`, `2^(m-13)` ≪ the full `2^(m-7)` table).
+///
+/// Requires `r_rest[1..N_INNER]` to be the geometric friendly constants
+/// (`friendly_challenges()[1..]`); the caller always sets `r_rest = friendly ‖ outer`.
+pub fn fold_and_first_round(
+    a_packed: &[u8],
+    b_packed: &[u8],
+    w: &[F128],
+    r_rest: &[F128],
+) -> (Vec<F128>, Vec<F128>, F128, F128) {
+    use rayon::prelude::*;
+    assert_eq!(a_packed.len(), b_packed.len());
+    debug_assert_eq!(
+        &r_rest[1..N_INNER],
+        &friendly_challenges()[1..N_INNER],
+        "fold_and_first_round assumes γ-geometric friendly dims"
+    );
+    let n = a_packed.len() / 8;
+    let table = build_w_tables(w);
+    let eq_outer = super::univariate_skip::build_eq(&r_rest[N_INNER..]);
+    let n_outer = eq_outer.len();
+    assert_eq!(n, n_outer * 128, "each outer block is 128 (2^7) messages");
+    // D₁ = ∏_{j=1}^{6}(1+γ^{2^j}); the eq over the remaining friendly dims is
+    // γ^{2·int(inner')}/D₁, so the Horner (which omits 1/D₁) is rescaled by D₁⁻¹.
+    let mut d1 = F128::ONE;
+    for j in 1..N_INNER {
+        d1 *= F128::ONE + gamma_pow(1usize << j);
+    }
+    let d1_inv = d1.inv();
+
+    // Uninit alloc: the parallel loop below writes every slot of a_mlv/b_mlv, so
+    // `vec![ZERO; n]`'s serial zero-fill (512 MB at m=30) is pure waste and caps
+    // the multi-thread speedup (Amdahl) — the same reason RS's fold uses this.
+    // Write-before-read contract upheld: every chunk's 128 slots are written.
+    let mut a_mlv = crate::scratch::take_f128(n);
+    let mut b_mlv = crate::scratch::take_f128(n);
+    let (g1, g_inf) = a_mlv
+        .par_chunks_mut(128)
+        .zip(b_mlv.par_chunks_mut(128))
+        .zip(eq_outer.par_iter())
+        .enumerate()
+        .map(|(outer, ((am, bm), &eo))| {
+            // One fused pass over the 64 pairs (reverse, for the γ²-Horner): fold
+            // the four rows at r₁, write them to a_mlv/b_mlv, AND accumulate the
+            // first message from those just-folded values — no read-back of the
+            // folded array (the two-pass version re-read 2 KB/block). γ² = x², so
+            // each Σ weight is a pure 2-bit shift: a *wide* Horner on a 256-bit
+            // accumulator (no per-step reduction — max degree 2·63+127 = 253 <
+            // 256), reduced once per block.
+            let base = outer * 128;
+            let mut s1 = F256Unreduced::ZERO;
+            let mut s_inf = F256Unreduced::ZERO;
+            for inner in (0..64).rev() {
+                let (i0, i1) = (2 * inner, 2 * inner + 1);
+                let a0 = byte_dot(a_packed, base + i0, &table);
+                let a1 = byte_dot(a_packed, base + i1, &table);
+                let b0 = byte_dot(b_packed, base + i0, &table);
+                let b1 = byte_dot(b_packed, base + i1, &table);
+                am[i0] = a0;
+                am[i1] = a1;
+                bm[i0] = b0;
+                bm[i1] = b1;
+                s1 = shl2_xor(s1, a1 * b1);
+                s_inf = shl2_xor(s_inf, (a0 + a1) * (b0 + b1));
+            }
+            let e = eo * d1_inv;
+            (e * s1.reduce(), e * s_inf.reduce())
+        })
+        .reduce(|| (F128::ZERO, F128::ZERO), |(p, q), (r, s)| (p + r, q + s));
+    (a_mlv, b_mlv, g1, g_inf)
+}
+
+/// One wide-Horner step with a compile-time shift `S` (the friendly base
+/// `γ^{2^{i+1}} = x^S`): `acc << S` (256-bit) then XOR the reduced product `p`
+/// into the low 128 bits. Generalizes [`shl2_xor`] (S=2, round 0) to rounds
+/// 1..5, where the *remaining* friendly dims are `(γ^{2^{i+1}})`-geometric.
+/// `S ∈ {4,8,16,32,64}` — the `S == 64` case is split out because `u64 << 64`
+/// is UB (and the const generic makes the branch compile away).
+#[inline]
+pub(super) fn shl_xor<const S: u32>(acc: F256Unreduced, p: F128) -> F256Unreduced {
+    if S == 64 {
+        F256Unreduced {
+            r0: p.lo,
+            r1: acc.r0 ^ p.hi,
+            r2: acc.r1,
+            r3: acc.r2,
+        }
+    } else {
+        let inv = 64 - S;
+        F256Unreduced {
+            r0: (acc.r0 << S) ^ p.lo,
+            r1: ((acc.r1 << S) | (acc.r0 >> inv)) ^ p.hi,
+            r2: (acc.r2 << S) | (acc.r1 >> inv),
+            r3: (acc.r3 << S) | (acc.r2 >> inv),
+        }
+    }
+}
+
+/// `norm_i = (∏_{j=i+1}^{6}(1+γ^{2^j}))⁻¹` — the round-`i` analog of
+/// `fold_and_first_round`'s `d1_inv` (which is `norm_0`). The friendly eq over
+/// the message's remaining dims (`vars i+1..6`) is `norm_i · (γ^{2^{i+1}})^p`,
+/// so the Horner (which omits `norm_i`) is rescaled by it.
+fn friendly_norm(i: usize) -> F128 {
+    let mut d = F128::ONE;
+    for j in (i + 1)..N_INNER {
+        d *= F128::ONE + gamma_pow(1usize << j);
+    }
+    d.inv()
+}
+
+/// Fused fold-by-`rho` + friendly-Horner round message — the rounds-1..5 analog
+/// of [`fold_and_first_round`], and a drop-in (bit-identical output) replacement
+/// for the general [`super::multilinear::fold_and_compute_round_pair_into`] on
+/// those rounds.
+///
+/// After binding friendly bits `0..i` and folding bit `i-1` by `rho`, the round-`i`
+/// message's free index splits as `[friendly i+1..6 (low, lo_size = 2^{6-i}) |
+/// outer (high, 2^{m-13})]`. The friendly lo dims are `(γ^{2^{i+1}})`-geometric,
+/// so their eq-weighted inner sum is a **Horner in `x^SHIFT`** (`SHIFT = 2^{i+1}`,
+/// a pure shift — no per-term PMULL), where the general kernel pays 2 `eq_lo`
+/// PMULLs per term. The outer hi dims keep the general split-eq multiply
+/// (`eq_outer_lo`/`eq_outer_hi`, constant across rounds 1..5). `c_inv = norm_i`
+/// (see [`friendly_norm`]) rescales the Horner.
+///
+/// Folds `a→a_out`, `b→b_out` by `rho`; returns the bare `(G(1), G(∞))`
+/// (Convention A). Parallel over the outer-hi dim.
+#[allow(clippy::too_many_arguments)]
+fn fold_and_friendly_round_pair_into<const SHIFT: u32>(
+    a: &[F128],
+    b: &[F128],
+    a_out: &mut [F128],
+    b_out: &mut [F128],
+    rho: F128,
+    lo_size: usize,
+    eq_outer_lo: &[F128],
+    eq_outer_hi: &[F128],
+    c_inv: F128,
+) -> (F128, F128) {
+    use rayon::prelude::*;
+    let half = a.len() / 2;
+    debug_assert_eq!(a_out.len(), half);
+    debug_assert_eq!(b_out.len(), half);
+    let n_ol = eq_outer_lo.len();
+    let n_oh = eq_outer_hi.len();
+    let block_out = 2 * lo_size; // a_out entries per friendly block (incl. bound var)
+    let block_in = 2 * block_out; // a entries per friendly block (pre-fold)
+    debug_assert_eq!(block_out * n_ol * n_oh, half);
+    let chunk_out = n_ol * block_out;
+    let chunk_in = n_ol * block_in;
+
+    let (sum1, sum_inf) = a_out
+        .par_chunks_mut(chunk_out)
+        .zip(b_out.par_chunks_mut(chunk_out))
+        .enumerate()
+        .map(|(oh, (a_oc, b_oc))| {
+            let a_ic = &a[oh * chunk_in..(oh + 1) * chunk_in];
+            let b_ic = &b[oh * chunk_in..(oh + 1) * chunk_in];
+            let mut p1_acc = F256Unreduced::ZERO;
+            let mut pinf_acc = F256Unreduced::ZERO;
+            for ol in 0..n_ol {
+                let ib = ol * block_in;
+                let ob = ol * block_out;
+                let mut s1 = F256Unreduced::ZERO;
+                let mut sinf = F256Unreduced::ZERO;
+                // Reverse for the Horner: the first-processed pair carries the
+                // highest power of ω = x^SHIFT.
+                for p in (0..lo_size).rev() {
+                    let i0 = ib + 4 * p;
+                    // LSB fold by rho (binds the previous round's variable).
+                    let a0 = a_ic[i0] + rho * (a_ic[i0 + 1] + a_ic[i0]);
+                    let a1 = a_ic[i0 + 2] + rho * (a_ic[i0 + 3] + a_ic[i0 + 2]);
+                    let b0 = b_ic[i0] + rho * (b_ic[i0 + 1] + b_ic[i0]);
+                    let b1 = b_ic[i0 + 2] + rho * (b_ic[i0 + 3] + b_ic[i0 + 2]);
+                    let o = ob + 2 * p;
+                    a_oc[o] = a0;
+                    a_oc[o + 1] = a1;
+                    b_oc[o] = b0;
+                    b_oc[o + 1] = b1;
+                    s1 = shl_xor::<SHIFT>(s1, a1 * b1);
+                    sinf = shl_xor::<SHIFT>(sinf, (a0 + a1) * (b0 + b1));
+                }
+                let el = eq_outer_lo[ol];
+                p1_acc ^= el.mul_unreduced(s1.reduce());
+                pinf_acc ^= el.mul_unreduced(sinf.reduce());
+            }
+            let eh = eq_outer_hi[oh] * c_inv;
+            (eh * p1_acc.reduce(), eh * pinf_acc.reduce())
+        })
+        .reduce(|| (F128::ZERO, F128::ZERO), |(x, y), (u, v)| (x + u, y + v));
+    (sum1, sum_inf)
+}
+
+/// Friendly-Horner LOOKAHEAD pass — the lookahead analog of
+/// [`fold_and_friendly_round_pair_into`], for the two lookahead iterations
+/// whose eq still spans friendly dims (i=1: dims 3..6, SHIFT=8; i=3: dims
+/// 5..6, SHIFT=32). The 8 Q-sums accumulate via `shl_xor::<SHIFT>` wide-Horner
+/// (pure shifts) over the γ-geometric friendly-lo dims instead of 8 `eq_lo`
+/// PMULLs per position; the outer eq keeps the general split multiply.
+/// `PER_U` = 8 (entry, fold one pending challenge) or 16 (steady, fold two).
+/// Output identical to the general lookahead pass (exact field arithmetic).
+#[allow(clippy::too_many_arguments)]
+fn lookahead_friendly_pass<const SHIFT: u32, const PER_U: usize>(
+    a: &[F128],
+    b: &[F128],
+    a_out: &mut [F128],
+    b_out: &mut [F128],
+    rhos: (F128, F128),
+    lo_size: usize,
+    eq_outer_lo: &[F128],
+    eq_outer_hi: &[F128],
+    c_inv: F128,
+) -> crate::zerocheck::multilinear::LookaheadSums {
+    use crate::zerocheck::multilinear::{lookahead_finish, lookahead_products};
+    use rayon::prelude::*;
+    let n_u = a.len() / PER_U;
+    debug_assert_eq!(a_out.len(), 4 * n_u);
+    let n_ol = eq_outer_lo.len();
+    debug_assert_eq!(lo_size * n_ol * eq_outer_hi.len(), n_u);
+    // Wide-Horner degree bound: SHIFT·(lo_size−1) + 127 < 256.
+    debug_assert!(SHIFT as usize * (lo_size - 1) + 127 < 256);
+    let chunk_u = lo_size * n_ol; // u-positions per outer-hi chunk
+    let sums = a_out
+        .par_chunks_mut(4 * chunk_u)
+        .zip(b_out.par_chunks_mut(4 * chunk_u))
+        .enumerate()
+        .map(|(oh, (ao, bo))| {
+            let mut chunk_acc = [F256Unreduced::ZERO; 8];
+            for ol in 0..n_ol {
+                let mut horner = [F256Unreduced::ZERO; 8];
+                // Reverse, so the first-processed position carries the highest
+                // power of ω = x^SHIFT.
+                for p in (0..lo_size).rev() {
+                    let u = (oh * n_ol + ol) * lo_size + p;
+                    let mut ga = [F128::ZERO; 4];
+                    let mut gb = [F128::ZERO; 4];
+                    for v in 0..4usize {
+                        let base = u * PER_U + v * (PER_U / 4);
+                        let (fa, fb) = if PER_U == 8 {
+                            (
+                                a[base] + rhos.0 * (a[base] + a[base + 1]),
+                                b[base] + rhos.0 * (b[base] + b[base + 1]),
+                            )
+                        } else {
+                            let xa0 = a[base] + rhos.0 * (a[base] + a[base + 1]);
+                            let xa1 = a[base + 2] + rhos.0 * (a[base + 2] + a[base + 3]);
+                            let xb0 = b[base] + rhos.0 * (b[base] + b[base + 1]);
+                            let xb1 = b[base + 2] + rhos.0 * (b[base + 2] + b[base + 3]);
+                            (xa0 + rhos.1 * (xa0 + xa1), xb0 + rhos.1 * (xb0 + xb1))
+                        };
+                        ga[v] = fa;
+                        gb[v] = fb;
+                        let o = 4 * (ol * lo_size + p) + v;
+                        ao[o] = fa;
+                        bo[o] = fb;
+                    }
+                    let prods = lookahead_products(&ga, &gb);
+                    for k in 0..8 {
+                        horner[k] = shl_xor_generic::<SHIFT>(horner[k], prods[k]);
+                    }
+                }
+                let el = eq_outer_lo[ol];
+                for k in 0..8 {
+                    chunk_acc[k] ^= el.mul_unreduced(horner[k].reduce());
+                }
+            }
+            let eh = eq_outer_hi[oh] * c_inv;
+            let mut out = [F128::ZERO; 8];
+            for k in 0..8 {
+                out[k] = eh * chunk_acc[k].reduce();
+            }
+            out
+        })
+        .reduce(
+            || [F128::ZERO; 8],
+            |mut p, q| {
+                for k in 0..8 {
+                    p[k] += q[k];
+                }
+                p
+            },
+        );
+    lookahead_finish(sums)
+}
+
+/// [`shl_xor`] with the shift as a const generic (the friendly bases here are
+/// `x^8` and `x^32`; both < 64 so the plain path suffices).
+#[inline]
+fn shl_xor_generic<const S: u32>(acc: F256Unreduced, p: F128) -> F256Unreduced {
+    let inv = 64 - S;
+    F256Unreduced {
+        r0: (acc.r0 << S) ^ p.lo,
+        r1: ((acc.r1 << S) | (acc.r0 >> inv)) ^ p.hi,
+        r2: (acc.r2 << S) | (acc.r1 >> inv),
+        r3: (acc.r3 << S) | (acc.r2 >> inv),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rounds 2..m: the multilinear sumcheck over the rest variables (AB only — c
+// dropped out in round 1). Reuses `multilinear::{round_pair_naive,
+// fold_in_place_pair}`; the round structure mirrors the RS path exactly.
+// ---------------------------------------------------------------------------
+
+/// Prover's multilinear sumcheck on the folded rows `â(r₁,·)`, `b̂(r₁,·)`. Binds
+/// each rest variable (low-bit first) to the supplied challenge `rhos[i]`,
+/// emitting `(G(1), G(∞))` per round (Convention A — no eq factor on the wire).
+/// `r_rest` are the eq weights (friendly inner, then outer). Returns the
+/// per-round messages and the final evals `(â(r₁,ρ), b̂(r₁,ρ))`.
+pub fn prove_multilinear(
+    mut a_mlv: Vec<F128>,
+    mut b_mlv: Vec<F128>,
+    r_rest: &[F128],
+    rhos: &[F128],
+) -> (Vec<(F128, F128)>, F128, F128) {
+    let n_mlv = r_rest.len();
+    assert_eq!(rhos.len(), n_mlv);
+    assert_eq!(a_mlv.len(), 1usize << n_mlv);
+    let mut msgs = Vec::with_capacity(n_mlv);
+
+    // Round 0: message from the full rows (no fold yet) — the biggest round, so
+    // compute it with a parallel reduce (Convention A: bare G(1), since the
+    // bound var's eq factor r[0]=ONE). `eq` weights the remaining vars.
+    {
+        use rayon::prelude::*;
+        let half = a_mlv.len() / 2;
+        let eq = super::univariate_skip::build_eq(&r_rest[1..]);
+        let (g1, g_inf) = (0..half)
+            .into_par_iter()
+            .map(|x| {
+                let (a0, a1) = (a_mlv[2 * x], a_mlv[2 * x + 1]);
+                let (b0, b1) = (b_mlv[2 * x], b_mlv[2 * x + 1]);
+                let e = eq[x];
+                (e * a1 * b1, e * (a0 + a1) * (b0 + b1))
+            })
+            .reduce(|| (F128::ZERO, F128::ZERO), |(p, q), (r, s)| (p + r, q + s));
+        msgs.push((g1, g_inf));
+    }
+
+    // Rounds 1..n_mlv: fuse the fold by ρ_{i-1} with this round's message. Use
+    // the parallel fused path while ≥10 vars remain; below that, naive. Ping-pong
+    // scratch avoids a fresh alloc+free per round.
+    let n_in = a_mlv.len();
+    let (mut a_nxt, mut b_nxt) = if n_in >= 1024 {
+        // Uninit pooled buffers (NOT vec![ZERO; n_in/2]): the fused fold writes
+        // every slot of a_nxt/b_nxt[..half] before reading (write-before-read),
+        // so a zero-fill is wasted — and it's a *serial* 256 MB memset before the
+        // parallel loop (Amdahl), the same trap `a_mlv`/`b_mlv` avoid via the pool.
+        (
+            crate::scratch::take_f128(n_in / 2),
+            crate::scratch::take_f128(n_in / 2),
+        )
+    } else {
+        (Vec::new(), Vec::new())
+    };
+    for i in 1..n_mlv {
+        let rho_prev = rhos[i - 1];
+        let log_before = a_mlv.len().trailing_zeros() as usize;
+        let mut r_next = vec![F128::ONE; log_before - 1];
+        r_next[1..].copy_from_slice(&r_rest[i + 1..]);
+        let pair = if log_before >= 10 {
+            let half = a_mlv.len() / 2;
+            let pair = fold_and_compute_round_pair_into(
+                &a_mlv,
+                &b_mlv,
+                &mut a_nxt[..half],
+                &mut b_nxt[..half],
+                rho_prev,
+                &r_next,
+            );
+            std::mem::swap(&mut a_mlv, &mut a_nxt);
+            std::mem::swap(&mut b_mlv, &mut b_nxt);
+            a_mlv.truncate(half);
+            b_mlv.truncate(half);
+            pair
+        } else {
+            fold_in_place_pair(&mut a_mlv, &mut b_mlv, rho_prev);
+            round_pair_naive(&a_mlv, &b_mlv, &r_next)
+        };
+        msgs.push(pair);
+    }
+
+    // Final binding by the last challenge.
+    fold_in_place_pair(&mut a_mlv, &mut b_mlv, rhos[n_mlv - 1]);
+    (msgs, a_mlv[0], b_mlv[0])
+}
+
+/// Verifier's multilinear consistency: propagate the running inner claim from the
+/// round-1 value `claim_ab` through every round, reconstructing `G(0)` from the
+/// eq weight and interpolating at `ρ`. Returns the final running claim, which the
+/// caller checks equals `a_eval · b_eval`.
+pub fn verify_multilinear(
+    claim_ab: F128,
+    r_rest: &[F128],
+    msgs: &[(F128, F128)],
+    rhos: &[F128],
+) -> F128 {
+    let mut c = claim_ab;
+    for i in 0..r_rest.len() {
+        let (g1, g_inf) = msgs[i];
+        let r_eq = r_rest[i];
+        // c = (1+r_eq)·G(0) + r_eq·G(1)  ⇒  G(0) = (c + r_eq·G(1))·(1+r_eq)⁻¹.
+        let g0 = (c + r_eq * g1) * (F128::ONE + r_eq).inv();
+        let rho = rhos[i];
+        // G(ρ) = G(0)(1+ρ) + G(1)ρ + G(∞)ρ(ρ+1).
+        c = g0 * (F128::ONE + rho) + g1 * rho + g_inf * rho * (rho + F128::ONE);
+    }
+    c
+}
+
+// ---------------------------------------------------------------------------
+// Fiat–Shamir driver: prove / verify against a SHA-256 `Challenger`.
+// ---------------------------------------------------------------------------
+
+/// A fixed, valid point of `Y`, the fallback for the (≈`2^-289`) chance that
+/// rejection sampling exhausts its attempt budget. Baked from one offline sample.
+///
+/// No longer used by the AG-skip `r₁` derivation (the nonce-grind path panics
+/// on exhaustion instead — an accepted fallback claim would let a cheating
+/// prover pin `r₁` to this public constant). Still backs
+/// [`crate::lincheck::SkipPoint::sample_fresh`], where BOTH sides replay the
+/// same deterministic loop, so a prover cannot claim failure unilaterally:
+/// forcing it costs `~1/P_fail ≈ 2^289`, far above the `2^128` target. (Keep
+/// linked to the sampler's attempt cap; lowering the cap raises `P_fail`.)
+pub(crate) fn fallback_point() -> EvaluationPoint {
+    EvaluationPoint {
+        x: F128 {
+            lo: 17376575154980521683,
+            hi: 16956381729448392221,
+        },
+        y: F128 {
+            lo: 3703262331298828801,
+            hi: 354800370152310762,
+        },
+        z1: F128 {
+            lo: 12509146339372511806,
+            hi: 14754238706087384589,
+        },
+        z2: F128 {
+            lo: 7848999207301165946,
+            hi: 6313416638638821140,
+        },
+        z3: F128 {
+            lo: 4302402807812267211,
+            hi: 11246714171241606505,
+        },
+    }
+}
+
+/// Squeeze the 32-byte SHA-256 seed for `r₁` from the transcript (two `F128`
+/// samples). Shared by the prover's nonce grind and the verifier's replay.
+fn r1_seed<C: Challenger>(challenger: &mut C) -> [u8; 32] {
+    challenger.observe_label(b"flock-ag-skip-r1-point");
+    let s0 = challenger.sample_f128();
+    let s1 = challenger.sample_f128();
+    let mut seed = [0u8; 32];
+    seed[0..8].copy_from_slice(&s0.lo.to_le_bytes());
+    seed[8..16].copy_from_slice(&s0.hi.to_le_bytes());
+    seed[16..24].copy_from_slice(&s1.lo.to_le_bytes());
+    seed[24..32].copy_from_slice(&s1.hi.to_le_bytes());
+    seed
+}
+
+/// Bind the chosen `r₁` nonce into the transcript. Must happen before any
+/// later challenge is sampled — ξ̂ and the tail ρ's depend on `r₁` through it.
+fn observe_r1_nonce<C: Challenger>(challenger: &mut C, nonce: u32) {
+    challenger.observe_label(b"flock-ag-skip-r1-nonce");
+    challenger.observe_bytes(&nonce.to_le_bytes());
+}
+
+/// Prover: derive `r₁` by GRINDING a nonce, instead of the verifier replaying
+/// the whole rejection-sampling loop. Each nonce seeds an independent
+/// one-attempt DRBG `SHA256(seed ‖ nonce)`
+/// ([`crate::genus95_curve_code::evaluation_point_from_nonce`]); the first
+/// nonce whose attempt lands a valid point is observed into the transcript and
+/// shipped in the proof, so the verifier re-derives `r₁` with a SINGLE attempt
+/// rather than the expected ~100 (worst-case 20 000) replayed ones.
+///
+/// Per-attempt acceptance is ~1%, so exhausting all
+/// [`SAMPLE_ATTEMPT_BUDGET`](crate::genus95_curve_code::SAMPLE_ATTEMPT_BUDGET)
+/// nonces has probability ~2⁻²⁸⁹ — a completeness error we accept (panic)
+/// instead of a verifier-side fallback point: an unconditionally accepted
+/// fallback claim would let a cheating prover fix `r₁` to a public constant.
+pub(super) fn sample_r1_prover<C: Challenger>(challenger: &mut C) -> (EvaluationPoint, u32) {
+    let seed = r1_seed(challenger);
+    let kind = challenger.hash_kind();
+    for nonce in 0..crate::genus95_curve_code::SAMPLE_ATTEMPT_BUDGET {
+        if let Some(point) =
+            crate::genus95_curve_code::evaluation_point_from_nonce(&seed, nonce, kind)
+        {
+            observe_r1_nonce(challenger, nonce);
+            return (point, nonce);
+        }
+    }
+    unreachable!("r1 nonce grind exhausted its budget (probability ~2^-289)")
+}
+
+/// Verifier: re-derive `r₁` from the proof's nonce — range-check it, run the
+/// single attempt, and reject unless it lands a valid point. The verifier does
+/// NOT check the nonce is the prover's minimal one, so a cheating prover may
+/// pick any of the ~200 expected valid nonces in the budget: ≤ log₂(20 000) ≈
+/// 14.3 bits of grinding over `r₁`, charged to the soundness budget exactly
+/// like a PoW grind.
+pub(super) fn replay_r1_verifier<C: Challenger>(
+    challenger: &mut C,
+    nonce: u32,
+) -> Result<EvaluationPoint, AgVerifyError> {
+    let seed = r1_seed(challenger);
+    if nonce >= crate::genus95_curve_code::SAMPLE_ATTEMPT_BUDGET {
+        return Err(AgVerifyError::BadR1Nonce { nonce });
+    }
+    observe_r1_nonce(challenger, nonce);
+    crate::genus95_curve_code::evaluation_point_from_nonce(&seed, nonce, challenger.hash_kind())
+        .ok_or(AgVerifyError::BadR1Nonce { nonce })
+}
+
+/// All round messages the AG-skip prover sends, in order.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgProof {
+    /// Round 1: `P^{ab}` fresh coords (158).
+    pub round1_ab: Vec<F128>,
+    /// Round 1: the folded c message `w̄` (64).
+    pub round1_c: Vec<F128>,
+    /// Grinding nonce for `r₁`: the verifier re-derives the point from
+    /// `SHA256(seed ‖ nonce)` in one attempt (see [`replay_r1_verifier`]).
+    pub r1_nonce: u32,
+    /// Multilinear rounds: `(G(1), G(∞))` each; length `m − K_SKIP`.
+    pub multilinear_rounds: Vec<(F128, F128)>,
+    pub final_a_eval: F128,
+    pub final_b_eval: F128,
+    pub final_c_eval: F128,
+}
+
+/// Evaluation claims the AG-skip zerocheck reduces to (no PCS). `a_eval`, `b_eval`
+/// are at the AG point `r₁` with rest coords `mlv_challenges`; `c_eval` is at `r₁`
+/// with rest coords `r_rest` (a *different* point — c dropped out in round 1).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgClaim {
+    pub r1: EvaluationPoint,
+    pub mlv_challenges: Vec<F128>,
+    pub r_rest: Vec<F128>,
+    pub a_eval: F128,
+    pub b_eval: F128,
+    pub c_eval: F128,
+}
+
+/// Verifier rejection reasons.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AgVerifyError {
+    LogNTooSmall {
+        log_n: usize,
+    },
+    BadRound1Length {
+        which: &'static str,
+        expected: usize,
+        got: usize,
+    },
+    BadMultilinearRoundsLength {
+        expected: usize,
+        got: usize,
+    },
+    /// The claimed `r₁` nonce is out of budget or its attempt rejects.
+    BadR1Nonce {
+        nonce: u32,
+    },
+    CEvalMismatch,
+    SumcheckFinalFailed,
+}
+
+/// Prove `a(y)·b(y) = c(y)` for all `y ∈ {0,1}^m` via the AG-skip zerocheck.
+/// `a/b/c_packed` are LSB-first bit-packed (length `2^m/8`); requires `m ≥ 13`.
+#[cfg(target_arch = "aarch64")]
+pub fn prove<C: Challenger>(
+    a_packed: &[u8],
+    b_packed: &[u8],
+    c_packed: &[u8],
+    m: usize,
+    challenger: &mut C,
+) -> (AgProof, AgClaim) {
+    assert!(m >= K_SKIP + N_INNER, "m >= 13 required");
+    let expected = (1usize << m) / 8;
+    assert_eq!(a_packed.len(), expected);
+    assert_eq!(b_packed.len(), expected);
+    assert_eq!(c_packed.len(), expected);
+
+    challenger.observe_label(b"flock-ag-skip-v1");
+    let r_outer = challenger.sample_f128_vec(m - K_SKIP - N_INNER);
+    let eq = crate::zerocheck::univariate_skip::build_eq(&r_outer);
+
+    let msg = prove_round1(a_packed, b_packed, c_packed, &eq);
+    prove_from_round1(a_packed, b_packed, msg, &r_outer, challenger)
+}
+
+/// [`prove`] that ALSO returns the c-claim's `s_hat_v_c` — the length-128
+/// ring-switch fold the PCS open would otherwise recompute via `fold_1b_rows`
+/// on `z_packed` at the c-claim's suffix. Captured as a near-free byproduct of
+/// round 1's c-scan (the two-bank [`round1::round1_slp_packed_banks`]), so the
+/// open skips the c witness scan — the AG analog of the RS path's
+/// `prove_packed_padded_capture_s_hat_v_c`. The returned `AgProof`/`AgClaim` are
+/// byte-identical to [`prove`]'s (`bank0 + bank1 == wbar`).
+///
+/// `s_hat_v_c` is in canonical (`fold_1b_rows`) form: layout
+/// `s_hat_v_c[skip + b·64]` for `skip ∈ [0,64)`, `b ∈ {0,1}` the 7th packing
+/// bit, with the friendly-bit-0 `eq` factor stripped (re-applied by
+/// `build_claim_weights_from_skip` via `eq(x_outer[0])`).
+#[cfg(target_arch = "aarch64")]
+pub fn prove_capture_s_hat_v_c<C: Challenger>(
+    a_packed: &[u8],
+    b_packed: &[u8],
+    c_packed: &[u8],
+    m: usize,
+    challenger: &mut C,
+) -> (AgProof, AgClaim, Vec<F128>) {
+    assert!(m >= K_SKIP + N_INNER, "m >= 13 required");
+    let expected = (1usize << m) / 8;
+    assert_eq!(a_packed.len(), expected);
+    assert_eq!(b_packed.len(), expected);
+    assert_eq!(c_packed.len(), expected);
+
+    challenger.observe_label(b"flock-ag-skip-v1");
+    let r_outer = challenger.sample_f128_vec(m - K_SKIP - N_INNER);
+    let eq = crate::zerocheck::univariate_skip::build_eq(&r_outer);
+
+    let (msg, s_hat_v_c) = prove_round1_banks(a_packed, b_packed, c_packed, &eq);
+    let (proof, claim) = prove_from_round1(a_packed, b_packed, msg, &r_outer, challenger);
+    (proof, claim, s_hat_v_c)
+}
+
+/// Round 1 via the two-bank kernel: returns the canonical [`Round1Message`]
+/// (`w̄ = bank0 + bank1`, then `D⁻¹`-scaled — bit-identical to [`prove_round1`])
+/// AND the length-128 canonical `s_hat_v_c`. See [`prove_capture_s_hat_v_c`].
+#[cfg(target_arch = "aarch64")]
+fn prove_round1_banks(
+    a_packed: &[u8],
+    b_packed: &[u8],
+    c_packed: &[u8],
+    eq: &[F128],
+) -> (Round1Message, Vec<F128>) {
+    let (res_ab, bank0, bank1) = if ROUND1_UNFUSED.load(Ordering::Relaxed) {
+        crate::genus95_curve_code::round1::round1_slp_packed_banks(a_packed, b_packed, c_packed, eq)
+    } else {
+        crate::genus95_curve_code::round1::round1_slp_packed_banks_fused(
+            a_packed, b_packed, c_packed, eq,
+        )
+    };
+    let di = d_inv();
+    let msg = Round1Message {
+        ab_fresh: (0..158).map(|s| di * res_ab[s]).collect(),
+        c_msg: (0..64).map(|i| di * (bank0[i] + bank1[i])).collect(),
+    };
+    // Canonical s_hat_v_c[skip + b·64] = bank_b[skip] / D₁, with γ⁻¹ for bank 1
+    // (the kernel's odd-i bank carries an extra γ from friendly bit 0 = 1).
+    // 1/D₁ = (1+γ)·κ since D = (1+γ)·D₁ and κ = D⁻¹ = d_inv().
+    let inv_d1 = (F128::ONE + gamma_pow(1)) * di;
+    let gamma_inv = gamma_pow(1).inv();
+    let n_skip = 1usize << K_SKIP;
+    let mut s_hat_v_c = vec![F128::ZERO; 1 << crate::pcs::LOG_PACKING];
+    for skip in 0..n_skip {
+        s_hat_v_c[skip] = bank0[skip] * inv_d1;
+        s_hat_v_c[n_skip + skip] = bank1[skip] * inv_d1 * gamma_inv;
+    }
+    (msg, s_hat_v_c)
+}
+
+/// Shared post-round-1 tail of [`prove`] / [`prove_capture_s_hat_v_c`]: observe
+/// the round-1 message, sample `r₁`, fold `a/b` at `r₁`, and run the multilinear
+/// sumcheck to the final evals. `msg` is consumed into the returned `AgProof`.
+#[cfg(target_arch = "aarch64")]
+fn prove_from_round1<C: Challenger>(
+    a_packed: &[u8],
+    b_packed: &[u8],
+    msg: Round1Message,
+    r_outer: &[F128],
+    challenger: &mut C,
+) -> (AgProof, AgClaim) {
+    challenger.observe_f128_slice(&msg.ab_fresh);
+    challenger.observe_f128_slice(&msg.c_msg);
+
+    let (r1, r1_nonce) = sample_r1_prover(challenger);
+    let c_eval = eval_c_at(&msg, &r1);
+
+    let bf = base_evaluation_functional(&r1).expect("denominator nonzero at r1");
+    let w: Vec<F128> = bf.iter().copied().collect();
+    let mut r_rest = friendly_challenges().to_vec();
+    r_rest.extend_from_slice(r_outer);
+
+    // Round 0: fused fold of a,b at r1 + the first (full-size) multilinear message.
+    let (a_mlv, b_mlv, g1_0, ginf_0) = fold_and_first_round(a_packed, b_packed, &w, &r_rest);
+    let (rounds, rhos, a_eval, b_eval) =
+        mlv_tail_fs(a_mlv, b_mlv, g1_0, ginf_0, &r_rest, challenger);
+
+    let proof = AgProof {
+        round1_ab: msg.ab_fresh,
+        round1_c: msg.c_msg,
+        r1_nonce,
+        multilinear_rounds: rounds,
+        final_a_eval: a_eval,
+        final_b_eval: b_eval,
+        final_c_eval: c_eval,
+    };
+    let claim = AgClaim {
+        r1,
+        mlv_challenges: rhos,
+        r_rest,
+        a_eval,
+        b_eval,
+        c_eval,
+    };
+    (proof, claim)
+}
+
+/// FS-interleaved multilinear tail shared by the 64-slot and tensor provers:
+/// observes round 0's message `(g1_0, ginf_0)`, then runs the
+/// lookahead/friendly/classic rounds to the final binding. `r_rest` must be
+/// `friendly ‖ outer`; the wire output is bit-identical across the internal
+/// path choices (lookahead on/off, friendly on/off).
+pub(super) fn mlv_tail_fs<C: Challenger>(
+    a_mlv: Vec<F128>,
+    b_mlv: Vec<F128>,
+    g1_0: F128,
+    ginf_0: F128,
+    r_rest: &[F128],
+    challenger: &mut C,
+) -> (Vec<(F128, F128)>, Vec<F128>, F128, F128) {
+    let mut rounds = Vec::with_capacity(r_rest.len());
+    let mut rhos = Vec::with_capacity(r_rest.len());
+    rounds.push((g1_0, ginf_0));
+    challenger.observe_f128(g1_0);
+    challenger.observe_f128(ginf_0);
+    let rho0 = challenger.sample_f128();
+    rhos.push(rho0);
+    let (tail_rounds, tail_rhos, a_eval, b_eval) =
+        mlv_tail_fs_resume(a_mlv, b_mlv, 1, rho0, None, r_rest, challenger);
+    rounds.extend(tail_rounds);
+    rhos.extend(tail_rhos);
+    (rounds, rhos, a_eval, b_eval)
+}
+
+/// Resume the FS tail mid-stream at round `i0`: the arrays are folded through
+/// every sampled challenge EXCEPT `rho_prev` (and `pending2`, if set — the
+/// lookahead deferred-fold invariant). Lets a caller that derived the early
+/// round messages elsewhere (e.g. the swoop's fold-level lookahead, which
+/// covers rounds 0–1 during the witness fold) hand off without extra passes.
+pub(super) fn mlv_tail_fs_resume<C: Challenger>(
+    mut a_mlv: Vec<F128>,
+    mut b_mlv: Vec<F128>,
+    i0: usize,
+    mut rho_prev: F128,
+    mut pending2: Option<F128>,
+    r_rest: &[F128],
+    challenger: &mut C,
+) -> (Vec<(F128, F128)>, Vec<F128>, F128, F128) {
+    if LOOKAHEAD_DISABLE.load(Ordering::Relaxed) {
+        crate::suboptimal_path!(
+            "classic per-round tail (LOOKAHEAD_DISABLE set)",
+            "lookahead tail (default)"
+        );
+    }
+    if NXT_ZEROFILL.load(Ordering::Relaxed) {
+        crate::suboptimal_path!(
+            "zero-filled tail scratch (NXT_ZEROFILL set)",
+            "pooled uninit scratch (default)"
+        );
+    }
+    if DISABLE_FRIENDLY_HORNER.load(Ordering::Relaxed) {
+        crate::suboptimal_path!(
+            "general kernel on friendly rounds (DISABLE_FRIENDLY_HORNER set)",
+            "friendly-Horner kernel (default)"
+        );
+    }
+    if LOOKAHEAD_FRIENDLY.load(Ordering::Relaxed) {
+        crate::suboptimal_path!(
+            "friendly-Horner lookahead (LOOKAHEAD_FRIENDLY set; measured −1.5% on Air)",
+            "general lookahead (default)"
+        );
+    }
+    let n_mlv = r_rest.len();
+    let mut rounds = Vec::with_capacity(n_mlv);
+    let mut rhos = Vec::with_capacity(n_mlv);
+
+    // Rounds 1..n_mlv: fused fold(ρ_{i-1}) + this round's message, FS-interleaved
+    // (parallel fused path while ≥10 vars remain, else naive). Ping-pong scratch.
+    //
+    // For the friendly rounds 1..=5 the message still has `6-i` `γ`-geometric
+    // inner dims, so we use the friendly-Horner kernel (no per-term `eq_lo`
+    // PMULL) with the outer eq pre-split once. Rounds 6+ (no friendly dims left)
+    // and the small tail fall back to the general kernel / naive path. The
+    // friendly kernel is bit-identical to the general one (see
+    // `friendly_round_matches_general`), so the proof is unchanged.
+    let split_outer = super::univariate_skip::SplitEqGhash::new(&r_rest[N_INNER..]);
+    let n_in = a_mlv.len();
+    let (mut a_nxt, mut b_nxt) = if n_in >= 1024 {
+        // Uninit pooled buffers (NOT vec![ZERO; n_in/2]): the fused fold writes
+        // every slot of a_nxt/b_nxt[..half] before reading (write-before-read),
+        // so a zero-fill is wasted — and it's a *serial* 256 MB memset before the
+        // parallel loop (Amdahl), the same trap `a_mlv`/`b_mlv` avoid via the pool.
+        // (`NXT_ZEROFILL` restores the old vec![ZERO] path for a within-process A/B.)
+        if NXT_ZEROFILL.load(Ordering::Relaxed) {
+            (vec![F128::ZERO; n_in / 2], vec![F128::ZERO; n_in / 2])
+        } else {
+            (
+                crate::scratch::take_f128(n_in / 2),
+                crate::scratch::take_f128(n_in / 2),
+            )
+        }
+    } else {
+        (Vec::new(), Vec::new())
+    };
+    // LOOKAHEAD state: `pending2`, when set, is a sampled challenge whose fold
+    // has been deferred (the lookahead pass folds it together with `rho_prev`,
+    // 4→1, on the next pass). Invariant: the arrays are folded through all
+    // sampled challenges EXCEPT `rho_prev` (and `pending2` if set).
+    let mut i = i0;
+    while i < n_mlv {
+        let len = a_mlv.len();
+        // Lookahead pass: needs another message round after this one and a
+        // large enough array for the fused path (same threshold as classic).
+        let lookahead = !LOOKAHEAD_DISABLE.load(Ordering::Relaxed) && i + 1 < n_mlv && len >= 1024;
+        if lookahead {
+            let out_len = if pending2.is_some() { len / 4 } else { len / 2 };
+            let (ao, bo) = (&mut a_nxt[..out_len], &mut b_nxt[..out_len]);
+            // Friendly-Horner lookahead for the iterations whose eq still spans
+            // γ-geometric friendly dims: i=1 (dims 3..6) and i=3 (dims 5..6).
+            // Opt-in (see LOOKAHEAD_FRIENDLY): measured slower on Air.
+            let use_friendly = LOOKAHEAD_FRIENDLY.load(Ordering::Relaxed);
+            let q = if let Some(r2) = pending2 {
+                if use_friendly && i == 3 {
+                    lookahead_friendly_pass::<32, 16>(
+                        &a_mlv,
+                        &b_mlv,
+                        ao,
+                        bo,
+                        (rho_prev, r2),
+                        4,
+                        &split_outer.lo,
+                        &split_outer.hi,
+                        friendly_norm(4),
+                    )
+                } else {
+                    fold2_lookahead_into(&a_mlv, &b_mlv, ao, bo, (rho_prev, r2), &r_rest[i + 2..])
+                }
+            } else if use_friendly && i == 1 {
+                lookahead_friendly_pass::<8, 8>(
+                    &a_mlv,
+                    &b_mlv,
+                    ao,
+                    bo,
+                    (rho_prev, F128::ZERO),
+                    16,
+                    &split_outer.lo,
+                    &split_outer.hi,
+                    friendly_norm(2),
+                )
+            } else {
+                fold1_lookahead_into(
+                    &a_mlv,
+                    &b_mlv,
+                    ao,
+                    bo,
+                    (rho_prev, F128::ZERO),
+                    &r_rest[i + 2..],
+                )
+            };
+            std::mem::swap(&mut a_mlv, &mut a_nxt);
+            std::mem::swap(&mut b_mlv, &mut b_nxt);
+            a_mlv.truncate(out_len);
+            b_mlv.truncate(out_len);
+            let (m1a, mia) = lookahead_msg_first(&q, r_rest[i + 1]);
+            rounds.push((m1a, mia));
+            challenger.observe_f128(m1a);
+            challenger.observe_f128(mia);
+            let rho_a = challenger.sample_f128();
+            rhos.push(rho_a);
+            let (m1b, mib) = lookahead_msg_second(&q, rho_a);
+            rounds.push((m1b, mib));
+            challenger.observe_f128(m1b);
+            challenger.observe_f128(mib);
+            let rho_b = challenger.sample_f128();
+            rhos.push(rho_b);
+            rho_prev = rho_a;
+            pending2 = Some(rho_b);
+            i += 2;
+            continue;
+        }
+        // Leaving lookahead mode: resolve the deferred fold before classic
+        // processing (arrays here are ≤ 2·1024 elements — serial fold is free).
+        if let Some(r2) = pending2.take() {
+            fold_in_place_pair(&mut a_mlv, &mut b_mlv, rho_prev);
+            rho_prev = r2;
+            continue;
+        }
+        let log_before = a_mlv.len().trailing_zeros() as usize;
+        let (m1, mi) = if log_before >= 10 {
+            let half = a_mlv.len() / 2;
+            let use_friendly =
+                (1..=5).contains(&i) && !DISABLE_FRIENDLY_HORNER.load(Ordering::Relaxed);
+            let pair = if use_friendly {
+                // Friendly-Horner: lo = friendly dims i+1..6, hi = outer (split once).
+                let lo_size = 1usize << (N_INNER - 1 - i);
+                let c_inv = friendly_norm(i);
+                let (lo, hi) = (&split_outer.lo, &split_outer.hi);
+                let (ao, bo) = (&mut a_nxt[..half], &mut b_nxt[..half]);
+                match i {
+                    1 => fold_and_friendly_round_pair_into::<4>(
+                        &a_mlv, &b_mlv, ao, bo, rho_prev, lo_size, lo, hi, c_inv,
+                    ),
+                    2 => fold_and_friendly_round_pair_into::<8>(
+                        &a_mlv, &b_mlv, ao, bo, rho_prev, lo_size, lo, hi, c_inv,
+                    ),
+                    3 => fold_and_friendly_round_pair_into::<16>(
+                        &a_mlv, &b_mlv, ao, bo, rho_prev, lo_size, lo, hi, c_inv,
+                    ),
+                    4 => fold_and_friendly_round_pair_into::<32>(
+                        &a_mlv, &b_mlv, ao, bo, rho_prev, lo_size, lo, hi, c_inv,
+                    ),
+                    5 => fold_and_friendly_round_pair_into::<64>(
+                        &a_mlv, &b_mlv, ao, bo, rho_prev, lo_size, lo, hi, c_inv,
+                    ),
+                    _ => unreachable!(),
+                }
+            } else {
+                let mut r_next = vec![F128::ONE; log_before - 1];
+                r_next[1..].copy_from_slice(&r_rest[i + 1..]);
+                fold_and_compute_round_pair_into(
+                    &a_mlv,
+                    &b_mlv,
+                    &mut a_nxt[..half],
+                    &mut b_nxt[..half],
+                    rho_prev,
+                    &r_next,
+                )
+            };
+            std::mem::swap(&mut a_mlv, &mut a_nxt);
+            std::mem::swap(&mut b_mlv, &mut b_nxt);
+            a_mlv.truncate(half);
+            b_mlv.truncate(half);
+            pair
+        } else {
+            let mut r_next = vec![F128::ONE; log_before - 1];
+            r_next[1..].copy_from_slice(&r_rest[i + 1..]);
+            fold_in_place_pair(&mut a_mlv, &mut b_mlv, rho_prev);
+            round_pair_naive(&a_mlv, &b_mlv, &r_next)
+        };
+        rounds.push((m1, mi));
+        challenger.observe_f128(m1);
+        challenger.observe_f128(mi);
+        rho_prev = challenger.sample_f128();
+        rhos.push(rho_prev);
+        i += 1;
+    }
+    // Final binding: one or (after a trailing lookahead pass) two deferred
+    // challenges remain.
+    fold_in_place_pair(&mut a_mlv, &mut b_mlv, rho_prev);
+    if let Some(r2) = pending2 {
+        fold_in_place_pair(&mut a_mlv, &mut b_mlv, r2);
+    }
+    let (a_eval, b_eval) = (a_mlv[0], b_mlv[0]);
+    challenger.observe_f128(a_eval);
+    challenger.observe_f128(b_eval);
+    // Recycle the tail buffers (same as the RS tail in `zerocheck.rs`) — the
+    // truncated Vecs keep their full capacity, and dropping them instead
+    // would munmap + re-fault 100s of MB on the next prove.
+    crate::scratch::give_f128(a_mlv);
+    crate::scratch::give_f128(b_mlv);
+    crate::scratch::give_f128(a_nxt);
+    crate::scratch::give_f128(b_nxt);
+    (rounds, rhos, a_eval, b_eval)
+}
+
+/// Verify an AG-skip zerocheck proof for an instance over `{0,1}^m`. Walks the
+/// challenger in lockstep with the prover and checks every round's consistency.
+pub fn verify<C: Challenger>(
+    m: usize,
+    proof: &AgProof,
+    challenger: &mut C,
+) -> Result<AgClaim, AgVerifyError> {
+    if m < K_SKIP + N_INNER {
+        return Err(AgVerifyError::LogNTooSmall { log_n: m });
+    }
+    let n_mlv = m - K_SKIP;
+    if proof.round1_ab.len() != 158 {
+        return Err(AgVerifyError::BadRound1Length {
+            which: "ab",
+            expected: 158,
+            got: proof.round1_ab.len(),
+        });
+    }
+    if proof.round1_c.len() != 64 {
+        return Err(AgVerifyError::BadRound1Length {
+            which: "c",
+            expected: 64,
+            got: proof.round1_c.len(),
+        });
+    }
+    if proof.multilinear_rounds.len() != n_mlv {
+        return Err(AgVerifyError::BadMultilinearRoundsLength {
+            expected: n_mlv,
+            got: proof.multilinear_rounds.len(),
+        });
+    }
+
+    challenger.observe_label(b"flock-ag-skip-v1");
+    let r_outer = challenger.sample_f128_vec(m - K_SKIP - N_INNER);
+    challenger.observe_f128_slice(&proof.round1_ab);
+    challenger.observe_f128_slice(&proof.round1_c);
+
+    let r1 = replay_r1_verifier(challenger, proof.r1_nonce)?;
+    let msg = Round1Message {
+        ab_fresh: proof.round1_ab.clone(),
+        c_msg: proof.round1_c.clone(),
+    };
+    if eval_c_at(&msg, &r1) != proof.final_c_eval {
+        return Err(AgVerifyError::CEvalMismatch);
+    }
+    let mut c_running = eval_ab_at(&msg, &r1);
+
+    let mut r_rest = friendly_challenges().to_vec();
+    r_rest.extend_from_slice(&r_outer);
+
+    let mut rhos = Vec::with_capacity(n_mlv);
+    for i in 0..n_mlv {
+        let (g1, g_inf) = proof.multilinear_rounds[i];
+        let r_eq = r_rest[i];
+        let g0 = (c_running + r_eq * g1) * (F128::ONE + r_eq).inv();
+        challenger.observe_f128(g1);
+        challenger.observe_f128(g_inf);
+        let rho = challenger.sample_f128();
+        rhos.push(rho);
+        c_running = g0 * (F128::ONE + rho) + g1 * rho + g_inf * rho * (rho + F128::ONE);
+    }
+    challenger.observe_f128(proof.final_a_eval);
+    challenger.observe_f128(proof.final_b_eval);
+
+    if c_running != proof.final_a_eval * proof.final_b_eval {
+        return Err(AgVerifyError::SumcheckFinalFailed);
+    }
+    Ok(AgClaim {
+        r1,
+        mlv_challenges: rhos,
+        r_rest,
+        a_eval: proof.final_a_eval,
+        b_eval: proof.final_b_eval,
+        c_eval: proof.final_c_eval,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::genus95_curve_code::{RngCore, Sha256Rng, sample_random_evaluation_point};
+
+    /// The pinned friendly challenges reproduce the geometric eq weight
+    /// `eq(r_inner, b) = γ^{int(b)} / D` for every inner index `b ∈ [0, 128)`.
+    #[test]
+    fn friendly_eq_is_gamma_geometric_over_d() {
+        let r = friendly_challenges();
+        let di = d_inv();
+        for b in 0..(1usize << N_INNER) {
+            let mut eq = F128::ONE;
+            for j in 0..N_INNER {
+                eq *= if (b >> j) & 1 == 1 {
+                    r[j]
+                } else {
+                    F128::ONE + r[j]
+                };
+            }
+            assert_eq!(eq, gamma_pow(b) * di, "b={b}");
+        }
+    }
+
+    #[test]
+    fn d_times_d_inv_is_one() {
+        assert_eq!(d_const() * d_inv(), F128::ONE);
+    }
+
+    /// The SHA-256 DRBG drives the rejection sampler deterministically: equal
+    /// seeds give the same `r₁`, distinct seeds (almost surely) differ.
+    #[test]
+    fn sha256_rng_seeds_sampler_deterministically() {
+        let seed = [0x5Au8; 32];
+        let p1 = sample_random_evaluation_point(&mut Sha256Rng::new(seed)).expect("point");
+        let p2 = sample_random_evaluation_point(&mut Sha256Rng::new(seed)).expect("point");
+        assert_eq!(p1, p2, "same seed must give same r1");
+        let p3 = sample_random_evaluation_point(&mut Sha256Rng::new([0xA5u8; 32])).expect("point");
+        assert_ne!(p1, p3, "different seed should give a different r1");
+    }
+
+    /// Round-1 keystone: the prover's message, evaluated at `r₁` by the verifier
+    /// (`⟨E(r₁), [w̄|fresh]⟩` for AB, `⟨base(r₁), w̄⟩` for C), matches a direct
+    /// per-column reference `Σ_o eq[o] Σ_b (γ^b/D)·[…]`. Honest witness (`c=a&b`)
+    /// so systematic vanishing holds and `w̄` is the true value section.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn round1_eval_matches_direct_reference() {
+        use crate::genus95_curve_code::{BaseMessage, evaluate_base_functional};
+
+        let mut rng = Sha256Rng::new([42u8; 32]);
+        let n = 2usize;
+        let mut am = vec![[0u64; 128]; n];
+        let mut bm = vec![[0u64; 128]; n];
+        let mut cm = vec![[0u64; 128]; n];
+        for o in 0..n {
+            for b in 0..128 {
+                am[o][b] = rng.next_u64();
+                bm[o][b] = rng.next_u64();
+                cm[o][b] = am[o][b] & bm[o][b];
+            }
+        }
+        let pack = |ms: &[[u64; 128]]| -> Vec<u8> {
+            let mut p = vec![0u8; ms.len() * 1024];
+            for (o, blk) in ms.iter().enumerate() {
+                for b in 0..128 {
+                    p[o * 1024 + b * 8..o * 1024 + b * 8 + 8]
+                        .copy_from_slice(&blk[b].to_le_bytes());
+                }
+            }
+            p
+        };
+        let eq: Vec<F128> = (0..n)
+            .map(|_| F128 {
+                lo: rng.next_u64(),
+                hi: rng.next_u64(),
+            })
+            .collect();
+
+        let msg = prove_round1(&pack(&am), &pack(&bm), &pack(&cm), &eq);
+        let r1 = sample_random_evaluation_point(&mut Sha256Rng::new([7u8; 32])).expect("point");
+
+        let v_ab = eval_ab_at(&msg, &r1);
+        let v_c = eval_c_at(&msg, &r1);
+
+        let bf =
+            crate::genus95_curve_code::base_evaluation_functional(&r1).expect("base functional");
+        let di = d_inv();
+        let mut d_ab = F128::ZERO;
+        let mut d_c = F128::ZERO;
+        for o in 0..n {
+            for b in 0..128 {
+                let w = eq[o] * gamma_pow(b) * di;
+                let ea = evaluate_base_functional(&bf, &BaseMessage(am[o][b]));
+                let eb = evaluate_base_functional(&bf, &BaseMessage(bm[o][b]));
+                let ec = evaluate_base_functional(&bf, &BaseMessage(cm[o][b]));
+                d_ab += w * ea * eb;
+                d_c += w * ec;
+            }
+        }
+        assert_eq!(v_ab, d_ab, "P^ab(r1) != direct reference");
+        assert_eq!(v_c, d_c, "c(r1) != direct reference");
+    }
+
+    /// The folded rows feed the multilinear sumcheck: (1) `â(r₁, rest=o*128+b)`
+    /// equals the per-column base evaluation, and (2) the eq-weighted sum of the
+    /// folded products, `Σ_rest eq(r_rest,rest)·â(r₁,rest)·b̂(r₁,rest)`, equals the
+    /// round-1 AB claim `eval_ab_at` — i.e. the multilinear phase starts from the
+    /// exact value round 1 produced.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn fold_at_r1_consistent_with_round1_claim() {
+        use crate::genus95_curve_code::{
+            BaseMessage, base_evaluation_functional, evaluate_base_functional,
+        };
+
+        let mut rng = Sha256Rng::new([99u8; 32]);
+        let n = 2usize;
+        let mut am = vec![[0u64; 128]; n];
+        let mut bm = vec![[0u64; 128]; n];
+        let mut cm = vec![[0u64; 128]; n];
+        for o in 0..n {
+            for b in 0..128 {
+                am[o][b] = rng.next_u64();
+                bm[o][b] = rng.next_u64();
+                cm[o][b] = am[o][b] & bm[o][b];
+            }
+        }
+        let pack = |ms: &[[u64; 128]]| -> Vec<u8> {
+            let mut p = vec![0u8; ms.len() * 1024];
+            for (o, blk) in ms.iter().enumerate() {
+                for b in 0..128 {
+                    p[o * 1024 + b * 8..o * 1024 + b * 8 + 8]
+                        .copy_from_slice(&blk[b].to_le_bytes());
+                }
+            }
+            p
+        };
+        let (a_packed, b_packed, c_packed) = (pack(&am), pack(&bm), pack(&cm));
+        let eq: Vec<F128> = (0..n)
+            .map(|_| F128 {
+                lo: rng.next_u64(),
+                hi: rng.next_u64(),
+            })
+            .collect();
+
+        let msg = prove_round1(&a_packed, &b_packed, &c_packed, &eq);
+        let r1 = sample_random_evaluation_point(&mut Sha256Rng::new([7u8; 32])).expect("point");
+        let bf = base_evaluation_functional(&r1).expect("base functional");
+        let w: Vec<F128> = bf.iter().copied().collect();
+
+        let a_mlv = fold_witness_at_r1(&a_packed, &w);
+        let b_mlv = fold_witness_at_r1(&b_packed, &w);
+
+        // (1) folded row == per-column base evaluation.
+        for o in 0..n {
+            for b in 0..128 {
+                assert_eq!(
+                    a_mlv[o * 128 + b],
+                    evaluate_base_functional(&bf, &BaseMessage(am[o][b])),
+                    "a_mlv[{o},{b}]"
+                );
+            }
+        }
+
+        // (2) eq-weighted fold sum == round-1 AB claim.
+        let di = d_inv();
+        let mut s = F128::ZERO;
+        for o in 0..n {
+            for b in 0..128 {
+                let r = o * 128 + b;
+                let eq_rest = eq[o] * gamma_pow(b) * di;
+                s += eq_rest * a_mlv[r] * b_mlv[r];
+            }
+        }
+        assert_eq!(s, eval_ab_at(&msg, &r1), "fold sum != round-1 AB claim");
+    }
+
+    /// The fused `fold_and_first_round` equals doing the two folds and the round-0
+    /// message separately.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn fold_and_first_round_matches_separate() {
+        use crate::genus95_curve_code::base_evaluation_functional;
+        use crate::zerocheck::univariate_skip::build_eq;
+
+        let mut rng = Sha256Rng::new([88u8; 32]);
+        let m = 14usize;
+        let nbytes = (1usize << m) / 8;
+        let mut a = vec![0u8; nbytes];
+        let mut b = vec![0u8; nbytes];
+        for x in a.iter_mut() {
+            *x = rng.next_u64() as u8;
+        }
+        for x in b.iter_mut() {
+            *x = rng.next_u64() as u8;
+        }
+        let r_outer: Vec<F128> = (0..m - K_SKIP - N_INNER)
+            .map(|_| F128 {
+                lo: rng.next_u64(),
+                hi: rng.next_u64(),
+            })
+            .collect();
+        let mut r_rest = friendly_challenges().to_vec();
+        r_rest.extend_from_slice(&r_outer);
+        let _ = build_eq(&r_outer); // (eq weights are derived inside)
+        let r1 = sample_random_evaluation_point(&mut Sha256Rng::new([3u8; 32])).expect("point");
+        let bf = base_evaluation_functional(&r1).expect("bf");
+        let w: Vec<F128> = bf.iter().copied().collect();
+
+        let (a_mlv_f, b_mlv_f, g1, ginf) = fold_and_first_round(&a, &b, &w, &r_rest);
+        let a_mlv = fold_witness_at_r1(&a, &w);
+        let b_mlv = fold_witness_at_r1(&b, &w);
+        assert_eq!(a_mlv_f, a_mlv, "fused a_mlv != separate fold");
+        assert_eq!(b_mlv_f, b_mlv, "fused b_mlv != separate fold");
+
+        let log_now = a_mlv.len().trailing_zeros() as usize;
+        let mut r_next = vec![F128::ONE; log_now];
+        r_next[1..].copy_from_slice(&r_rest[1..]);
+        assert_eq!(
+            (g1, ginf),
+            round_pair_naive(&a_mlv, &b_mlv, &r_next),
+            "fused first message != round_pair_naive"
+        );
+    }
+
+    /// The friendly-Horner round kernel ([`fold_and_friendly_round_pair_into`])
+    /// produces a **bit-identical** folded `a_out`/`b_out` and `(G(1), G(∞))` to
+    /// the general [`super::super::multilinear::fold_and_compute_round_pair_into`]
+    /// for every friendly round `i ∈ 1..=5`. (Same field value, so the two
+    /// factorizations — per-term `eq_lo` PMULL vs friendly `γ`-Horner — agree to
+    /// the bit; this is what makes the wired `prove` byte-identical.)
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn friendly_round_matches_general() {
+        use crate::zerocheck::univariate_skip::SplitEqGhash;
+
+        let mut rng = Sha256Rng::new([0x1f; 32]);
+        let o = 9usize; // outer dims (m - 13), big enough to exercise n_ol > 1
+        let r_outer: Vec<F128> = (0..o)
+            .map(|_| F128 {
+                lo: rng.next_u64(),
+                hi: rng.next_u64(),
+            })
+            .collect();
+        let friendly = friendly_challenges();
+        let split = SplitEqGhash::new(&r_outer);
+
+        for i in 1..=5usize {
+            let l = 8 - i + o; // array log at the start of round i
+            let n = 1usize << l;
+            let a: Vec<F128> = (0..n)
+                .map(|_| F128 {
+                    lo: rng.next_u64(),
+                    hi: rng.next_u64(),
+                })
+                .collect();
+            let b: Vec<F128> = (0..n)
+                .map(|_| F128 {
+                    lo: rng.next_u64(),
+                    hi: rng.next_u64(),
+                })
+                .collect();
+            let rho = F128 {
+                lo: rng.next_u64(),
+                hi: rng.next_u64(),
+            };
+            let half = n / 2;
+
+            // General kernel: r_next = [ONE, friendly[i+1..7], r_outer].
+            let mut r_next = vec![F128::ONE; l - 1];
+            let mut tail = friendly[i + 1..N_INNER].to_vec();
+            tail.extend_from_slice(&r_outer);
+            r_next[1..].copy_from_slice(&tail);
+            let mut a_gen = crate::alloc_uninit_f128_vec(half);
+            let mut b_gen = crate::alloc_uninit_f128_vec(half);
+            let msg_gen =
+                fold_and_compute_round_pair_into(&a, &b, &mut a_gen, &mut b_gen, rho, &r_next);
+
+            // Friendly-Horner kernel.
+            let mut a_fr = crate::alloc_uninit_f128_vec(half);
+            let mut b_fr = crate::alloc_uninit_f128_vec(half);
+            let lo_size = 1usize << (N_INNER - 1 - i); // 2^{6-i}
+            let c_inv = friendly_norm(i);
+            let (lo, hi) = (&split.lo, &split.hi);
+            let msg_fr = match i {
+                1 => fold_and_friendly_round_pair_into::<4>(
+                    &a, &b, &mut a_fr, &mut b_fr, rho, lo_size, lo, hi, c_inv,
+                ),
+                2 => fold_and_friendly_round_pair_into::<8>(
+                    &a, &b, &mut a_fr, &mut b_fr, rho, lo_size, lo, hi, c_inv,
+                ),
+                3 => fold_and_friendly_round_pair_into::<16>(
+                    &a, &b, &mut a_fr, &mut b_fr, rho, lo_size, lo, hi, c_inv,
+                ),
+                4 => fold_and_friendly_round_pair_into::<32>(
+                    &a, &b, &mut a_fr, &mut b_fr, rho, lo_size, lo, hi, c_inv,
+                ),
+                5 => fold_and_friendly_round_pair_into::<64>(
+                    &a, &b, &mut a_fr, &mut b_fr, rho, lo_size, lo, hi, c_inv,
+                ),
+                _ => unreachable!(),
+            };
+
+            assert_eq!(a_fr, a_gen, "round {i}: folded a_out mismatch");
+            assert_eq!(b_fr, b_gen, "round {i}: folded b_out mismatch");
+            assert_eq!(msg_fr, msg_gen, "round {i}: (G(1), G(∞)) mismatch");
+        }
+    }
+
+    /// End-to-end (no PCS): round 1 → fold → multilinear sumcheck, and the
+    /// verifier's running claim telescopes from the round-1 value down to
+    /// `a_eval · b_eval` at the final folded point — i.e. the verifier accepts a
+    /// correctly-produced proof. `m = 14` (7 inner + 1 outer rest dims).
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn full_chain_verifier_accepts() {
+        use crate::zerocheck::univariate_skip::build_eq;
+
+        let mut rng = Sha256Rng::new([123u8; 32]);
+        let n = 2usize;
+        let mut am = vec![[0u64; 128]; n];
+        let mut bm = vec![[0u64; 128]; n];
+        let mut cm = vec![[0u64; 128]; n];
+        for o in 0..n {
+            for b in 0..128 {
+                am[o][b] = rng.next_u64();
+                bm[o][b] = rng.next_u64();
+                cm[o][b] = am[o][b] & bm[o][b];
+            }
+        }
+        let pack = |ms: &[[u64; 128]]| -> Vec<u8> {
+            let mut p = vec![0u8; ms.len() * 1024];
+            for (o, blk) in ms.iter().enumerate() {
+                for b in 0..128 {
+                    p[o * 1024 + b * 8..o * 1024 + b * 8 + 8]
+                        .copy_from_slice(&blk[b].to_le_bytes());
+                }
+            }
+            p
+        };
+        let (a_packed, b_packed, c_packed) = (pack(&am), pack(&bm), pack(&cm));
+
+        // One outer challenge → eq weights (one per block); r_rest = friendly ‖ outer.
+        let r_outer = vec![F128 {
+            lo: rng.next_u64(),
+            hi: rng.next_u64(),
+        }];
+        let eq = build_eq(&r_outer);
+        assert_eq!(eq.len(), n);
+
+        let msg = prove_round1(&a_packed, &b_packed, &c_packed, &eq);
+        let r1 = sample_random_evaluation_point(&mut Sha256Rng::new([7u8; 32])).expect("point");
+        let claim_ab = eval_ab_at(&msg, &r1);
+
+        let bf =
+            crate::genus95_curve_code::base_evaluation_functional(&r1).expect("base functional");
+        let w: Vec<F128> = bf.iter().copied().collect();
+        let a_mlv = fold_witness_at_r1(&a_packed, &w);
+        let b_mlv = fold_witness_at_r1(&b_packed, &w);
+
+        let mut r_rest = friendly_challenges().to_vec();
+        r_rest.extend_from_slice(&r_outer);
+        let rhos: Vec<F128> = (0..r_rest.len())
+            .map(|_| F128 {
+                lo: rng.next_u64(),
+                hi: rng.next_u64(),
+            })
+            .collect();
+
+        let (msgs, a_eval, b_eval) = prove_multilinear(a_mlv, b_mlv, &r_rest, &rhos);
+        let c = verify_multilinear(claim_ab, &r_rest, &msgs, &rhos);
+        assert_eq!(
+            c,
+            a_eval * b_eval,
+            "verifier final claim != a_eval * b_eval"
+        );
+    }
+
+    fn random_witness(m: usize, seed: u8) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let mut rng = Sha256Rng::new([seed; 32]);
+        let nbytes = (1usize << m) / 8;
+        let mut a = vec![0u8; nbytes];
+        let mut b = vec![0u8; nbytes];
+        for x in a.iter_mut() {
+            *x = rng.next_u64() as u8;
+        }
+        for x in b.iter_mut() {
+            *x = rng.next_u64() as u8;
+        }
+        let c: Vec<u8> = a.iter().zip(&b).map(|(x, y)| x & y).collect(); // honest c = a & b
+        (a, b, c)
+    }
+
+    /// Full Fiat–Shamir roundtrip: prove and verify with matching SHA-256
+    /// challengers; the verifier accepts and reproduces the prover's claim.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn prove_verify_roundtrip() {
+        use crate::challenger::FsChallenger;
+        let m = 20usize; // ≥ 16 so the fused (≥10-var) multilinear path is exercised
+        let (a, b, c) = random_witness(m, 55);
+        let (proof, claim) = prove(&a, &b, &c, m, &mut FsChallenger::new(b"flock-ag-skip-test"));
+        let vclaim = verify(m, &proof, &mut FsChallenger::new(b"flock-ag-skip-test"))
+            .expect("verifier accepts honest proof");
+        assert_eq!(vclaim, claim, "verifier claim != prover claim");
+    }
+
+    /// The r₁ nonce grind follows the transcript hash: a BLAKE3-FS transcript
+    /// derives r₁ through the BLAKE3 expander (`FsRng::Blake3`) and still
+    /// roundtrips — and produces a different r₁/nonce than the SHA-256
+    /// transcript (the two proofs genuinely diverge, so both arms are live).
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn prove_verify_roundtrip_blake3_fs() {
+        use crate::challenger::FsChallenger;
+        use crate::hash::HashKind;
+        let m = 14usize;
+        let (a, b, c) = random_witness(m, 91);
+        let mk = |kind| FsChallenger::with_hash(b"flock-ag-skip-b3", kind);
+        let (proof_b3, claim_b3) = prove(&a, &b, &c, m, &mut mk(HashKind::Blake3));
+        let vclaim = verify(m, &proof_b3, &mut mk(HashKind::Blake3))
+            .expect("verifier accepts honest BLAKE3-FS proof");
+        assert_eq!(vclaim, claim_b3);
+
+        let (proof_sha, _) = prove(&a, &b, &c, m, &mut mk(HashKind::Sha256));
+        assert_ne!(
+            proof_b3, proof_sha,
+            "BLAKE3-FS and SHA-256-FS transcripts must diverge"
+        );
+    }
+
+    /// LOOKAHEAD parity: the sumcheck-lookahead tail produces a bit-identical
+    /// proof and claim to the classic one-round-per-pass tail (the transcript
+    /// is unchanged — lookahead only changes the prover's evaluation strategy).
+    /// m = 20 gives 14 mlv rounds: entry fold1 pass, several fold2 passes, the
+    /// pending-resolution demotion, and the small-round classic fallback are
+    /// all exercised.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn lookahead_matches_classic() {
+        use crate::challenger::FsChallenger;
+        let m = 20usize;
+        let (a, b, c) = random_witness(m, 77);
+        LOOKAHEAD_DISABLE.store(false, Ordering::Relaxed);
+        let (p_look, c_look) = prove(&a, &b, &c, m, &mut FsChallenger::new(b"flock-ag-la-test"));
+        LOOKAHEAD_FRIENDLY.store(true, Ordering::Relaxed);
+        let (p_friend, c_friend) =
+            prove(&a, &b, &c, m, &mut FsChallenger::new(b"flock-ag-la-test"));
+        LOOKAHEAD_FRIENDLY.store(false, Ordering::Relaxed);
+        LOOKAHEAD_DISABLE.store(true, Ordering::Relaxed);
+        let (p_classic, c_classic) =
+            prove(&a, &b, &c, m, &mut FsChallenger::new(b"flock-ag-la-test"));
+        LOOKAHEAD_DISABLE.store(false, Ordering::Relaxed);
+        assert_eq!(p_look, p_classic, "lookahead proof != classic proof");
+        assert_eq!(c_look, c_classic, "lookahead claim != classic claim");
+        assert_eq!(
+            p_friend, p_classic,
+            "friendly-lookahead proof != classic proof"
+        );
+        assert_eq!(
+            c_friend, c_classic,
+            "friendly-lookahead claim != classic claim"
+        );
+    }
+
+    /// The verifier rejects a proof with a tampered round message.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn verify_rejects_mutated_proof() {
+        use crate::challenger::FsChallenger;
+        let m = 14usize;
+        let (a, b, c) = random_witness(m, 66);
+        let (mut proof, _) = prove(&a, &b, &c, m, &mut FsChallenger::new(b"flock-ag-skip-test"));
+        proof.multilinear_rounds[0].0 += F128::ONE;
+        assert!(
+            verify(m, &proof, &mut FsChallenger::new(b"flock-ag-skip-test")).is_err(),
+            "must reject a tampered round message"
+        );
+    }
+
+    /// The verifier rejects a tampered `r₁` grinding nonce: out-of-budget
+    /// nonces outright (`BadR1Nonce`), and any shifted in-budget nonce — either
+    /// its attempt rejects, or it lands a *different* valid `r₁` and the c-eval
+    /// / sumcheck consistency breaks downstream.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn verify_rejects_tampered_r1_nonce() {
+        use crate::challenger::FsChallenger;
+        let m = 14usize;
+        let (a, b, c) = random_witness(m, 67);
+        let (proof, _) = prove(&a, &b, &c, m, &mut FsChallenger::new(b"flock-ag-skip-test"));
+
+        let mut oob = proof.clone();
+        oob.r1_nonce = crate::genus95_curve_code::SAMPLE_ATTEMPT_BUDGET;
+        assert_eq!(
+            verify(m, &oob, &mut FsChallenger::new(b"flock-ag-skip-test")),
+            Err(AgVerifyError::BadR1Nonce {
+                nonce: oob.r1_nonce
+            }),
+            "must reject an out-of-budget nonce"
+        );
+
+        for delta in 1..=3u32 {
+            let mut tampered = proof.clone();
+            tampered.r1_nonce = proof.r1_nonce + delta;
+            assert!(
+                verify(m, &tampered, &mut FsChallenger::new(b"flock-ag-skip-test")).is_err(),
+                "must reject nonce shifted by {delta}"
+            );
+        }
+    }
+
+    /// **Std-pack keystone (#4).** The AG c-claim's point — skip = `r₁` (the AG
+    /// `EvaluationPoint`), rest = `r_rest` (friendly ‖ outer) — maps cleanly onto
+    /// the *standard* packed witness `[skip 6 | bit6 | …]` prefix. Concretely: the
+    /// standard ring-switch claim check with AG **base** weights for the skip
+    /// recovers the AG zerocheck's `c_eval`:
+    ///
+    /// ```text
+    /// claim_check( base(r₁) ⊗ eq(r_rest[0]),  fold_1b_rows(pack_witness(z)) ) == c_eval
+    /// ```
+    ///
+    /// This is the direct analog of the RS φ₈ c-ring-switch
+    /// (`ring_switch::claim_check_recovers_zhat_skip`), and is what lets the AG
+    /// `(ab, c)` claims reuse the existing RS open path unchanged. No extra κ
+    /// factor: the `D⁻¹` carry is already baked into `w̄`, and `r_rest[0] =
+    /// friendly_challenges()[0]` supplies the matching `eq` factor for bit 6.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn ag_c_claim_maps_onto_std_pack() {
+        use crate::challenger::FsChallenger;
+        use crate::genus95_curve_code::base_evaluation_functional;
+        use crate::pcs::pack::pack_witness;
+        use crate::pcs::ring_switch::{
+            build_claim_weights_from_skip, claim_check, fold_1b_rows_naive,
+        };
+        use crate::zerocheck::univariate_skip::build_eq;
+
+        for &m in &[13usize, 14, 15] {
+            // Random bit-witness z; c = C·z = z (the C = I convention).
+            let mut rng = Sha256Rng::new([m as u8; 32]);
+            let nbits = 1usize << m;
+            let mut z_bits = vec![false; nbits];
+            let mut z_bytes = vec![0u8; nbits / 8];
+            for j in 0..(nbits / 8) {
+                let byte = rng.next_u64() as u8;
+                z_bytes[j] = byte;
+                for r in 0..8 {
+                    z_bits[8 * j + r] = (byte >> r) & 1 == 1;
+                }
+            }
+            // a, b are arbitrary here — only the c-claim is exercised.
+            let (a, b) = (z_bytes.clone(), z_bytes.clone());
+
+            let (_proof, claim) = prove(
+                &a,
+                &b,
+                &z_bytes,
+                m,
+                &mut FsChallenger::new(b"flock-ag-stdpack-keystone"),
+            );
+
+            // c-claim point: skip = r₁, full (m − K_SKIP) multilinear = r_rest.
+            let x_outer = &claim.r_rest;
+            assert_eq!(x_outer.len(), m - K_SKIP);
+
+            // Standard packing + ring-switch s_hat_v over the suffix x_outer[1..].
+            let packed = pack_witness(&z_bits, m);
+            let suffix_tensor = build_eq(&x_outer[1..]);
+            assert_eq!(packed.len(), suffix_tensor.len());
+            let s_hat_v = fold_1b_rows_naive(&packed, &suffix_tensor);
+
+            // AG base weights for the skip (64), tensored with eq(x_outer[0]).
+            let bf = base_evaluation_functional(&claim.r1).expect("base functional");
+            let skip_w: Vec<F128> = (0..(1usize << K_SKIP)).map(|i| bf[i]).collect();
+            let weights = build_claim_weights_from_skip(&skip_w, x_outer[0]);
+
+            assert_eq!(
+                claim_check(&weights, &s_hat_v),
+                claim.c_eval,
+                "AG c-claim claim_check != c_eval at m={m}",
+            );
+        }
+    }
+
+    /// The captured `s_hat_v_c` (from [`prove_capture_s_hat_v_c`]) is byte-for-byte
+    /// the canonical ring-switch fold `fold_1b_rows(pack_witness(z), eq(r_rest[1..]))`
+    /// the PCS open would otherwise recompute — and the `AgProof`/`AgClaim` are
+    /// identical to plain [`prove`]'s. This pins the two-bank kernel + the
+    /// `1/D₁`, `γ⁻¹` rescaling against the independent `fold_1b_rows` oracle.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn s_hat_v_c_matches_fold_1b_rows() {
+        use crate::challenger::FsChallenger;
+        use crate::pcs::pack::pack_witness;
+        use crate::pcs::ring_switch::fold_1b_rows_naive;
+        use crate::zerocheck::univariate_skip::build_eq;
+
+        for &m in &[13usize, 14, 15, 16] {
+            let mut rng = Sha256Rng::new([m as u8 ^ 0x3c; 32]);
+            let nbits = 1usize << m;
+            let mut z_bits = vec![false; nbits];
+            let mut z_bytes = vec![0u8; nbits / 8];
+            for j in 0..(nbits / 8) {
+                let byte = rng.next_u64() as u8;
+                z_bytes[j] = byte;
+                for r in 0..8 {
+                    z_bits[8 * j + r] = (byte >> r) & 1 == 1;
+                }
+            }
+            let (a, b) = (z_bytes.clone(), z_bytes.clone());
+
+            // Plain prove (reference proof) vs capture (proof must be identical).
+            let (proof_ref, _claim_ref) = prove(
+                &a,
+                &b,
+                &z_bytes,
+                m,
+                &mut FsChallenger::new(b"flock-ag-shatvc"),
+            );
+            let (proof, claim, s_hat_v_c) = prove_capture_s_hat_v_c(
+                &a,
+                &b,
+                &z_bytes,
+                m,
+                &mut FsChallenger::new(b"flock-ag-shatvc"),
+            );
+            assert_eq!(proof, proof_ref, "captured AgProof != plain prove at m={m}");
+
+            // Canonical reference: fold_1b_rows over the c-claim suffix r_rest[1..].
+            let packed = pack_witness(&z_bits, m);
+            let suffix = build_eq(&claim.r_rest[1..]);
+            let want = fold_1b_rows_naive(&packed, &suffix);
+            assert_eq!(s_hat_v_c, want, "s_hat_v_c != fold_1b_rows at m={m}");
+        }
+    }
+
+    /// The verifier rejects a witness that violates `a·b = c`: the systematic
+    /// vanishing reconstruction injects the wrong value section, so the sumcheck
+    /// running claim fails to telescope to `a_eval·b_eval`.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn verify_rejects_dishonest_witness() {
+        use crate::challenger::FsChallenger;
+        let m = 14usize;
+        let mut rng = Sha256Rng::new([77u8; 32]);
+        let nbytes = (1usize << m) / 8;
+        let mut a = vec![0u8; nbytes];
+        let mut b = vec![0u8; nbytes];
+        let mut c = vec![0u8; nbytes];
+        for x in a.iter_mut() {
+            *x = rng.next_u64() as u8;
+        }
+        for x in b.iter_mut() {
+            *x = rng.next_u64() as u8;
+        }
+        for x in c.iter_mut() {
+            *x = rng.next_u64() as u8; // random c, ≠ a & b
+        }
+        let (proof, _) = prove(&a, &b, &c, m, &mut FsChallenger::new(b"flock-ag-skip-test"));
+        assert!(
+            verify(m, &proof, &mut FsChallenger::new(b"flock-ag-skip-test")).is_err(),
+            "must reject a witness violating a*b=c"
+        );
+    }
+}

--- a/crates/flock-core/src/zerocheck/multilinear.rs
+++ b/crates/flock-core/src/zerocheck/multilinear.rs
@@ -1046,6 +1046,197 @@ fn uni_skip_fold_and_round_pair_optimized_packed_serial(
     (a_folded, b_folded, mlv_challenges[0] * sum1, sum_inf)
 }
 
+// ---------------------------------------------------------------------------
+// Sumcheck LOOKAHEAD (Rothblum): one pass accumulates the BIVARIATE
+//
+//   Q(X,Y) = Σ_u eq(rest,u) · â(X,Y,u) · b̂(X,Y,u)
+//
+// covering the next TWO rounds. The first round's message is the Y∈{0,1}
+// eq-weighted combination of Q's rows; once its challenge ρ arrives, the
+// second round's message is Q(ρ,·) — both O(1) from 8 accumulated sums, no
+// pass over the data. Each pass then folds TWO already-bound variables (4→1),
+// so per two rounds the traffic drops from (read 2n + write n) + (read n +
+// write n/2) to (read 2n + write n/2) — −44% in the tail's fully memory-bound
+// regime, where the extra multiplies hide (measured: fold-only == full).
+//
+// TRANSCRIPT-INVARIANT: exact field arithmetic means the derived messages
+// equal the classically computed ones bit-for-bit (see the parity test); only
+// the prover's evaluation strategy changes.
+//
+// The 8 sums (X kept in coefficient form — ρ is unknown at accumulation time;
+// the Y=0 column only ever feeds the first message at X∈{1,∞}, so it needs
+// just those two projections rather than 3 coefficients):
+//   s10   = Σ eq·A(1,0)B(1,0)                (col Y=0 @ X=1)
+//   sinf0 = Σ eq·ΔₓA(0)·ΔₓB(0)               (col Y=0, X-leading)
+//   s1    = X-coeffs of col Y=1  (accumulated as c0, value@X=1, c2)
+//   sinf  = X-coeffs of col Y=∞  (the Y-slope product column, same trick)
+// ---------------------------------------------------------------------------
+
+/// The reduced lookahead sums for one pass.
+#[derive(Clone, Copy, Debug)]
+pub struct LookaheadSums {
+    pub s10: F128,
+    pub sinf0: F128,
+    pub s1: [F128; 3],
+    pub sinf: [F128; 3],
+}
+
+/// First-message derivation (Convention A, the AG tail's `r_next[0] = ONE`):
+/// eq-weighted combination of the Y∈{0,1} rows, `r_y` = eq coord of Y.
+#[inline]
+pub fn lookahead_msg_first(q: &LookaheadSums, r_y: F128) -> (F128, F128) {
+    let om = F128::ONE + r_y; // 1−r_y in char 2
+    let col1_at1 = q.s1[0] + q.s1[1] + q.s1[2];
+    (om * q.s10 + r_y * col1_at1, om * q.sinf0 + r_y * q.s1[2])
+}
+
+/// Second-message derivation after the first variable binds to `rho`:
+/// evaluate the two column polynomials at `rho`. Zero passes.
+#[inline]
+pub fn lookahead_msg_second(q: &LookaheadSums, rho: F128) -> (F128, F128) {
+    let r2 = rho * rho;
+    (
+        q.s1[0] + rho * q.s1[1] + r2 * q.s1[2],
+        q.sinf[0] + rho * q.sinf[1] + r2 * q.sinf[2],
+    )
+}
+
+/// The 8 per-position Q products from the 4 folded values per witness
+/// (index = x + 2y): [s10, sinf0, c0, t11, c2, d0, dt, d2] — see the module
+/// comment for which sum each feeds.
+#[inline(always)]
+pub(crate) fn lookahead_products(ga: &[F128; 4], gb: &[F128; 4]) -> [F128; 8] {
+    let (ga00, ga10, ga01, ga11) = (ga[0], ga[1], ga[2], ga[3]);
+    let (gb00, gb10, gb01, gb11) = (gb[0], gb[1], gb[2], gb[3]);
+    let sxa0 = ga00 + ga10;
+    let sxb0 = gb00 + gb10;
+    let sxa1 = ga01 + ga11;
+    let sxb1 = gb01 + gb11;
+    let dca = ga00 + ga01;
+    let dcb = gb00 + gb01;
+    let dsa = sxa0 + sxa1;
+    let dsb = sxb0 + sxb1;
+    [
+        ga10 * gb10,               // s10
+        sxa0 * sxb0,               // sinf0
+        ga01 * gb01,               // col1 c0
+        ga11 * gb11,               // col1 @ X=1
+        sxa1 * sxb1,               // col1 c2
+        dca * dcb,                 // col∞ c0
+        (dca + dsa) * (dcb + dsb), // col∞ @ X=1
+        dsa * dsb,                 // col∞ c2
+    ]
+}
+
+/// Per-position Q contribution, eq-weighted into the 8 unreduced accumulators.
+#[inline(always)]
+fn lookahead_accum(ga: &[F128; 4], gb: &[F128; 4], eq: F128, acc: &mut [F256Unreduced; 8]) {
+    let p = lookahead_products(ga, gb);
+    for k in 0..8 {
+        acc[k] ^= eq.mul_unreduced(p[k]);
+    }
+}
+
+pub(crate) fn lookahead_finish(s: [F128; 8]) -> LookaheadSums {
+    let [s10, sinf0, c0, t11, c2, d0, dt, d2] = s;
+    LookaheadSums {
+        s10,
+        sinf0,
+        s1: [c0, t11 + c0 + c2, c2],
+        sinf: [d0, dt + d0 + d2, d2],
+    }
+}
+
+macro_rules! lookahead_pass {
+    ($name:ident, $per_u:expr, $fold:expr, $doc:literal) => {
+        #[doc = $doc]
+        /// Writes the folded arrays into `a_out`/`b_out` and returns the 8
+        /// lookahead sums over the next two variables. `r_y` is the eq coord of
+        /// the SECOND lookahead variable; `rest` the coords after it
+        /// (`rest.len() == log2(out_len/4)`). Parallel over the eq-hi chunks.
+        pub fn $name(
+            a: &[F128],
+            b: &[F128],
+            a_out: &mut [F128],
+            b_out: &mut [F128],
+            rhos: (F128, F128),
+            rest: &[F128],
+        ) -> LookaheadSums {
+            use rayon::prelude::*;
+            const PER_U: usize = $per_u;
+            let n_u = a.len() / PER_U;
+            assert_eq!(a.len(), b.len());
+            assert_eq!(a.len() % PER_U, 0);
+            assert_eq!(a_out.len(), 4 * n_u);
+            assert_eq!(b_out.len(), 4 * n_u);
+            assert_eq!(
+                1usize << rest.len(),
+                n_u,
+                "rest coords must cover log2(len/{PER_U})"
+            );
+            let n_lo = rest.len() / 2;
+            let eq_lo = build_eq(&rest[..n_lo]);
+            let eq_hi = build_eq(&rest[n_lo..]);
+            let lo_size = eq_lo.len();
+            let fold = $fold;
+            let sums = a_out
+                .par_chunks_mut(4 * lo_size)
+                .zip(b_out.par_chunks_mut(4 * lo_size))
+                .enumerate()
+                .map(|(u_hi, (ao, bo))| {
+                    let mut acc = [F256Unreduced::ZERO; 8];
+                    let base_u = u_hi * lo_size;
+                    for u_lo in 0..lo_size {
+                        let u = base_u + u_lo;
+                        let mut ga = [F128::ZERO; 4];
+                        let mut gb = [F128::ZERO; 4];
+                        for v in 0..4usize {
+                            let base = u * PER_U + v * (PER_U / 4);
+                            ga[v] = fold(&a[base..], rhos);
+                            gb[v] = fold(&b[base..], rhos);
+                            ao[4 * u_lo + v] = ga[v];
+                            bo[4 * u_lo + v] = gb[v];
+                        }
+                        lookahead_accum(&ga, &gb, eq_lo[u_lo], &mut acc);
+                    }
+                    let eh = eq_hi[u_hi];
+                    let mut out = [F128::ZERO; 8];
+                    for k in 0..8 {
+                        out[k] = eh * acc[k].reduce();
+                    }
+                    out
+                })
+                .reduce(
+                    || [F128::ZERO; 8],
+                    |mut p, q| {
+                        for k in 0..8 {
+                            p[k] += q[k];
+                        }
+                        p
+                    },
+                );
+            lookahead_finish(sums)
+        }
+    };
+}
+
+lookahead_pass!(
+    fold1_lookahead_into,
+    8,
+    |e: &[F128], r: (F128, F128)| e[0] + r.0 * (e[0] + e[1]),
+    "Entry lookahead pass: fold ONE pending variable (`rhos.0`; `rhos.1` unused), n → n/2."
+);
+lookahead_pass!(
+    fold2_lookahead_into,
+    16,
+    |e: &[F128], r: (F128, F128)| {
+        let x0 = e[0] + r.0 * (e[0] + e[1]);
+        let x1 = e[2] + r.0 * (e[2] + e[3]);
+        x0 + r.1 * (x0 + x1)
+    },
+    "Steady-state lookahead pass: fold TWO pending variables (4→1), n → n/4."
+);
+
 /// `&[bool]` convenience wrapper around
 /// [`uni_skip_fold_and_round_pair_optimized_packed`]. Packs internally, builds
 /// the fold table from `z`.

--- a/crates/flock-prover/Cargo.toml
+++ b/crates/flock-prover/Cargo.toml
@@ -30,6 +30,26 @@ keccak = { workspace = true }
 sha3 = { workspace = true }
 
 [[bench]]
+name = "blake3_rs_vs_ag"
+harness = false
+
+[[bench]]
+name = "ag_breakdown"
+harness = false
+
+[[bench]]
+name = "ag_round1_ab"
+harness = false
+
+[[bench]]
+name = "ag_e2e_zerocheck"
+harness = false
+
+[[bench]]
+name = "ag_lookahead_ab"
+harness = false
+
+[[bench]]
 name = "genus95_curve_code"
 harness = false
 

--- a/crates/flock-prover/benches/ag_breakdown.rs
+++ b/crates/flock-prover/benches/ag_breakdown.rs
@@ -1,0 +1,137 @@
+//! Phase breakdown of the PRODUCTION AG zerocheck prove: times the production
+//! kernels individually (round-1 banks-fused, skip→mlv fold) plus the full
+//! `prove_capture_s_hat_v_c`, attributing the remainder to the mlv tail (+ r1
+//! sample/functional/c-eval overhead). Lookahead on/off shows the tail split.
+//!
+//!   cargo +1.95.0 bench --bench ag_breakdown -- [m] [reps]   (default 30, 5)
+
+// The AG round-1 kernel (and the ag_skip prover entry points this bench
+// drives) are aarch64-only; on other arches the bench is a no-op stub.
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {
+    eprintln!("ag_breakdown: aarch64-only bench (NEON AG round-1 kernel)");
+}
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    aarch64_only::run()
+}
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64_only {
+    use std::hint::black_box;
+    use std::sync::atomic::Ordering;
+    use std::time::Instant;
+
+    use flock_prover::challenger::FsChallenger;
+    use flock_prover::field::F128;
+    use flock_prover::genus95_curve_code::round1::round1_slp_packed_banks_fused;
+    use flock_prover::zerocheck::ag_skip::{
+        LOOKAHEAD_DISABLE, N_INNER, fold_and_first_round, friendly_challenges,
+        prove_capture_s_hat_v_c,
+    };
+
+    struct Rng(u64);
+    impl Rng {
+        fn n(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+            z ^ (z >> 31)
+        }
+        fn f(&mut self) -> F128 {
+            F128 {
+                lo: self.n(),
+                hi: self.n(),
+            }
+        }
+    }
+
+    pub(super) fn run() {
+        let m: usize = std::env::args()
+            .nth(1)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(30);
+        let reps: usize = std::env::args()
+            .nth(2)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(5);
+        let bytes = (1usize << m) / 8;
+        let mut rng = Rng(0xB0EA_D000 ^ m as u64);
+        let mut a = vec![0u8; bytes];
+        let mut b = vec![0u8; bytes];
+        for x in a.iter_mut() {
+            *x = rng.n() as u8;
+        }
+        for x in b.iter_mut() {
+            *x = rng.n() as u8;
+        }
+        let c: Vec<u8> = a.iter().zip(&b).map(|(&x, &y)| x & y).collect();
+        let n_blocks = bytes / 1024;
+        let eq: Vec<F128> = (0..n_blocks).map(|_| rng.f()).collect();
+        let w: Vec<F128> = (0..64).map(|_| rng.f()).collect();
+        let mut r_rest = friendly_challenges().to_vec();
+        for _ in 0..(m - 6 - N_INNER) {
+            r_rest.push(rng.f());
+        }
+
+        eprintln!(
+            "m={m} ({} MB/witness), {} reps, {} threads",
+            bytes >> 20,
+            reps,
+            rayon::current_num_threads()
+        );
+        let med = |mut v: Vec<f64>| -> f64 {
+            v.sort_by(|x, y| x.partial_cmp(y).unwrap());
+            v[v.len() / 2]
+        };
+        let time = |f: &mut dyn FnMut()| -> f64 {
+            f(); // warm
+            let mut v = Vec::new();
+            for _ in 0..reps {
+                let t0 = Instant::now();
+                f();
+                v.push(t0.elapsed().as_secs_f64() * 1e3);
+            }
+            med(v)
+        };
+
+        let t_r1 = time(&mut || {
+            black_box(round1_slp_packed_banks_fused(&a, &b, &c, &eq));
+        });
+        let t_fold = time(&mut || {
+            black_box(fold_and_first_round(&a, &b, &w, &r_rest));
+        });
+        LOOKAHEAD_DISABLE.store(false, Ordering::Relaxed);
+        let t_total_la = time(&mut || {
+            let mut ch = FsChallenger::new(b"ag-breakdown");
+            black_box(prove_capture_s_hat_v_c(&a, &b, &c, m, &mut ch));
+        });
+        LOOKAHEAD_DISABLE.store(true, Ordering::Relaxed);
+        let t_total_cl = time(&mut || {
+            let mut ch = FsChallenger::new(b"ag-breakdown");
+            black_box(prove_capture_s_hat_v_c(&a, &b, &c, m, &mut ch));
+        });
+        LOOKAHEAD_DISABLE.store(false, Ordering::Relaxed);
+
+        let tail_la = t_total_la - t_r1 - t_fold;
+        let tail_cl = t_total_cl - t_r1 - t_fold;
+        eprintln!("\nproduction AG zerocheck breakdown (medians):");
+        eprintln!(
+            "  round-1 URM (banks fused)      {t_r1:7.2} ms  ({:4.1}%)",
+            t_r1 / t_total_la * 100.0
+        );
+        eprintln!(
+            "  skip->mlv fold (byte-dot u64)  {t_fold:7.2} ms  ({:4.1}%)",
+            t_fold / t_total_la * 100.0
+        );
+        eprintln!(
+            "  mlv tail + misc, LOOKAHEAD     {tail_la:7.2} ms  ({:4.1}%)",
+            tail_la / t_total_la * 100.0
+        );
+        eprintln!("  ---------------------------------------------");
+        eprintln!("  TOTAL prove (lookahead)        {t_total_la:7.2} ms");
+        eprintln!("  [tail+misc classic: {tail_cl:.2} ms; total classic: {t_total_cl:.2} ms]");
+    }
+}

--- a/crates/flock-prover/benches/ag_e2e_zerocheck.rs
+++ b/crates/flock-prover/benches/ag_e2e_zerocheck.rs
@@ -1,0 +1,468 @@
+//! Step-wise e2e comparison of the AG-skip zerocheck vs the RS univariate-skip
+//! zerocheck, at m up to 32. Both reduce `a·b = c` over `{0,1}^m` to evaluation
+//! claims; this times the prover phases of each from the same thermal state.
+//!
+//! Phases (comparable rows):
+//!   - Round-1 URM:   AG `round1_slp_packed` (Paar SLP)        vs  RS additive-NTT URM.
+//!   - skip→mlv fold: AG `fold_and_first_round` (fused, γ-Horner) vs RS fused fold+round2.
+//!   - r1 sample:     AG-only (rejection sample of a curve point).
+//!   - mlv tail:      AG fused `fold_and_compute_round_pair_into` vs RS fused tail
+//!     (shared `multilinear.rs` — same path both sides).
+//!
+//! The tail is timed under three fold schedules (see [`Sched`]): Classic, the
+//! production Lookahead, and the prototype Uniform 4->1. Cross-schedule parity is
+//! asserted, so all three provably compute the same thing.
+//!
+//!   AG_E2E_MS=30,32 cargo bench --bench ag_e2e_zerocheck
+
+// The AG round-1 kernel (and the ag_skip prover entry points this bench
+// drives) are aarch64-only; on other arches the bench is a no-op stub.
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {
+    eprintln!("ag_e2e_zerocheck: aarch64-only bench (NEON AG round-1 kernel)");
+}
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    aarch64_only::run()
+}
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64_only {
+    use std::hint::black_box;
+    use std::time::Instant;
+
+    use flock_prover::challenger::{Challenger, FsChallenger};
+    use flock_prover::field::{F8, F128};
+    use flock_prover::genus95_curve_code::round1::round1_slp_packed;
+    use flock_prover::genus95_curve_code::{
+        Sha256Rng, base_evaluation_functional, sample_random_evaluation_point,
+    };
+    use flock_prover::ntt::{AdditiveNttGf8, InvNttTableByteSingleGf8};
+    use flock_prover::zerocheck::ag_skip::{d_inv, fold_and_first_round, friendly_challenges};
+    use flock_prover::zerocheck::multilinear::{
+        UniSkipFoldTable, fold_and_compute_round_pair_into, fold_in_place_pair,
+        fold1_lookahead_into, fold2_lookahead_into, lookahead_msg_first, lookahead_msg_second,
+        round_pair_naive, uni_skip_fold_and_round_pair_optimized_packed,
+    };
+    use flock_prover::zerocheck::univariate_skip::build_eq;
+    use flock_prover::zerocheck::univariate_skip_optimized::{
+        c_s_f128, medium_challenges_ghash, round1_shift_reduce_extract_c_packed,
+        small_challenges_ghash,
+    };
+
+    const K_SKIP: usize = 6;
+    const N_INNER: usize = 7;
+
+    struct Rng(u64);
+    impl Rng {
+        fn new(seed: u64) -> Self {
+            Self(seed)
+        }
+        fn next_u64(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+            z ^ (z >> 31)
+        }
+        fn fill_bytes(&mut self, buf: &mut [u8]) {
+            let mut i = 0;
+            while i + 8 <= buf.len() {
+                buf[i..i + 8].copy_from_slice(&self.next_u64().to_le_bytes());
+                i += 8;
+            }
+        }
+    }
+
+    fn time_ms<R>(f: impl FnOnce() -> R) -> (f64, R) {
+        let t0 = Instant::now();
+        let r = f();
+        (t0.elapsed().as_secs_f64() * 1000.0, r)
+    }
+
+    /// `AG_E2E_TAILS=classic` times only the Classic tail — the shipping schedule.
+    /// Keeps a paper-facing run lean (no extra fold regenerations, less thermal load)
+    /// at the cost of the cross-schedule parity checks. Default times all three.
+    fn tails_all() -> bool {
+        !matches!(std::env::var("AG_E2E_TAILS").as_deref(), Ok("classic"))
+    }
+
+    /// Cross-schedule parity. All three bind `rho_at(0), rho_at(1), …` in the same
+    /// order, so the final value must agree; Uniform's message stream is Classic's
+    /// minus the first entry, rounds 0/1 having moved into the skip->mlv fold.
+    fn check_tails(
+        tag: &str,
+        msgs_c: &[(F128, F128)],
+        fin_c: (F128, F128),
+        msgs_la: &[(F128, F128)],
+        fin_la: (F128, F128),
+        msgs_un: &[(F128, F128)],
+        fin_un: (F128, F128),
+    ) {
+        assert_eq!(
+            msgs_c, msgs_la,
+            "{tag}: lookahead tail messages differ from classic"
+        );
+        assert_eq!(
+            fin_c, fin_la,
+            "{tag}: lookahead final binding differs from classic"
+        );
+        assert_eq!(
+            msgs_un,
+            &msgs_c[1..],
+            "{tag}: uniform tail messages differ from classic rounds 2.."
+        );
+        assert_eq!(
+            fin_un, fin_c,
+            "{tag}: uniform final binding differs from classic"
+        );
+    }
+
+    /// Which fold schedule the tail runs.
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    enum Sched {
+        /// One pass per round: read 2s, write s. Sizes n, n/2, n/4, …
+        Classic,
+        /// Production lookahead. Entry `fold1` (read 2n, write n — no traffic saving,
+        /// it only emits two messages) then steady `fold2`. Sizes n, n/2, n/8, n/32, …
+        Lookahead,
+        /// Every pass 4->1 (read 2s, write s/2). Requires TWO challenges already
+        /// pending at tail entry, i.e. the skip->mlv fold must emit the bivariate Q
+        /// for rounds 0 and 1 instead of the univariate for round 0. Modelled here by
+        /// starting the same loop with `pending2` set. Sizes n, n/4, n/16, …
+        Uniform,
+    }
+
+    /// Shared multilinear tail, mirroring the production AG loop in
+    /// `zerocheck::ag_skip::prove_capture_s_hat_v_c`. Both the RS and AG sides reach
+    /// this with `a_mlv.len() == 2^r_rest.len()` and the same challenge indexing
+    /// (`r_rest[i+1..]` for round `i`), so it is literally the same code on both.
+    ///
+    /// `lookahead_on` selects the one-pass-per-TWO-rounds path (`fold1/fold2_lookahead_into`,
+    /// second message derived from the bivariate Q); `false` reproduces the classic
+    /// one-pass-per-round loop. Challenges are synthetic (no transcript here), which
+    /// does not change the work done — only the values.
+    /// Returns `(elapsed_ms, round messages, final bound (a,b))`. Classic and lookahead
+    /// bind the identical challenge sequence (`rho_at(0), rho_at(1), …`), so both must
+    /// return identical messages and final values — asserted by the callers.
+    fn mlv_tail(
+        mut a_mlv: Vec<F128>,
+        mut b_mlv: Vec<F128>,
+        r_rest: &[F128],
+        sched: Sched,
+    ) -> (f64, Vec<(F128, F128)>, (F128, F128)) {
+        let n_mlv = r_rest.len();
+        let n_in = a_mlv.len();
+        // Scratch allocated (and zero-filled) OUTSIDE the timed region, as before.
+        let (mut a_nxt, mut b_nxt) = if n_in >= 1024 {
+            (vec![F128::ZERO; n_in / 2], vec![F128::ZERO; n_in / 2])
+        } else {
+            (Vec::new(), Vec::new())
+        };
+        let rho_at = |i: usize| F128 {
+            lo: 0xC0DE + i as u64,
+            hi: 0xFACE,
+        };
+        let mut rounds: Vec<(F128, F128)> = Vec::with_capacity(n_mlv);
+        let (t_tail, _) = time_ms(|| {
+            let mut rho_prev = rho_at(0);
+            // `pending2`: a sampled challenge whose fold is deferred to the next
+            // lookahead pass (which folds it with `rho_prev`, 4 -> 1). Uniform starts
+            // with one already pending — rounds 0/1 having been emitted upstream —
+            // so its very first pass is a 4->1 fold at full size.
+            let (mut pending2, mut i) = match sched {
+                Sched::Uniform => (Some(rho_at(1)), 2usize),
+                _ => (None, 1usize),
+            };
+            while i < n_mlv {
+                let len = a_mlv.len();
+                // Same gate as production: needs a round after this one, and a big
+                // enough array for the fused path.
+                if sched != Sched::Classic && i + 1 < n_mlv && len >= 1024 {
+                    let out_len = if pending2.is_some() { len / 4 } else { len / 2 };
+                    let (ao, bo) = (&mut a_nxt[..out_len], &mut b_nxt[..out_len]);
+                    let q = if let Some(r2) = pending2 {
+                        fold2_lookahead_into(
+                            &a_mlv,
+                            &b_mlv,
+                            ao,
+                            bo,
+                            (rho_prev, r2),
+                            &r_rest[i + 2..],
+                        )
+                    } else {
+                        fold1_lookahead_into(
+                            &a_mlv,
+                            &b_mlv,
+                            ao,
+                            bo,
+                            (rho_prev, F128::ZERO),
+                            &r_rest[i + 2..],
+                        )
+                    };
+                    std::mem::swap(&mut a_mlv, &mut a_nxt);
+                    std::mem::swap(&mut b_mlv, &mut b_nxt);
+                    a_mlv.truncate(out_len);
+                    b_mlv.truncate(out_len);
+                    let rho_a = rho_at(i);
+                    rounds.push(lookahead_msg_first(&q, r_rest[i + 1]));
+                    rounds.push(lookahead_msg_second(&q, rho_a));
+                    rho_prev = rho_a;
+                    pending2 = Some(rho_at(i + 1));
+                    i += 2;
+                    continue;
+                }
+                // Leaving lookahead mode: resolve the deferred fold first.
+                if let Some(r2) = pending2.take() {
+                    fold_in_place_pair(&mut a_mlv, &mut b_mlv, rho_prev);
+                    rho_prev = r2;
+                    continue;
+                }
+                let log_before = a_mlv.len().trailing_zeros() as usize;
+                let mut r_next = vec![F128::ONE; log_before - 1];
+                r_next[1..].copy_from_slice(&r_rest[i + 1..]);
+                let pair = if log_before >= 10 {
+                    let half = a_mlv.len() / 2;
+                    let pair = fold_and_compute_round_pair_into(
+                        &a_mlv,
+                        &b_mlv,
+                        &mut a_nxt[..half],
+                        &mut b_nxt[..half],
+                        rho_prev,
+                        &r_next,
+                    );
+                    std::mem::swap(&mut a_mlv, &mut a_nxt);
+                    std::mem::swap(&mut b_mlv, &mut b_nxt);
+                    a_mlv.truncate(half);
+                    b_mlv.truncate(half);
+                    pair
+                } else {
+                    fold_in_place_pair(&mut a_mlv, &mut b_mlv, rho_prev);
+                    round_pair_naive(&a_mlv, &b_mlv, &r_next)
+                };
+                rounds.push(pair);
+                rho_prev = rho_at(i);
+                i += 1;
+            }
+            // Final binding: one or (after a trailing lookahead pass) two deferred
+            // challenges remain.
+            fold_in_place_pair(&mut a_mlv, &mut b_mlv, rho_prev);
+            if let Some(r2) = pending2 {
+                fold_in_place_pair(&mut a_mlv, &mut b_mlv, r2);
+            }
+            black_box(&a_mlv);
+        });
+        assert_eq!(a_mlv.len(), 1, "tail must bind every variable");
+        (t_tail, rounds, (a_mlv[0], b_mlv[0]))
+    }
+
+    /// RS univariate-skip prover phases (non-padded path), mirroring `prove_packed`.
+    fn rs_phases(a: &[u8], b: &[u8], c: &[u8], m: usize) -> (f64, f64, f64, f64, f64) {
+        let mut ch = FsChallenger::new(b"flock-bench-v0");
+        let n_mlv = m - K_SKIP;
+        ch.observe_label(b"flock-zerocheck-v0");
+        let r_skip = ch.sample_f128_vec(K_SKIP);
+        let r_outer = ch.sample_f128_vec(m - K_SKIP - N_INNER);
+        let mut r = vec![F128::ZERO; m];
+        r[..K_SKIP].copy_from_slice(&r_skip);
+        for (i, v) in small_challenges_ghash().iter().enumerate() {
+            r[K_SKIP + i] = *v;
+        }
+        for (i, v) in medium_challenges_ghash().iter().enumerate() {
+            r[K_SKIP + 3 + i] = *v;
+        }
+        r[K_SKIP + N_INNER..].copy_from_slice(&r_outer);
+
+        let ntt_s = AdditiveNttGf8::new(K_SKIP, F8::ZERO);
+        let ntt_l = AdditiveNttGf8::new(K_SKIP, F8(1u8 << K_SKIP));
+        let inv = InvNttTableByteSingleGf8::new(&ntt_s, &ntt_l);
+
+        let (t_round1, (r1ab, r1c)) = time_ms(|| {
+            round1_shift_reduce_extract_c_packed(
+                black_box(a),
+                black_box(b),
+                black_box(c),
+                m,
+                K_SKIP,
+                &r,
+                &inv,
+            )
+        });
+        let cs = c_s_f128();
+        let r1ab: Vec<F128> = r1ab.iter().map(|x| cs * *x).collect();
+        let r1c: Vec<F128> = r1c.iter().map(|x| cs * *x).collect();
+        ch.observe_f128_slice(&r1ab);
+        ch.observe_f128_slice(&r1c);
+        let z = ch.sample_f128();
+
+        let fold_table = UniSkipFoldTable::new(K_SKIP, z);
+        let mut mlv_arg = vec![F128::ONE; n_mlv];
+        mlv_arg[1..].copy_from_slice(&r[K_SKIP + 1..]);
+        let (t_fold, (a_mlv, b_mlv, _m1, _mi)) = time_ms(|| {
+            uni_skip_fold_and_round_pair_optimized_packed(
+                black_box(a),
+                black_box(b),
+                m,
+                K_SKIP,
+                &fold_table,
+                &mlv_arg,
+            )
+        });
+
+        // Tail twice: classic, then lookahead. The second fold is untimed — it only
+        // regenerates the inputs the first tail consumed (cheaper than a 2 GB clone).
+        debug_assert_eq!(a_mlv.len(), 1usize << n_mlv);
+        let r_rest = &r[K_SKIP..];
+        let refold = || {
+            uni_skip_fold_and_round_pair_optimized_packed(a, b, m, K_SKIP, &fold_table, &mlv_arg)
+        };
+        let (t_tail_classic, msgs_c, fin_c) = mlv_tail(a_mlv, b_mlv, r_rest, Sched::Classic);
+        if !tails_all() {
+            return (t_round1, t_fold, t_tail_classic, 0.0, 0.0);
+        }
+        let (a2, b2, _, _) = refold();
+        let (t_tail_la, msgs_la, fin_la) = mlv_tail(a2, b2, r_rest, Sched::Lookahead);
+        let (a3, b3, _, _) = refold();
+        let (t_tail_un, msgs_un, fin_un) = mlv_tail(a3, b3, r_rest, Sched::Uniform);
+        check_tails("RS", &msgs_c, fin_c, &msgs_la, fin_la, &msgs_un, fin_un);
+        (t_round1, t_fold, t_tail_classic, t_tail_la, t_tail_un)
+    }
+
+    /// AG-skip prover phases.
+    fn ag_phases(a: &[u8], b: &[u8], c: &[u8], m: usize) -> (f64, f64, f64, f64, f64, f64) {
+        let mut ch = FsChallenger::new(b"flock-bench-ag-v0");
+        ch.observe_label(b"flock-ag-skip-v0");
+        let r_outer = ch.sample_f128_vec(m - K_SKIP - N_INNER);
+        let eq = build_eq(&r_outer);
+
+        let (t_round1, (res_ab, wbar)) =
+            time_ms(|| round1_slp_packed(black_box(a), black_box(b), black_box(c), &eq));
+        let di = d_inv();
+        let ab_fresh: Vec<F128> = (0..158).map(|s| di * res_ab[s]).collect();
+        let c_msg: Vec<F128> = (0..64).map(|i| di * wbar[i]).collect();
+        ch.observe_f128_slice(&ab_fresh);
+        ch.observe_f128_slice(&c_msg);
+
+        let (t_r1, r1) = time_ms(|| {
+            ch.observe_label(b"flock-ag-skip-r1-point");
+            let s0 = ch.sample_f128();
+            let s1 = ch.sample_f128();
+            let mut seed = [0u8; 32];
+            seed[0..8].copy_from_slice(&s0.lo.to_le_bytes());
+            seed[8..16].copy_from_slice(&s0.hi.to_le_bytes());
+            seed[16..24].copy_from_slice(&s1.lo.to_le_bytes());
+            seed[24..32].copy_from_slice(&s1.hi.to_le_bytes());
+            sample_random_evaluation_point(&mut Sha256Rng::new(seed)).expect("point")
+        });
+
+        let mut r_rest = friendly_challenges().to_vec();
+        r_rest.extend_from_slice(&r_outer);
+        let bf = base_evaluation_functional(&r1).expect("bf");
+        let w: Vec<F128> = bf.iter().copied().collect();
+        // Fold + first multilinear message, fused (like RS's uni_skip_fold).
+        let (t_fold, (a_mlv, b_mlv)) = time_ms(|| {
+            let (am, bm, g1, ginf) = fold_and_first_round(black_box(a), black_box(b), &w, &r_rest);
+            black_box((g1, ginf));
+            (am, bm)
+        });
+
+        // Tail: rounds 1..n_mlv, classic then lookahead (same shared loop as RS).
+        debug_assert_eq!(a_mlv.len(), 1usize << r_rest.len());
+        let (t_tail_classic, msgs_c, fin_c) = mlv_tail(a_mlv, b_mlv, &r_rest, Sched::Classic);
+        if !tails_all() {
+            return (t_round1, t_r1, t_fold, t_tail_classic, 0.0, 0.0);
+        }
+        let (a2, b2, _, _) = fold_and_first_round(a, b, &w, &r_rest);
+        let (t_tail_la, msgs_la, fin_la) = mlv_tail(a2, b2, &r_rest, Sched::Lookahead);
+        let (a3, b3, _, _) = fold_and_first_round(a, b, &w, &r_rest);
+        let (t_tail_un, msgs_un, fin_un) = mlv_tail(a3, b3, &r_rest, Sched::Uniform);
+        check_tails("AG", &msgs_c, fin_c, &msgs_la, fin_la, &msgs_un, fin_un);
+        (t_round1, t_r1, t_fold, t_tail_classic, t_tail_la, t_tail_un)
+    }
+
+    pub(super) fn run() {
+        let _ = flock_prover::init_perf_thread_pool();
+        // `AG_E2E_MS=31,32` overrides the default sweep (comma/space-separated).
+        let ms: Vec<usize> = match std::env::var("AG_E2E_MS") {
+            Ok(s) => s
+                .split(|c: char| c.is_whitespace() || c == ',')
+                .filter(|t| !t.is_empty())
+                .map(|t| t.parse().expect("AG_E2E_MS: integer m"))
+                .collect(),
+            Err(_) => vec![24, 28, 30],
+        };
+        for &m in &ms {
+            let n_bytes = (1usize << m) / 8;
+            println!(
+                "\n=== m = {m}  ({} MB / witness, {} MB total) ===",
+                n_bytes >> 20,
+                (3 * n_bytes) >> 20
+            );
+            let mut rng = Rng::new(0xABCD_0000 + m as u64);
+            let mut a = vec![0u8; n_bytes];
+            rng.fill_bytes(&mut a);
+            let mut b = vec![0u8; n_bytes];
+            rng.fill_bytes(&mut b);
+            let c: Vec<u8> = a.iter().zip(&b).map(|(x, y)| x & y).collect();
+
+            // warm caches (LUT/SLP/eval OnceLocks, NTT tables).
+            let _ = rs_phases(&a, &b, &c, m);
+            let _ = ag_phases(&a, &b, &c, m);
+
+            let (rs_r1, rs_fold, rs_tail, rs_tail_la, rs_tail_un) = rs_phases(&a, &b, &c, m);
+            let (ag_r1, ag_sample, ag_fold, ag_tail, ag_tail_la, ag_tail_un) =
+                ag_phases(&a, &b, &c, m);
+            let rs_head = rs_r1 + rs_fold;
+            let ag_head = ag_r1 + ag_sample + ag_fold;
+
+            println!(
+                "  {:<26} {:>10} {:>10} {:>9}",
+                "phase", "RS (ms)", "AG (ms)", "RS/AG"
+            );
+            let row = |name: &str, rs: f64, ag: f64| {
+                let spd = if ag > 0.0 {
+                    format!("{:.2}x", rs / ag)
+                } else {
+                    "—".into()
+                };
+                println!("  {:<26} {:>10.1} {:>10.1} {:>9}", name, rs, ag, spd);
+            };
+            row("round-1 URM", rs_r1, ag_r1);
+            row("skip->mlv fold", rs_fold, ag_fold);
+            println!(
+                "  {:<26} {:>10} {:>10.1} {:>9}",
+                "r1 sample (AG only)", "-", ag_sample, ""
+            );
+            row("mlv tail", rs_tail, ag_tail);
+            row("TOTAL (prove phases)", rs_head + rs_tail, ag_head + ag_tail);
+            if tails_all() {
+                row("mlv tail (lookahead)", rs_tail_la, ag_tail_la);
+                row("mlv tail (uniform 4->1)", rs_tail_un, ag_tail_un);
+                row(
+                    "TOTAL (lookahead tail)",
+                    rs_head + rs_tail_la,
+                    ag_head + ag_tail_la,
+                );
+                row(
+                    "TOTAL (uniform tail)",
+                    rs_head + rs_tail_un,
+                    ag_head + ag_tail_un,
+                );
+                println!(
+                    "  tail vs classic: lookahead RS {:.2}x AG {:.2}x | uniform RS {:.2}x AG {:.2}x",
+                    rs_tail / rs_tail_la,
+                    ag_tail / ag_tail_la,
+                    rs_tail / rs_tail_un,
+                    ag_tail / ag_tail_un
+                );
+                println!(
+                    "  (uniform excludes the Q the skip->mlv fold would have to emit — traffic-free there, but not free)"
+                );
+            }
+            println!(
+                "  note: AG fold = unchecked byte-dot skip-collapse + γ² wide-shift first message (deferred reduction); round-1 SLP carries the overall win."
+            );
+        }
+    }
+}

--- a/crates/flock-prover/benches/ag_lookahead_ab.rs
+++ b/crates/flock-prover/benches/ag_lookahead_ab.rs
@@ -1,0 +1,163 @@
+//! Same-process paired A/B of sumcheck LOOKAHEAD inside the full production AG
+//! zerocheck prove (`prove_capture_s_hat_v_c`), via [`LOOKAHEAD_DISABLE`].
+//! Alternating classic/lookahead in one process cancels thermal drift; the
+//! paired per-round delta is the statistic. Proofs asserted bit-identical.
+//!
+//!   cargo +1.95.0 bench --bench ag_lookahead_ab [m] [rounds]      # MT (default)
+//!   RAYON_NUM_THREADS=1 cargo bench --bench ag_lookahead_ab       # ST
+
+// The AG round-1 kernel (and the ag_skip prover entry points this bench
+// drives) are aarch64-only; on other arches the bench is a no-op stub.
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {
+    eprintln!("ag_lookahead_ab: aarch64-only bench (NEON AG round-1 kernel)");
+}
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    aarch64_only::run()
+}
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64_only {
+    use std::hint::black_box;
+    use std::sync::atomic::Ordering;
+    use std::time::Instant;
+
+    use flock_prover::challenger::FsChallenger;
+    use flock_prover::zerocheck::ag_skip::{
+        LOOKAHEAD_DISABLE, LOOKAHEAD_FRIENDLY, prove_capture_s_hat_v_c,
+    };
+
+    struct Rng(u64);
+    impl Rng {
+        fn n(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+            z ^ (z >> 31)
+        }
+    }
+
+    pub(super) fn run() {
+        let m: usize = std::env::args()
+            .nth(1)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(28);
+        let rounds: usize = std::env::args()
+            .nth(2)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(8);
+        let bytes = (1usize << m) / 8;
+
+        let mut rng = Rng(0x1A0C_AB00);
+        let mut a = vec![0u8; bytes];
+        let mut b = vec![0u8; bytes];
+        for x in a.iter_mut() {
+            *x = rng.n() as u8;
+        }
+        for x in b.iter_mut() {
+            *x = rng.n() as u8;
+        }
+        let c: Vec<u8> = a.iter().zip(&b).map(|(&x, &y)| x & y).collect();
+
+        eprintln!(
+            "m={m} ({} MB/witness), {} paired rounds, {} threads",
+            bytes >> 20,
+            rounds,
+            rayon::current_num_threads()
+        );
+
+        let run = |classic: bool| -> (f64, Vec<u8>) {
+            LOOKAHEAD_DISABLE.store(classic, Ordering::Relaxed);
+            let mut ch = FsChallenger::new(b"ag-lookahead-ab");
+            let t0 = Instant::now();
+            let out = prove_capture_s_hat_v_c(&a, &b, &c, m, &mut ch);
+            let el = t0.elapsed().as_secs_f64();
+            let ser = bincode::serialize(&out.0).unwrap();
+            black_box(&out);
+            (el * 1e3, ser)
+        };
+
+        // Warm both paths and assert bit-identical proofs.
+        let (_, p_classic) = run(true);
+        let (_, p_look) = run(false);
+        assert!(p_classic == p_look, "lookahead proof != classic proof");
+        eprintln!("proofs bit-identical: OK");
+
+        let med = |mut v: Vec<f64>| -> f64 {
+            v.sort_by(|x, y| x.partial_cmp(y).unwrap());
+            v[v.len() / 2]
+        };
+        let mut deltas = Vec::new();
+        let (mut tc, mut tl) = (Vec::new(), Vec::new());
+        for r in 0..rounds {
+            let (c_ms, l_ms) = if r % 2 == 0 {
+                let (c_ms, _) = run(true);
+                let (l_ms, _) = run(false);
+                (c_ms, l_ms)
+            } else {
+                let (l_ms, _) = run(false);
+                let (c_ms, _) = run(true);
+                (c_ms, l_ms)
+            };
+            eprintln!(
+                "  classic {c_ms:7.2} ms   lookahead {l_ms:7.2} ms   paired Δ {:+.2} ms",
+                c_ms - l_ms
+            );
+            deltas.push(c_ms - l_ms);
+            tc.push(c_ms);
+            tl.push(l_ms);
+        }
+        LOOKAHEAD_DISABLE.store(false, Ordering::Relaxed);
+        let wins = deltas.iter().filter(|d| **d > 0.0).count();
+        eprintln!(
+            "\nmedian: classic {:.2} ms   lookahead {:.2} ms   paired-delta {:+.2} ms ({:+.1}% of zerocheck prove); lookahead faster {wins}/{rounds}",
+            med(tc.clone()),
+            med(tl),
+            med(deltas.clone()),
+            med(deltas) / med(tc) * 100.0
+        );
+
+        // ---- Second phase: friendly-lookahead vs general-lookahead (i=1,3) ----
+        let run_f = |general: bool| -> f64 {
+            LOOKAHEAD_FRIENDLY.store(!general, Ordering::Relaxed);
+            let mut ch = FsChallenger::new(b"ag-lookahead-ab");
+            let t0 = Instant::now();
+            let out = prove_capture_s_hat_v_c(&a, &b, &c, m, &mut ch);
+            let el = t0.elapsed().as_secs_f64();
+            black_box(out);
+            el * 1e3
+        };
+        let mut fdeltas = Vec::new();
+        let (mut tg, mut tf) = (Vec::new(), Vec::new());
+        for r in 0..rounds {
+            let (g_ms, f_ms) = if r % 2 == 0 {
+                let g = run_f(true);
+                let f = run_f(false);
+                (g, f)
+            } else {
+                let f = run_f(false);
+                let g = run_f(true);
+                (g, f)
+            };
+            eprintln!(
+                "  la-general {g_ms:7.2} ms   la-friendly {f_ms:7.2} ms   paired Δ {:+.2} ms",
+                g_ms - f_ms
+            );
+            fdeltas.push(g_ms - f_ms);
+            tg.push(g_ms);
+            tf.push(f_ms);
+        }
+        LOOKAHEAD_FRIENDLY.store(false, Ordering::Relaxed);
+        let fwins = fdeltas.iter().filter(|d| **d > 0.0).count();
+        eprintln!(
+            "\nmedian: la-general {:.2} ms   la-friendly {:.2} ms   paired-delta {:+.2} ms ({:+.1}%); friendly faster {fwins}/{rounds}",
+            med(tg.clone()),
+            med(tf),
+            med(fdeltas.clone()),
+            med(fdeltas) / med(tg) * 100.0
+        );
+    }
+}

--- a/crates/flock-prover/benches/ag_round1_ab.rs
+++ b/crates/flock-prover/benches/ag_round1_ab.rs
@@ -1,0 +1,125 @@
+//! Same-process paired A/B of the fused round-1 kernel inside the FULL
+//! production AG zerocheck prove (`prove_capture_s_hat_v_c`), via the
+//! [`ROUND1_UNFUSED`] toggle. Alternating unfused/fused in one process cancels
+//! thermal drift (the codebase's DISABLE_FRIENDLY_HORNER methodology); the
+//! paired per-round delta is the statistic, not cross-run absolute times.
+//!
+//!   cargo +1.95.0 bench --bench ag_round1_ab [m] [rounds]      # MT (default)
+//!   RAYON_NUM_THREADS=1 cargo bench --bench ag_round1_ab       # ST
+//!
+//! Default m=28 (32 MB/witness, 32768 round-1 blocks), 8 paired rounds.
+
+// The AG round-1 kernel (and the ag_skip prover entry points this bench
+// drives) are aarch64-only; on other arches the bench is a no-op stub.
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {
+    eprintln!("ag_round1_ab: aarch64-only bench (NEON AG round-1 kernel)");
+}
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    aarch64_only::run()
+}
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64_only {
+    use std::hint::black_box;
+    use std::sync::atomic::Ordering;
+    use std::time::Instant;
+
+    use flock_prover::challenger::FsChallenger;
+    use flock_prover::zerocheck::ag_skip::{ROUND1_UNFUSED, prove_capture_s_hat_v_c};
+
+    struct Rng(u64);
+    impl Rng {
+        fn n(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+            z ^ (z >> 31)
+        }
+    }
+
+    pub(super) fn run() {
+        let m: usize = std::env::args()
+            .nth(1)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(28);
+        let rounds: usize = std::env::args()
+            .nth(2)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(8);
+        let bytes = (1usize << m) / 8;
+
+        // Valid witnesses: c = a ∘ b is bitwise AND over GF(2) rows.
+        let mut rng = Rng(0xA0B0_C0D0);
+        let mut a = vec![0u8; bytes];
+        let mut b = vec![0u8; bytes];
+        for x in a.iter_mut() {
+            *x = rng.n() as u8;
+        }
+        for x in b.iter_mut() {
+            *x = rng.n() as u8;
+        }
+        let c: Vec<u8> = a.iter().zip(&b).map(|(&x, &y)| x & y).collect();
+
+        let nthreads = rayon::current_num_threads();
+        eprintln!(
+            "m={m} ({} MB/witness, {} round-1 blocks), {} paired rounds, {} threads",
+            bytes >> 20,
+            bytes / 1024,
+            rounds,
+            nthreads
+        );
+
+        let run = |unfused: bool| -> f64 {
+            ROUND1_UNFUSED.store(unfused, Ordering::Relaxed);
+            let mut ch = FsChallenger::new(b"ag-round1-ab");
+            let t0 = Instant::now();
+            let out = prove_capture_s_hat_v_c(&a, &b, &c, m, &mut ch);
+            let el = t0.elapsed().as_secs_f64();
+            black_box(out);
+            el * 1e3
+        };
+
+        // Warm both paths (scratch pool, page faults) before timing.
+        let _ = run(true);
+        let _ = run(false);
+
+        let mut deltas = Vec::new();
+        let (mut us, mut fs) = (Vec::new(), Vec::new());
+        for r in 0..rounds {
+            // Alternate order each round to cancel any first-mover advantage.
+            let (tu, tf) = if r % 2 == 0 {
+                let tu = run(true);
+                let tf = run(false);
+                (tu, tf)
+            } else {
+                let tf = run(false);
+                let tu = run(true);
+                (tu, tf)
+            };
+            eprintln!(
+                "  unfused {tu:7.2} ms   fused {tf:7.2} ms   paired Δ {:+.2} ms",
+                tu - tf
+            );
+            deltas.push(tu - tf);
+            us.push(tu);
+            fs.push(tf);
+        }
+        ROUND1_UNFUSED.store(false, Ordering::Relaxed);
+
+        let med = |mut v: Vec<f64>| -> f64 {
+            v.sort_by(|x, y| x.partial_cmp(y).unwrap());
+            v[v.len() / 2]
+        };
+        let (mu, mf, md) = (med(us), med(fs), med(deltas.clone()));
+        let wins = deltas.iter().filter(|d| **d > 0.0).count();
+        eprintln!("\nmedian: unfused {mu:.2} ms   fused {mf:.2} ms");
+        eprintln!(
+            "paired-delta median {md:+.2} ms ({:+.1}% of zerocheck prove); fused faster in {wins}/{rounds} rounds",
+            md / mu * 100.0
+        );
+    }
+}

--- a/crates/flock-prover/benches/blake3_rs_vs_ag.rs
+++ b/crates/flock-prover/benches/blake3_rs_vs_ag.rs
@@ -1,0 +1,454 @@
+//! BLAKE3 `prove_fast` (RS additive-NTT zerocheck) vs `prove_fast_ag` (genus-95
+//! AG-code zerocheck) head-to-head — both on the standard pack + Ligerito PCS.
+//! The ONLY difference is round 1 of the zerocheck; everything else (witness gen,
+//! commit, lincheck, ring-switch open) is shared, so this isolates the AG-skip
+//! zerocheck win at the full-proof level.
+//!
+//! Run twice for ST and MT:
+//!   cargo bench --bench blake3_rs_vs_ag                       # MT (default)
+//!   RAYON_NUM_THREADS=1 cargo bench --bench blake3_rs_vs_ag   # ST
+//!
+//! Defaults to m=30 (K=65536 compressions). Override with `BLAKE3_K=<n_blocks>`
+//! (comma/space-separated for multiple). aarch64-only (the AG round-1 kernel is
+//! NEON); on other targets only the RS side is reported.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+use flock_prover::challenger::FsChallenger;
+use flock_prover::r1cs_hashes::blake3::{Blake3Setup, Compression, K_LOG, min_n_blocks_log};
+
+// Peak-heap tracker (mirrors blake3_lig_vs_bf.rs).
+struct PeakAlloc;
+static CUR: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+unsafe impl GlobalAlloc for PeakAlloc {
+    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc(l) };
+        if !p.is_null() {
+            let c = CUR.fetch_add(l.size(), Ordering::Relaxed) + l.size();
+            PEAK.fetch_max(c, Ordering::Relaxed);
+        }
+        p
+    }
+    unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
+        unsafe { System.dealloc(p, l) };
+        CUR.fetch_sub(l.size(), Ordering::Relaxed);
+    }
+    unsafe fn realloc(&self, p: *mut u8, l: Layout, new: usize) -> *mut u8 {
+        let q = unsafe { System.realloc(p, l, new) };
+        if !q.is_null() {
+            if new >= l.size() {
+                let c = CUR.fetch_add(new - l.size(), Ordering::Relaxed) + (new - l.size());
+                PEAK.fetch_max(c, Ordering::Relaxed);
+            } else {
+                CUR.fetch_sub(l.size() - new, Ordering::Relaxed);
+            }
+        }
+        q
+    }
+}
+#[global_allocator]
+static ALLOC: PeakAlloc = PeakAlloc;
+fn reset_peak() {
+    PEAK.store(CUR.load(Ordering::Relaxed), Ordering::Relaxed);
+}
+fn peak_mb() -> f64 {
+    PEAK.load(Ordering::Relaxed) as f64 / (1024.0 * 1024.0)
+}
+
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+    fn next_u32(&mut self) -> u32 {
+        self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        (z ^ (z >> 31)) as u32
+    }
+}
+
+fn random_compression(rng: &mut Rng) -> Compression {
+    let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
+    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+    (cv, m, rng.next_u32() as u64, 64u32, 11u32)
+}
+
+fn fmt_ms(s: f64) -> String {
+    let ms = s * 1000.0;
+    if ms < 1.0 {
+        format!("{:>8.2} µs", s * 1e6)
+    } else if ms < 1000.0 {
+        format!("{:>8.2} ms", ms)
+    } else {
+        format!("{:>8.2} s ", s)
+    }
+}
+
+fn fmt_kb(b: usize) -> String {
+    if b >= 1024 * 1024 {
+        format!("{:.2} MB", b as f64 / 1024.0 / 1024.0)
+    } else if b >= 1024 {
+        format!("{:.1} KB", b as f64 / 1024.0)
+    } else {
+        format!("{} B", b)
+    }
+}
+
+fn bench_block(n_blocks: usize, n_runs: usize, threads_label: &str) {
+    let n_log = min_n_blocks_log(n_blocks);
+    let m = K_LOG + n_log;
+    let n_slots = 1usize << n_log;
+    let witness_bytes = (1usize << m) / 8;
+
+    println!(
+        "\n=== K = {n_blocks:>6}  (m = {m}, slots = {n_slots}, witness = {} MB, {threads_label}) ===",
+        witness_bytes >> 20
+    );
+
+    let setup = Blake3Setup::new(n_blocks);
+    let mk_blocks = |seed: u64| {
+        let mut rng = Rng::new(seed);
+        (0..n_blocks)
+            .map(|_| random_compression(&mut rng))
+            .collect::<Vec<Compression>>()
+    };
+    let block_sets: Vec<Vec<Compression>> = (0..=n_runs)
+        .map(|run| mk_blocks(0xB1A_C0FFEE ^ (n_blocks as u64) ^ (run as u64)))
+        .collect();
+
+    // Global warm-up: prime the shared scratch pool + codeword path BEFORE timing
+    // either backend, so neither eats the one-time cold-codeword page-fault (which
+    // would otherwise be charged to whichever runs first). See the ag-skip memory
+    // note's "warm the scratch pool before A/B-ing prove time at scale" gotcha.
+    {
+        let mut ch = FsChallenger::new(b"flock-bench-warm");
+        let (p, _, _) = setup.prove_fast(&block_sets[0], &mut ch);
+        black_box(&p);
+    }
+
+    let mut rs_prove = f64::INFINITY;
+
+    // ============ RS (additive-NTT zerocheck) + Ligerito ============
+    {
+        let mut ch_p = FsChallenger::new(b"flock-bench-v0");
+        let (p, _, _) = setup.prove_fast(&block_sets[0], &mut ch_p);
+        black_box(&p);
+
+        for run in 0..n_runs {
+            let mut ch_p = FsChallenger::new(b"flock-bench-v0");
+            let t0 = Instant::now();
+            let (p, _, _) = setup.prove_fast(&block_sets[run + 1], &mut ch_p);
+            rs_prove = rs_prove.min(t0.elapsed().as_secs_f64());
+            black_box(&p);
+        }
+
+        reset_peak();
+        let mut ch_p = FsChallenger::new(b"flock-bench-v0");
+        let (proof, commitment, _) = setup.prove_fast(&block_sets[0], &mut ch_p);
+        let peak = peak_mb();
+        let mut ch_v = FsChallenger::new(b"flock-bench-v0");
+        let t0 = Instant::now();
+        setup
+            .verify(&commitment, &proof, &mut ch_v)
+            .expect("RS verify");
+        let verify_t = t0.elapsed().as_secs_f64();
+        let size = bincode::serialize(&proof).expect("ser RS proof").len();
+        black_box(&proof);
+
+        println!(
+            "  RS  zerocheck: prove = {}   verify = {}   proof = {}   peak = {:.1} MB",
+            fmt_ms(rs_prove),
+            fmt_ms(verify_t),
+            fmt_kb(size),
+            peak,
+        );
+    }
+
+    // ============ AG (genus-95 multiplication-code zerocheck) + Ligerito ========
+    #[cfg(target_arch = "aarch64")]
+    {
+        let mut ch_p = FsChallenger::new(b"flock-bench-v0");
+        let (p, _, _) = setup.prove_fast_ag(&block_sets[0], &mut ch_p);
+        black_box(&p);
+
+        let mut ag_prove = f64::INFINITY;
+        for run in 0..n_runs {
+            let mut ch_p = FsChallenger::new(b"flock-bench-v0");
+            let t0 = Instant::now();
+            let (p, _, _) = setup.prove_fast_ag(&block_sets[run + 1], &mut ch_p);
+            ag_prove = ag_prove.min(t0.elapsed().as_secs_f64());
+            black_box(&p);
+        }
+
+        reset_peak();
+        let mut ch_p = FsChallenger::new(b"flock-bench-v0");
+        let (proof, commitment, _) = setup.prove_fast_ag(&block_sets[0], &mut ch_p);
+        let peak = peak_mb();
+        let mut ch_v = FsChallenger::new(b"flock-bench-v0");
+        let t0 = Instant::now();
+        setup
+            .verify_ag(&commitment, &proof, &mut ch_v)
+            .expect("AG verify");
+        let verify_t = t0.elapsed().as_secs_f64();
+        let size = bincode::serialize(&proof).expect("ser AG proof").len();
+        black_box(&proof);
+
+        println!(
+            "  AG  zerocheck: prove = {}   verify = {}   proof = {}   peak = {:.1} MB",
+            fmt_ms(ag_prove),
+            fmt_ms(verify_t),
+            fmt_kb(size),
+            peak,
+        );
+        println!(
+            "  ──> AG prove speedup vs RS: {:.3}×  ({:+.2} ms)",
+            rs_prove / ag_prove,
+            (rs_prove - ag_prove) * 1000.0,
+        );
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    println!("  AG  zerocheck: (skipped — aarch64-only NEON kernel)");
+}
+
+/// Per-phase prove breakdown (witness / commit / zerocheck / lincheck / open)
+/// for RS vs AG. Best-of-N by total prove time; reports that run's phases (so
+/// the columns sum to the reported total). Triggered by BLAKE3_BREAKDOWN=1.
+#[cfg(target_arch = "aarch64")]
+fn bench_breakdown(n_blocks: usize, n_runs: usize, threads_label: &str) {
+    use flock_prover::prover::ProvePhaseTimings;
+    let n_log = min_n_blocks_log(n_blocks);
+    let m = K_LOG + n_log;
+    println!("\n=== BREAKDOWN  K = {n_blocks}  (m = {m}, {threads_label}) ===");
+
+    let setup = Blake3Setup::new(n_blocks);
+    let mk = |seed: u64| {
+        let mut rng = Rng::new(seed);
+        (0..n_blocks)
+            .map(|_| random_compression(&mut rng))
+            .collect::<Vec<Compression>>()
+    };
+    let sets: Vec<Vec<Compression>> = (0..=n_runs)
+        .map(|r| mk(0xB1A_C0FFEE ^ (n_blocks as u64) ^ (r as u64)))
+        .collect();
+
+    // Warm the shared scratch pool / codeword path before timing either side.
+    {
+        let mut ch = FsChallenger::new(b"flock-bd-warm");
+        let (p, _, _, _) = setup.prove_fast_timed(&sets[0], &mut ch);
+        black_box(&p);
+    }
+
+    let total =
+        |t: &ProvePhaseTimings| t.witness_s + t.commit_s + t.zerocheck_s + t.lincheck_s + t.open_s;
+
+    let mut rs_best = ProvePhaseTimings::default();
+    let mut rs_min = f64::INFINITY;
+    for run in 0..n_runs {
+        let mut ch = FsChallenger::new(b"flock-bd-v0");
+        let (p, _, _, t) = setup.prove_fast_timed(&sets[run + 1], &mut ch);
+        black_box(&p);
+        if total(&t) < rs_min {
+            rs_min = total(&t);
+            rs_best = t;
+        }
+    }
+
+    let mut ag_best = ProvePhaseTimings::default();
+    let mut ag_min = f64::INFINITY;
+    for run in 0..n_runs {
+        let mut ch = FsChallenger::new(b"flock-bd-v0");
+        let (p, _, _, t) = setup.prove_fast_ag_timed(&sets[run + 1], &mut ch);
+        black_box(&p);
+        if total(&t) < ag_min {
+            ag_min = total(&t);
+            ag_best = t;
+        }
+    }
+
+    let row = |name: &str, rs: f64, ag: f64| {
+        println!(
+            "  {:<10} RS {:>9}   AG {:>9}   Δ {:+8.2} ms",
+            name,
+            fmt_ms(rs),
+            fmt_ms(ag),
+            (rs - ag) * 1000.0
+        );
+    };
+    row("witness", rs_best.witness_s, ag_best.witness_s);
+    row("commit", rs_best.commit_s, ag_best.commit_s);
+    row("zerocheck", rs_best.zerocheck_s, ag_best.zerocheck_s);
+    row("lincheck", rs_best.lincheck_s, ag_best.lincheck_s);
+    row("open", rs_best.open_s, ag_best.open_s);
+    row("TOTAL", total(&rs_best), total(&ag_best));
+    println!(
+        "  ──> AG total speedup {:.3}×; the win is the zerocheck: {:+.2} ms",
+        total(&rs_best) / total(&ag_best),
+        (rs_best.zerocheck_s - ag_best.zerocheck_s) * 1000.0,
+    );
+}
+
+/// Within-process A/B of the AG zerocheck: friendly-Horner tail (rounds 1..=5)
+/// vs the general kernel, interleaved per run so thermal drift cancels. The two
+/// paths are bit-identical; this isolates the friendly-Horner perf delta from
+/// the (larger) cross-process noise floor. Triggered by AG_FRIENDLY_AB=1.
+#[cfg(target_arch = "aarch64")]
+fn bench_friendly_ab(n_blocks: usize, n_runs: usize, threads_label: &str) {
+    use flock_prover::zerocheck::ag_skip::DISABLE_FRIENDLY_HORNER;
+    use std::sync::atomic::Ordering;
+    let n_log = min_n_blocks_log(n_blocks);
+    let m = K_LOG + n_log;
+    println!(
+        "\n=== FRIENDLY A/B  K = {n_blocks}  (m = {m}, {threads_label}, best of {n_runs}) ==="
+    );
+
+    let setup = Blake3Setup::new(n_blocks);
+    let mk = |seed: u64| {
+        let mut rng = Rng::new(seed);
+        (0..n_blocks)
+            .map(|_| random_compression(&mut rng))
+            .collect::<Vec<Compression>>()
+    };
+    let blocks = mk(0xB1A_C0FFEE ^ (n_blocks as u64));
+
+    // Warm scratch pool / cold codeword once (charged to neither path).
+    {
+        let mut ch = FsChallenger::new(b"flock-ab-warm");
+        let (p, _, _, _) = setup.prove_fast_ag_timed(&blocks, &mut ch);
+        black_box(&p);
+    }
+
+    let (mut fr_min, mut gen_min) = (f64::INFINITY, f64::INFINITY);
+    for _ in 0..n_runs {
+        // Interleave friendly then general each run so they share thermal state.
+        DISABLE_FRIENDLY_HORNER.store(false, Ordering::Relaxed);
+        let mut ch = FsChallenger::new(b"flock-ab-v0");
+        let (p, _, _, t) = setup.prove_fast_ag_timed(&blocks, &mut ch);
+        black_box(&p);
+        fr_min = fr_min.min(t.zerocheck_s);
+
+        DISABLE_FRIENDLY_HORNER.store(true, Ordering::Relaxed);
+        let mut ch = FsChallenger::new(b"flock-ab-v0");
+        let (p, _, _, t) = setup.prove_fast_ag_timed(&blocks, &mut ch);
+        black_box(&p);
+        gen_min = gen_min.min(t.zerocheck_s);
+    }
+    DISABLE_FRIENDLY_HORNER.store(false, Ordering::Relaxed);
+
+    println!(
+        "  AG zerocheck: general {}   friendly {}   Δ {:+.2} ms  ({:.3}× faster)",
+        fmt_ms(gen_min),
+        fmt_ms(fr_min),
+        (gen_min - fr_min) * 1000.0,
+        gen_min / fr_min,
+    );
+}
+
+/// Within-process A/B of the tail's ping-pong buffer strategy: uninit pooled
+/// `take_f128` vs the old `vec![F128::ZERO; n_in/2]` (serial zero-fill, non-pooled),
+/// interleaved per run. Output is bit-identical. Triggered by AG_NXT_AB=1.
+#[cfg(target_arch = "aarch64")]
+fn bench_nxt_ab(n_blocks: usize, n_runs: usize, threads_label: &str) {
+    use flock_prover::zerocheck::ag_skip::NXT_ZEROFILL;
+    use std::sync::atomic::Ordering;
+    let n_log = min_n_blocks_log(n_blocks);
+    let m = K_LOG + n_log;
+    println!(
+        "\n=== NXT BUFFER A/B  K = {n_blocks}  (m = {m}, {threads_label}, best of {n_runs}) ==="
+    );
+
+    let setup = Blake3Setup::new(n_blocks);
+    let mk = |seed: u64| {
+        let mut rng = Rng::new(seed);
+        (0..n_blocks)
+            .map(|_| random_compression(&mut rng))
+            .collect::<Vec<Compression>>()
+    };
+    let blocks = mk(0xB1A_C0FFEE ^ (n_blocks as u64));
+    {
+        let mut ch = FsChallenger::new(b"flock-nxt-warm");
+        let (p, _, _, _) = setup.prove_fast_ag_timed(&blocks, &mut ch);
+        black_box(&p);
+    }
+
+    let (mut pool_min, mut zero_min) = (f64::INFINITY, f64::INFINITY);
+    for _ in 0..n_runs {
+        NXT_ZEROFILL.store(false, Ordering::Relaxed);
+        let mut ch = FsChallenger::new(b"flock-nxt-v0");
+        let (p, _, _, t) = setup.prove_fast_ag_timed(&blocks, &mut ch);
+        black_box(&p);
+        pool_min = pool_min.min(t.zerocheck_s);
+
+        NXT_ZEROFILL.store(true, Ordering::Relaxed);
+        let mut ch = FsChallenger::new(b"flock-nxt-v0");
+        let (p, _, _, t) = setup.prove_fast_ag_timed(&blocks, &mut ch);
+        black_box(&p);
+        zero_min = zero_min.min(t.zerocheck_s);
+    }
+    NXT_ZEROFILL.store(false, Ordering::Relaxed);
+
+    println!(
+        "  AG zerocheck: vec![ZERO] {}   pooled take_f128 {}   Δ {:+.2} ms  ({:.3}× faster)",
+        fmt_ms(zero_min),
+        fmt_ms(pool_min),
+        (zero_min - pool_min) * 1000.0,
+        zero_min / pool_min,
+    );
+}
+
+fn main() {
+    let _ = flock_prover::init_perf_thread_pool();
+    let threads = rayon::current_num_threads();
+    let label_owned = if threads == 1 {
+        "ST".to_string()
+    } else {
+        format!("MT, {threads} threads")
+    };
+    let label = label_owned.as_str();
+
+    #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
+    println!("(target: aarch64 + aes)");
+    println!("BLAKE3 prove_fast RS-zerocheck vs AG-zerocheck head-to-head — {label}");
+
+    let ks: Vec<usize> = match std::env::var("BLAKE3_K") {
+        Ok(s) => s
+            .split(|c: char| c.is_whitespace() || c == ',')
+            .filter(|t| !t.is_empty())
+            .map(|t| t.parse().expect("BLAKE3_K: integer K (n_blocks)"))
+            .collect(),
+        Err(_) => vec![65536],
+    };
+    let n_runs: usize = std::env::var("FLOCK_BENCH_RUNS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3);
+
+    let breakdown = std::env::var("BLAKE3_BREAKDOWN").is_ok();
+    let friendly_ab = std::env::var("AG_FRIENDLY_AB").is_ok();
+    let nxt_ab = std::env::var("AG_NXT_AB").is_ok();
+    for &n in &ks {
+        #[cfg(target_arch = "aarch64")]
+        if nxt_ab {
+            bench_nxt_ab(n, n_runs, label);
+            continue;
+        }
+        #[cfg(target_arch = "aarch64")]
+        if friendly_ab {
+            bench_friendly_ab(n, n_runs, label);
+            continue;
+        }
+        #[cfg(target_arch = "aarch64")]
+        if breakdown {
+            bench_breakdown(n, n_runs, label);
+            continue;
+        }
+        let _ = (breakdown, friendly_ab, nxt_ab);
+        bench_block(n, n_runs, label);
+    }
+}

--- a/crates/flock-prover/benches/keccak3_witlc_probe.rs
+++ b/crates/flock-prover/benches/keccak3_witlc_probe.rs
@@ -14,7 +14,7 @@ use std::time::Instant;
 
 use flock_prover::challenger::FsChallenger;
 use flock_prover::field::F128;
-use flock_prover::lincheck::{QuirkyPoint, prove_padded_capture_z_vec};
+use flock_prover::lincheck::{QuirkyPoint, SkipPoint, prove_padded_capture_z_vec};
 use flock_prover::r1cs_hashes::keccak::State;
 use flock_prover::r1cs_hashes::keccak3::{
     K_SKIP, KeccakLincheckCircuit, KeccakSetup, generate_witness_with_ab_packed_and_lincheck,
@@ -89,7 +89,7 @@ fn main() {
     let states: Vec<State> = (0..n_keccaks).map(|_| random_state(&mut rng)).collect();
 
     let x_ab = QuirkyPoint {
-        z_skip: rng.f128(),
+        z_skip: SkipPoint::Phi8(rng.f128()),
         x_inner_rest: (0..r1cs.k_log - K_SKIP).map(|_| rng.f128()).collect(),
         x_outer: (0..m - r1cs.k_log).map(|_| rng.f128()).collect(),
     };
@@ -158,7 +158,7 @@ fn main() {
         h.f128s(&[*m1, *mi]);
     }
     h.f128s(&lc_proof.z_partial);
-    h.f128s(&[lc_claim.r_inner_skip, lc_claim.w]);
+    h.f128s(&[lc_claim.r_inner_skip.phi8(), lc_claim.w]);
     h.f128s(&lc_claim.r_inner_rest);
     h.f128s(&z_vec_pre);
     println!("lc min: {lc_min:.2} ms  checksum_lc: {:016x}", h.0);

--- a/crates/flock-prover/benches/lincheck.rs
+++ b/crates/flock-prover/benches/lincheck.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 
 use flock_prover::challenger::FsChallenger;
 use flock_prover::field::F128;
-use flock_prover::lincheck::{QuirkyPoint, SparseMatrixCircuit, prove};
+use flock_prover::lincheck::{QuirkyPoint, SkipPoint, SparseMatrixCircuit, prove};
 use flock_prover::r1cs::SparseBinaryMatrix;
 
 const K_LOG: usize = 11; // k = 2048
@@ -119,7 +119,7 @@ fn main() {
             let mut z_packed = vec![0u8; n_bytes];
             rng.fill_bytes(&mut z_packed);
             let x_ab = QuirkyPoint {
-                z_skip: rng.f128(),
+                z_skip: SkipPoint::Phi8(rng.f128()),
                 x_inner_rest: rng.f128_vec(K_LOG - K_SKIP),
                 x_outer: rng.f128_vec(m - K_LOG),
             };

--- a/crates/flock-prover/benches/witness_lincheck_probe.rs
+++ b/crates/flock-prover/benches/witness_lincheck_probe.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 
 use flock_prover::challenger::FsChallenger;
 use flock_prover::field::F128;
-use flock_prover::lincheck::{QuirkyPoint, prove_padded_capture_z_vec};
+use flock_prover::lincheck::{QuirkyPoint, SkipPoint, prove_padded_capture_z_vec};
 use flock_prover::r1cs_hashes::blake3::{
     Blake3Setup, Compression, K_SKIP, generate_witness_with_ab_packed_and_lincheck,
     min_n_blocks_log,
@@ -94,7 +94,7 @@ fn main() {
 
     // Fixed claim point with the real blake3 dims.
     let x_ab = QuirkyPoint {
-        z_skip: rng.f128(),
+        z_skip: SkipPoint::Phi8(rng.f128()),
         x_inner_rest: (0..r1cs.k_log - K_SKIP).map(|_| rng.f128()).collect(),
         x_outer: (0..m - r1cs.k_log).map(|_| rng.f128()).collect(),
     };
@@ -164,7 +164,7 @@ fn main() {
         h.f128s(&[*m1, *mi]);
     }
     h.f128s(&lc_proof.z_partial);
-    h.f128s(&[lc_claim.r_inner_skip, lc_claim.w]);
+    h.f128s(&[lc_claim.r_inner_skip.phi8(), lc_claim.w]);
     h.f128s(&lc_claim.r_inner_rest);
     h.f128s(&z_vec_pre);
     println!("lc min: {lc_min:.2} ms  checksum_lc: {:016x}", h.0);

--- a/crates/flock-prover/src/bin/dump_lincheck_vectors.rs
+++ b/crates/flock-prover/src/bin/dump_lincheck_vectors.rs
@@ -47,7 +47,8 @@ use std::io::{BufWriter, Write};
 use flock_prover::challenger::{Challenger, FsChallenger};
 use flock_prover::field::F128;
 use flock_prover::lincheck::{
-    self, CscCircuit, LincheckCircuit, QuirkyPoint, build_eq_table, build_quirky_eq_table,
+    self, CscCircuit, LincheckCircuit, QuirkyPoint, SkipPoint, build_eq_table,
+    build_quirky_eq_table,
 };
 use flock_prover::r1cs::SparseBinaryMatrix;
 
@@ -175,7 +176,7 @@ fn main() -> std::io::Result<()> {
 
     // --- Quirky claim point.
     let x_ab = QuirkyPoint {
-        z_skip: rng.next_f128(),
+        z_skip: SkipPoint::Phi8(rng.next_f128()),
         x_inner_rest: (0..inner_rest_len).map(|_| rng.next_f128()).collect(),
         x_outer: (0..n_log).map(|_| rng.next_f128()).collect(),
     };
@@ -202,7 +203,7 @@ fn main() -> std::io::Result<()> {
     let mut ch2 = FsChallenger::new(DOMAIN);
     ch2.observe_label(b"flock-lincheck-v0");
     let alpha = ch2.sample_f128();
-    let eq_inner = build_quirky_eq_table(x_ab.z_skip, &x_ab.x_inner_rest, k_skip);
+    let eq_inner = build_quirky_eq_table(x_ab.z_skip.phi8(), &x_ab.x_inner_rest, k_skip);
     let comb_vec = circuit.fold_alpha_batched(alpha, &eq_inner);
     assert_eq!(comb_vec.len(), k);
     // sanity: the public build_eq_table(x_outer) the prover folds against.
@@ -237,7 +238,7 @@ fn main() -> std::io::Result<()> {
         write_u32(&mut w, v)?;
     }
 
-    write_f128(&mut w, x_ab.z_skip)?;
+    write_f128(&mut w, x_ab.z_skip.phi8())?;
     for &x in &x_ab.x_inner_rest {
         write_f128(&mut w, x)?;
     }
@@ -261,7 +262,7 @@ fn main() -> std::io::Result<()> {
     for &x in &proof.z_partial {
         write_f128(&mut w, x)?;
     }
-    write_f128(&mut w, claim.r_inner_skip)?;
+    write_f128(&mut w, claim.r_inner_skip.phi8())?;
     write_f128(&mut w, claim.w)?;
     w.flush()?;
 

--- a/crates/flock-prover/src/prover.rs
+++ b/crates/flock-prover/src/prover.rs
@@ -27,8 +27,11 @@
 
 use flock_core::challenger::Challenger;
 use flock_core::field::F128;
+use flock_core::lincheck::SkipPoint;
 use flock_core::lincheck::{self, QuirkyPoint, pack_z_lincheck_from_packed};
 use flock_core::pcs::{self, Commitment, PcsParams};
+#[cfg(target_arch = "aarch64")]
+use flock_core::proof::R1csProofLigeritoAg;
 use flock_core::proof::{R1csClaim, R1csProofLigerito, ZClaim, bind_statement};
 use flock_core::r1cs::BlockR1cs;
 use flock_core::zerocheck;
@@ -140,7 +143,7 @@ pub fn prove_ligerito<Ch: Challenger>(
         a_packed, b_packed, c_packed, r1cs.m, &padding, challenger,
     );
 
-    let x_ab = r1cs.x_ab_from_mlv(zc_claim.z, &zc_claim.mlv_challenges);
+    let x_ab = r1cs.x_ab_from_mlv(SkipPoint::Phi8(zc_claim.z), &zc_claim.mlv_challenges);
 
     let lc_circuit =
         lincheck::SparseMatrixCircuit::new(&r1cs.a_0, &r1cs.b_0).with_const_pin(r1cs.const_pin);
@@ -160,7 +163,7 @@ pub fn prove_ligerito<Ch: Challenger>(
         value: lc_claim.w,
     };
     let c = ZClaim {
-        point: r1cs.c_claim_point(zc_claim.z, &zc_claim.r_rest),
+        point: r1cs.c_claim_point(SkipPoint::Phi8(zc_claim.z), &zc_claim.r_rest),
         value: zc_claim.c_eval,
     };
 
@@ -257,6 +260,300 @@ pub fn prove_fast_ligerito_from_witness<Ch: Challenger>(
     };
     let claim = R1csClaim { ab, c };
     (proof, commitment, claim)
+}
+
+/// AG-skip mirror of [`prove_ligerito`]: same commit → bind → zerocheck →
+/// lincheck → ring-switch open pipeline, with round 1 of the zerocheck run on
+/// the genus-95 AG multiplication code. The `(ab, c)` claims carry AG
+/// base-code skip weights (`SkipPoint::Ag`) instead of φ₈ (`SkipPoint::Phi8`);
+/// the c-claim point is `(skip = r₁, rest = friendly ‖ outer)`. aarch64-only
+/// (the AG round-1 kernel is NEON).
+#[cfg(target_arch = "aarch64")]
+pub fn prove_ligerito_ag<Ch: Challenger>(
+    r1cs: &BlockR1cs,
+    z_packed: Vec<F128>,
+    pcs_params: &PcsParams,
+    challenger: &mut Ch,
+) -> (R1csProofLigeritoAg, Commitment, R1csClaim) {
+    assert_eq!(
+        r1cs.layout,
+        flock_core::r1cs::WitnessLayout::RowMajor,
+        "the generic matrix-driven provers assume the row-major layout"
+    );
+    assert_eq!(z_packed.len(), 1usize << (r1cs.m - 7));
+    assert_eq!(pcs_params.m, r1cs.m);
+    assert_eq!(
+        r1cs.k_skip,
+        zerocheck::ag_skip::K_SKIP,
+        "AG skip is k_skip=6"
+    );
+    assert!(
+        r1cs.c0_is_identity(),
+        "prove_ligerito_ag: C = I convention required (c aliases z)"
+    );
+
+    // a = A·z, b = B·z; for the C = I convention c aliases z (see `prove_ligerito`).
+    let a_packed_f128 = r1cs.apply_a_packed(&z_packed);
+    let b_packed_f128 = r1cs.apply_b_packed(&z_packed);
+    let z_packed_lincheck = lincheck::pack_z_lincheck_from_packed(&z_packed, r1cs.m, r1cs.k_log);
+    let lc_circuit =
+        lincheck::SparseMatrixCircuit::new(&r1cs.a_0, &r1cs.b_0).with_const_pin(r1cs.const_pin);
+    prove_fast_ligerito_ag_from_witness(
+        r1cs,
+        pcs_params,
+        z_packed,
+        a_packed_f128,
+        b_packed_f128,
+        z_packed_lincheck,
+        &lc_circuit,
+        None,
+        challenger,
+    )
+}
+
+/// AG-skip mirror of [`prove_fast_ligerito_from_witness`]: commit → bind →
+/// **AG zerocheck** ([`zerocheck::ag_skip`]) → lincheck → ring-switch Ligerito
+/// open. The zerocheck's `s_hat_v_c` capture and lincheck's `z_vec` capture
+/// feed the open exactly as in the RS path; claim points are built through the
+/// layout-aware [`BlockR1cs`] constructors, so both witness layouts work.
+/// aarch64-only (the AG round-1 kernel is NEON).
+#[cfg(target_arch = "aarch64")]
+#[allow(clippy::too_many_arguments)]
+pub fn prove_fast_ligerito_ag_from_witness<Ch: Challenger>(
+    r1cs: &BlockR1cs,
+    pcs_params: &PcsParams,
+    z_packed: Vec<F128>,
+    a_packed_f128: Vec<F128>,
+    b_packed_f128: Vec<F128>,
+    z_packed_lincheck: Vec<u8>,
+    lincheck_circuit: &dyn lincheck::LincheckCircuit,
+    prefaulted_codeword: Option<Vec<F128>>,
+    challenger: &mut Ch,
+) -> (R1csProofLigeritoAg, Commitment, R1csClaim) {
+    assert_eq!(
+        r1cs.k_skip,
+        zerocheck::ag_skip::K_SKIP,
+        "AG skip is k_skip=6"
+    );
+    let lig_config = pcs_params
+        .ligerito_prover_config()
+        .expect("Ligerito default config; bump m for tiny instances");
+
+    let (commitment, prover_data) = match prefaulted_codeword {
+        Some(buf) => pcs::commit_into(&z_packed, pcs_params, buf),
+        None => pcs::commit(&z_packed, pcs_params),
+    };
+    bind_statement(challenger, r1cs, &commitment);
+
+    // ---- AG-skip zerocheck (round 1 = genus-95 AG code; tail = shared MLV).
+    // Capture s_hat_v_c so the open skips fold_1b_rows for the c-claim.
+    let (ag_proof, ag_claim, s_hat_v_c) = {
+        let cast = |v: &[F128]| -> &[u8] {
+            unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, std::mem::size_of_val(v)) }
+        };
+        zerocheck::ag_skip::prove_capture_s_hat_v_c(
+            cast(&a_packed_f128),
+            cast(&b_packed_f128),
+            cast(&z_packed),
+            r1cs.m,
+            challenger,
+        )
+    };
+    flock_core::scratch::give_f128(a_packed_f128);
+    flock_core::scratch::give_f128(b_packed_f128);
+
+    // ---- Translate AG zerocheck output → lincheck input. Structurally
+    // identical to the RS path (`mlv_challenges` binds the m−k_skip non-skip
+    // bits low→high, address-ordered), only the skip basis differs (Ag vs Phi8).
+    let x_ab = r1cs.x_ab_from_mlv(SkipPoint::Ag(ag_claim.r1), &ag_claim.mlv_challenges);
+
+    let (lc_proof, lc_claim, z_vec_pre) = lincheck::prove_padded_capture_z_vec(
+        &z_packed_lincheck,
+        r1cs.m,
+        r1cs.k_log,
+        r1cs.k_skip,
+        r1cs.useful_bits,
+        lincheck_circuit,
+        &x_ab,
+        challenger,
+    );
+    drop(z_packed_lincheck);
+
+    let ab = ZClaim {
+        point: r1cs.ab_claim_point(lc_claim.r_inner_skip, &lc_claim.r_inner_rest, &x_ab.x_outer),
+        value: lc_claim.w,
+    };
+    // c-claim: ĉ = ẑ (C = I). Skip = r₁ (AG), rest = ag_claim.r_rest
+    // (friendly ‖ outer); value = ⟨base(r₁), w̄⟩ (κ already in w̄).
+    let c = ZClaim {
+        point: r1cs.c_claim_point(SkipPoint::Ag(ag_claim.r1), &ag_claim.r_rest),
+        value: ag_claim.c_eval,
+    };
+
+    // AB s_hat_v from lincheck's pre-sumcheck z_vec (basis-agnostic: it folds
+    // the witness bits, the skip weights enter only at claim_check). The c
+    // s_hat_v was captured during the AG round-1 c-scan.
+    let s_hat_v_ab = if r1cs.k_log >= pcs::LOG_PACKING {
+        Some(pcs::ring_switch::s_hat_v_from_z_vec(
+            &z_vec_pre,
+            &lc_claim.r_inner_rest[1..],
+        ))
+    } else {
+        None
+    };
+
+    let padding = r1cs.padding_spec();
+    let pre_ab: Option<&[F128]> = s_hat_v_ab.as_deref();
+    let pre_c: Option<&[F128]> = Some(s_hat_v_c.as_slice());
+    let pcs_open = open_claims_with_precomputed_ligerito(
+        z_packed,
+        &prover_data,
+        &commitment,
+        &[ab.clone(), c.clone()],
+        &[pre_ab, pre_c],
+        &padding,
+        &lig_config,
+        challenger,
+    );
+
+    let proof = R1csProofLigeritoAg {
+        ag: ag_proof,
+        lincheck: lc_proof,
+        pcs_open,
+    };
+    let claim = R1csClaim { ab, c };
+    (proof, commitment, claim)
+}
+
+/// **AG-skip** mirror of [`prove_fast_ligerito_timed`]: per-phase timers around
+/// [`prove_fast_ligerito_ag_from_witness`]'s phases (commit / AG zerocheck /
+/// lincheck / open). `zerocheck_s` is the genus-95 AG round 1 + multilinear
+/// tail; everything else is the shared path. Benchmark-only; aarch64.
+#[cfg(target_arch = "aarch64")]
+#[allow(clippy::too_many_arguments)]
+pub fn prove_fast_ligerito_ag_timed<Ch: Challenger>(
+    r1cs: &BlockR1cs,
+    pcs_params: &PcsParams,
+    z_packed: Vec<F128>,
+    a_packed_f128: Vec<F128>,
+    b_packed_f128: Vec<F128>,
+    z_packed_lincheck: Vec<u8>,
+    lincheck_circuit: &dyn lincheck::LincheckCircuit,
+    prefaulted_codeword: Option<Vec<F128>>,
+    challenger: &mut Ch,
+) -> (
+    R1csProofLigeritoAg,
+    Commitment,
+    R1csClaim,
+    ProvePhaseTimings,
+) {
+    use std::time::Instant;
+    let mut t = ProvePhaseTimings::default();
+    assert_eq!(
+        r1cs.k_skip,
+        zerocheck::ag_skip::K_SKIP,
+        "AG skip is k_skip=6"
+    );
+
+    let lig_config = pcs_params
+        .ligerito_prover_config()
+        .expect("Ligerito default config; bump m for tiny instances");
+
+    // --- PCS commit ---
+    let t0 = Instant::now();
+    let (commitment, prover_data) = match prefaulted_codeword {
+        Some(buf) => pcs::commit_into(&z_packed, pcs_params, buf),
+        None => pcs::commit(&z_packed, pcs_params),
+    };
+    t.commit_s = t0.elapsed().as_secs_f64();
+    bind_statement(challenger, r1cs, &commitment);
+
+    // --- AG-skip zerocheck (capturing s_hat_v_c) ---
+    let t0 = Instant::now();
+    let (ag_proof, ag_claim, s_hat_v_c) = {
+        let a_packed: &[u8] = unsafe {
+            std::slice::from_raw_parts(
+                a_packed_f128.as_ptr() as *const u8,
+                a_packed_f128.len() * core::mem::size_of::<F128>(),
+            )
+        };
+        let b_packed: &[u8] = unsafe {
+            std::slice::from_raw_parts(
+                b_packed_f128.as_ptr() as *const u8,
+                b_packed_f128.len() * core::mem::size_of::<F128>(),
+            )
+        };
+        let c_packed: &[u8] = unsafe {
+            std::slice::from_raw_parts(
+                z_packed.as_ptr() as *const u8,
+                z_packed.len() * core::mem::size_of::<F128>(),
+            )
+        };
+        zerocheck::ag_skip::prove_capture_s_hat_v_c(
+            a_packed, b_packed, c_packed, r1cs.m, challenger,
+        )
+    };
+    t.zerocheck_s = t0.elapsed().as_secs_f64();
+    flock_core::scratch::give_f128(a_packed_f128);
+    flock_core::scratch::give_f128(b_packed_f128);
+
+    let x_ab = r1cs.x_ab_from_mlv(SkipPoint::Ag(ag_claim.r1), &ag_claim.mlv_challenges);
+
+    // --- lincheck + base-claim / s_hat_v setup ---
+    let t0 = Instant::now();
+    let (lc_proof, lc_claim, z_vec_pre) = lincheck::prove_padded_capture_z_vec(
+        &z_packed_lincheck,
+        r1cs.m,
+        r1cs.k_log,
+        r1cs.k_skip,
+        r1cs.useful_bits,
+        lincheck_circuit,
+        &x_ab,
+        challenger,
+    );
+    drop(z_packed_lincheck);
+    let ab = ZClaim {
+        point: r1cs.ab_claim_point(lc_claim.r_inner_skip, &lc_claim.r_inner_rest, &x_ab.x_outer),
+        value: lc_claim.w,
+    };
+    let c = ZClaim {
+        point: r1cs.c_claim_point(SkipPoint::Ag(ag_claim.r1), &ag_claim.r_rest),
+        value: ag_claim.c_eval,
+    };
+    let s_hat_v_ab = if r1cs.k_log >= pcs::LOG_PACKING {
+        Some(pcs::ring_switch::s_hat_v_from_z_vec(
+            &z_vec_pre,
+            &lc_claim.r_inner_rest[1..],
+        ))
+    } else {
+        None
+    };
+    t.lincheck_s = t0.elapsed().as_secs_f64();
+
+    // --- Ligerito recursive PCS open ---
+    let pre_ab: Option<&[F128]> = s_hat_v_ab.as_deref();
+    let pre_c: Option<&[F128]> = Some(s_hat_v_c.as_slice());
+    let padding = r1cs.padding_spec();
+    let t0 = Instant::now();
+    let pcs_open = open_claims_with_precomputed_ligerito(
+        z_packed,
+        &prover_data,
+        &commitment,
+        &[ab.clone(), c.clone()],
+        &[pre_ab, pre_c],
+        &padding,
+        &lig_config,
+        challenger,
+    );
+    t.open_s = t0.elapsed().as_secs_f64();
+
+    let proof = R1csProofLigeritoAg {
+        ag: ag_proof,
+        lincheck: lc_proof,
+        pcs_open,
+    };
+    let claim = R1csClaim { ab, c };
+    (proof, commitment, claim, t)
 }
 
 /// Everything the prover produces *before* the PCS open: the zerocheck +
@@ -369,7 +666,7 @@ pub fn prove_fast_core_with_codeword<Ch: Challenger>(
     flock_core::scratch::give_f128(a_packed_f128);
     flock_core::scratch::give_f128(b_packed_f128);
 
-    let x_ab = r1cs.x_ab_from_mlv(zc_claim.z, &zc_claim.mlv_challenges);
+    let x_ab = r1cs.x_ab_from_mlv(SkipPoint::Phi8(zc_claim.z), &zc_claim.mlv_challenges);
 
     // Capture lincheck's pre-sumcheck z_vec so the PCS open can derive the
     // AB-claim's `s_hat_v` from it (skips fold_1b_rows for AB).
@@ -392,7 +689,7 @@ pub fn prove_fast_core_with_codeword<Ch: Challenger>(
         value: lc_claim.w,
     };
     let c = ZClaim {
-        point: r1cs.c_claim_point(zc_claim.z, &zc_claim.r_rest),
+        point: r1cs.c_claim_point(SkipPoint::Phi8(zc_claim.z), &zc_claim.r_rest),
         value: zc_claim.c_eval,
     };
 
@@ -502,7 +799,7 @@ pub fn prove_fast_ligerito_timed<Ch: Challenger>(
     flock_core::scratch::give_f128(a_packed_f128);
     flock_core::scratch::give_f128(b_packed_f128);
 
-    let x_ab = r1cs.x_ab_from_mlv(zc_claim.z, &zc_claim.mlv_challenges);
+    let x_ab = r1cs.x_ab_from_mlv(SkipPoint::Phi8(zc_claim.z), &zc_claim.mlv_challenges);
 
     // --- lincheck + base-claim / s_hat_v setup ---
     let t0 = Instant::now();
@@ -522,7 +819,7 @@ pub fn prove_fast_ligerito_timed<Ch: Challenger>(
         value: lc_claim.w,
     };
     let c = ZClaim {
-        point: r1cs.c_claim_point(zc_claim.z, &zc_claim.r_rest),
+        point: r1cs.c_claim_point(SkipPoint::Phi8(zc_claim.z), &zc_claim.r_rest),
         value: zc_claim.c_eval,
     };
     let s_hat_v_ab = if r1cs.k_log >= pcs::LOG_PACKING {

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -1457,6 +1457,94 @@ impl Blake3Setup {
             challenger,
         )
     }
+
+    /// AG-skip mirror of [`Self::prove_fast`]: round 1 of the zerocheck runs
+    /// on the genus-95 AG multiplication code instead of the RS additive-NTT
+    /// skip; everything else (witness gen, commit, lincheck, ring-switch open)
+    /// is shared. Witness generation dispatches on the r1cs's witness layout,
+    /// so both row-major and batch-major setups work. aarch64-only (NEON
+    /// round-1 kernel).
+    #[cfg(target_arch = "aarch64")]
+    pub fn prove_fast_ag<Ch: Challenger>(
+        &self,
+        blocks: &[Compression],
+        challenger: &mut Ch,
+    ) -> (
+        flock_core::proof::R1csProofLigeritoAg,
+        Commitment,
+        R1csClaim,
+    ) {
+        assert_eq!(blocks.len(), self.n_blocks);
+        let (codeword, (z_packed, a_packed_f128, b_packed_f128, z_packed_lincheck)) =
+            flock_core::pcs::prefault_codeword_during(&self.pcs_params, || {
+                self.generate_witness_ab(blocks)
+            });
+        let lc_circuit = self.r1cs.csc_lincheck_circuit();
+        crate::prover::prove_fast_ligerito_ag_from_witness(
+            &self.r1cs,
+            &self.pcs_params,
+            z_packed,
+            a_packed_f128,
+            b_packed_f128,
+            z_packed_lincheck,
+            lc_circuit,
+            codeword,
+            challenger,
+        )
+    }
+
+    /// AG-skip mirror of [`Self::prove_fast_timed`]: per-phase prove
+    /// breakdown (witness / commit / AG zerocheck / lincheck / open).
+    /// Benchmark-only; aarch64.
+    #[cfg(target_arch = "aarch64")]
+    pub fn prove_fast_ag_timed<Ch: Challenger>(
+        &self,
+        blocks: &[Compression],
+        challenger: &mut Ch,
+    ) -> (
+        flock_core::proof::R1csProofLigeritoAg,
+        Commitment,
+        R1csClaim,
+        crate::prover::ProvePhaseTimings,
+    ) {
+        assert_eq!(blocks.len(), self.n_blocks);
+        let t0 = std::time::Instant::now();
+        let (z_packed, a_packed_f128, b_packed_f128, z_packed_lincheck) =
+            self.generate_witness_ab(blocks);
+        let witness_s = t0.elapsed().as_secs_f64();
+        let lc_circuit = self.r1cs.csc_lincheck_circuit();
+        let (proof, commitment, claim, mut timings) = crate::prover::prove_fast_ligerito_ag_timed(
+            &self.r1cs,
+            &self.pcs_params,
+            z_packed,
+            a_packed_f128,
+            b_packed_f128,
+            z_packed_lincheck,
+            lc_circuit,
+            None,
+            challenger,
+        );
+        timings.witness_s = witness_s;
+        (proof, commitment, claim, timings)
+    }
+
+    /// AG-skip mirror of [`Self::verify`].
+    pub fn verify_ag<Ch: Challenger>(
+        &self,
+        commitment: &Commitment,
+        proof: &flock_core::proof::R1csProofLigeritoAg,
+        challenger: &mut Ch,
+    ) -> Result<R1csClaim, verifier::VerifyError> {
+        let lc_circuit = self.r1cs.csc_lincheck_circuit();
+        verifier::verify_ligerito_ag(
+            &self.r1cs,
+            commitment,
+            proof,
+            lc_circuit,
+            &self.pcs_params,
+            challenger,
+        )
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1816,6 +1904,78 @@ mod tests {
         assert!(
             setup.verify(&commitment, &bad, &mut ch).is_err(),
             "tampered batch-major proof accepted"
+        );
+    }
+
+    /// AG-skip e2e: prove_fast_ag → verify_ag roundtrip + tamper rejection,
+    /// through the full commit → AG zerocheck → lincheck → ring-switch
+    /// Ligerito open pipeline.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    #[ignore] // Heavy — run with `cargo test prove_fast_ligerito_ag_roundtrip -- --ignored`
+    fn prove_fast_ligerito_ag_roundtrip() {
+        use flock_core::challenger::FsChallenger;
+        let setup = Blake3Setup::new(256);
+        let mut rng = Rng::new(0xb1a_3a9_211e);
+        let blocks: Vec<Compression> = (0..256)
+            .map(|_| {
+                let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
+                let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                (cv, m, 0u64, 64u32, 11u32)
+            })
+            .collect();
+        let mut ch_p = FsChallenger::new(b"flock-blake3-ag-v0");
+        let (proof, commitment, claim_p) = setup.prove_fast_ag(&blocks, &mut ch_p);
+        let mut ch_v = FsChallenger::new(b"flock-blake3-ag-v0");
+        let claim_v = setup
+            .verify_ag(&commitment, &proof, &mut ch_v)
+            .unwrap_or_else(|e| panic!("AG verify rejected honest blake3 proof: {e:?}"));
+        assert_eq!(claim_p, claim_v, "AG verifier claim != prover claim");
+
+        // Tampering an AG round-1 message must reject.
+        let mut bad = proof.clone();
+        bad.ag.round1_ab[0] += flock_core::field::F128::ONE;
+        let mut ch_b = FsChallenger::new(b"flock-blake3-ag-v0");
+        assert!(
+            setup.verify_ag(&commitment, &bad, &mut ch_b).is_err(),
+            "must reject a tampered AG proof"
+        );
+    }
+
+    /// Batch-major AG roundtrip: the AG claim points are built through the
+    /// layout-aware [`BlockR1cs`] constructors, so the batch-major witness
+    /// layout works unchanged (mirror of `batch_major_prove_fast_roundtrip`).
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    #[ignore] // Heavy — run with `cargo test batch_major_prove_fast_ag_roundtrip -- --ignored`
+    fn batch_major_prove_fast_ag_roundtrip() {
+        use flock_core::challenger::FsChallenger;
+
+        let setup = Blake3Setup::new_batch_major(256);
+        let mut rng = Rng::new(0xBA7C_F013);
+        let inputs: Vec<Compression> = (0..256)
+            .map(|_| {
+                let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
+                let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                let counter = ((rng.next_u32() as u64) << 32) | (rng.next_u32() as u64);
+                (cv, m, counter, 64u32, 11u32)
+            })
+            .collect();
+
+        let mut ch_p = FsChallenger::new(b"flock-ag-batch-major-v0");
+        let (proof, commitment, claim_p) = setup.prove_fast_ag(&inputs, &mut ch_p);
+        let mut ch_v = FsChallenger::new(b"flock-ag-batch-major-v0");
+        let claim_v = setup
+            .verify_ag(&commitment, &proof, &mut ch_v)
+            .unwrap_or_else(|e| panic!("batch-major AG verifier rejected: {e:?}"));
+        assert_eq!(claim_p, claim_v);
+
+        let mut bad = proof.clone();
+        bad.ag.final_a_eval.lo ^= 1;
+        let mut ch = FsChallenger::new(b"flock-ag-batch-major-v0");
+        assert!(
+            setup.verify_ag(&commitment, &bad, &mut ch).is_err(),
+            "tampered batch-major AG proof accepted"
         );
     }
 

--- a/crates/flock-prover/src/r1cs_hashes/chain_common.rs
+++ b/crates/flock-prover/src/r1cs_hashes/chain_common.rs
@@ -387,10 +387,12 @@ pub fn verify_chain_ligerito_generic<Ch: Challenger>(
         .ligerito_verifier_config()
         .expect("Ligerito default verifier config for chain verify");
 
+    let ab_skip_weights = ab.point.z_skip.weights(flock_core::pcs::LOG_PACKING - 1);
+    let c_skip_weights = c.point.z_skip.weights(flock_core::pcs::LOG_PACKING - 1);
     flock_core::pcs::verify_opening_batch_ligerito_mixed(
         commitment,
         &[ab.value, c.value],
-        &[ab.point.z_skip, c.point.z_skip],
+        &[&ab_skip_weights, &c_skip_weights],
         &[ab_x_outer.as_slice(), c_x_outer.as_slice()],
         std::slice::from_ref(&pd_ref),
         &proof.pcs_open,

--- a/crates/flock-prover/src/r1cs_hashes/merkle_path_common.rs
+++ b/crates/flock-prover/src/r1cs_hashes/merkle_path_common.rs
@@ -521,10 +521,12 @@ pub fn verify_merkle_paths_ligerito_generic<Ch: Challenger>(
         .ligerito_verifier_config()
         .expect("Ligerito verifier config for merkle-path verify");
 
+    let ab_skip_weights = ab.point.z_skip.weights(flock_core::pcs::LOG_PACKING - 1);
+    let c_skip_weights = c.point.z_skip.weights(flock_core::pcs::LOG_PACKING - 1);
     flock_core::pcs::verify_opening_batch_ligerito_mixed(
         commitment,
         &[ab.value, c.value],
-        &[ab.point.z_skip, c.point.z_skip],
+        &[&ab_skip_weights, &c_skip_weights],
         &[ab_x_outer.as_slice(), c_x_outer.as_slice()],
         std::slice::from_ref(&pd_ref),
         &proof.pcs_open,

--- a/crates/flock-prover/tests/verifier_roundtrip.rs
+++ b/crates/flock-prover/tests/verifier_roundtrip.rs
@@ -112,3 +112,131 @@ fn r1cs_prove_verify_roundtrip_ligerito() {
         assert!(matches!(res, Err(VerifyError::PcsAb(_))));
     }
 }
+
+/// AG-skip mirror of the Ligerito roundtrip: prove_ligerito_ag →
+/// verify_ligerito_ag, plus tamper-rejection on the AG round messages, the
+/// c-eval, and the ring-switch s_hat_v (which the AG path claim-checks with
+/// AG base-code skip weights).
+#[cfg(target_arch = "aarch64")]
+#[test]
+#[ignore] // Heavier — run with `cargo test r1cs_prove_verify_roundtrip_ligerito_ag -- --ignored --nocapture`
+fn r1cs_prove_verify_roundtrip_ligerito_ag() {
+    use flock_prover::field::F128;
+    use flock_prover::prover::prove_ligerito_ag;
+
+    let m = 22;
+    let k_log = 16;
+    let k_skip = 6;
+    let r1cs = identity_r1cs(m, k_log, k_skip, 1 << k_log);
+    let mut rng = Rng::new(20_260_625);
+    let z = rng.bits(r1cs.n());
+    assert!(
+        r1cs.satisfies(&z),
+        "identity R1CS: z·z = z holds for boolean z"
+    );
+
+    let pcs_params = PcsParams {
+        m,
+        log_inv_rate: 1,
+        log_batch_size: 6,
+        profile: Default::default(),
+        merkle_hash: Default::default(),
+    };
+    let z_packed = pcs::pack_witness(&z, r1cs.m);
+    let lc_circuit = r1cs.sparse_lincheck_circuit();
+
+    // Honest: prover and verifier with matching transcripts.
+    let mut ch_p = FsChallenger::new(b"flock-ag-r1cs-v0");
+    let (proof, commitment, claim_p) = prove_ligerito_ag(&r1cs, z_packed, &pcs_params, &mut ch_p);
+
+    let mut ch_v = FsChallenger::new(b"flock-ag-r1cs-v0");
+    let claim_v = verifier::verify_ligerito_ag(
+        &r1cs,
+        &commitment,
+        &proof,
+        &lc_circuit,
+        &pcs_params,
+        &mut ch_v,
+    )
+    .unwrap_or_else(|e| panic!("AG ligerito verify rejected honest proof: {e:?}"));
+    assert_eq!(claim_p, claim_v, "verifier claim != prover claim");
+
+    // Tamper 1: corrupt an AG multilinear round message → AG replay rejects.
+    {
+        let mut bad = proof.clone();
+        bad.ag.multilinear_rounds[0].0 += F128::ONE;
+        let mut ch = FsChallenger::new(b"flock-ag-r1cs-v0");
+        assert!(
+            verifier::verify_ligerito_ag(
+                &r1cs,
+                &commitment,
+                &bad,
+                &lc_circuit,
+                &pcs_params,
+                &mut ch
+            )
+            .is_err(),
+            "must reject a tampered AG round message"
+        );
+    }
+
+    // Tamper 2: corrupt the AG c-eval → CEvalMismatch.
+    {
+        let mut bad = proof.clone();
+        bad.ag.final_c_eval += F128::ONE;
+        let mut ch = FsChallenger::new(b"flock-ag-r1cs-v0");
+        assert!(
+            matches!(
+                verifier::verify_ligerito_ag(
+                    &r1cs,
+                    &commitment,
+                    &bad,
+                    &lc_circuit,
+                    &pcs_params,
+                    &mut ch
+                ),
+                Err(VerifyError::Ag(_))
+            ),
+            "must reject a tampered c-eval"
+        );
+    }
+
+    // Tamper 3: corrupt the r1 grinding nonce → BadR1Nonce / downstream reject.
+    {
+        let mut bad = proof.clone();
+        bad.ag.r1_nonce += 1;
+        let mut ch = FsChallenger::new(b"flock-ag-r1cs-v0");
+        assert!(
+            verifier::verify_ligerito_ag(
+                &r1cs,
+                &commitment,
+                &bad,
+                &lc_circuit,
+                &pcs_params,
+                &mut ch
+            )
+            .is_err(),
+            "must reject a tampered r1 nonce"
+        );
+    }
+
+    // Tamper 4: corrupt a ring-switch s_hat_v → the claim_check with AG base
+    // weights (build_claim_weights_from_skip) fails at the PCS open.
+    {
+        let mut bad = proof.clone();
+        bad.pcs_open.ring_switches[0].s_hat_v[0].lo ^= 1;
+        let mut ch = FsChallenger::new(b"flock-ag-r1cs-v0");
+        assert!(
+            verifier::verify_ligerito_ag(
+                &r1cs,
+                &commitment,
+                &bad,
+                &lc_circuit,
+                &pcs_params,
+                &mut ch
+            )
+            .is_err(),
+            "must reject a tampered ring-switch s_hat_v"
+        );
+    }
+}


### PR DESCRIPTION
The AG-skip zerocheck, wired end to end on top of the genus-95 module (previous PR in the stack):

- `zerocheck/ag_skip.rs`: genus-95 round 1, pinned friendly (γ-geometric) challenges, shared multilinear tail, and the prover-side r1 nonce grind — the verifier re-derives r1 with a single attempt; `BadR1Nonce` rejects out-of-budget or non-landing nonces. Includes the lookahead tail kernels (fold1/fold2 lookahead, bivariate-Q message derivation) in `zerocheck/multilinear.rs` — wire-identical to classic, ~44% less steady-state tail traffic.
- **`SkipPoint` (lincheck)**: the `QuirkyPoint`/`LincheckClaim` skip coordinate becomes a two-basis enum — `Phi8(F128)` for RS, `Ag(EvaluationPoint)` for AG — with `.weights()` feeding the generalized claim-weight/quirky-eq builders and `sample_fresh` keeping each claim in its own basis. The layout-aware BlockR1cs point constructors take `SkipPoint`, so the AG path inherits both witness layouts; a batch-major AG roundtrip test pins that.
- **PCS boundary**: `ring_switch::verify`/`verify_succinct` and `verify_opening_batch_ligerito_mixed` take the length-64 skip evaluation functional instead of an `F128` point (callers build φ₈ Lagrange or AG base-code weights). The prover-side open was already skip-agnostic and is unchanged.
- **Hash-parameterized r1 derivation**: `Challenger::hash_kind()` (default SHA-256) selects the nonce-grind's outer hash and expander — SHA-256 counter mode or BLAKE3 XOF — so the sampler follows the FS transcript hash and no second primitive enters the soundness argument in any config. SHA-256 transcripts are byte-identical to before; a BLAKE3-FS roundtrip test pins the arm.
- Prover/verifier plumbing (`R1csProofLigeritoAg`, `prove_ligerito_ag`, `verify_ligerito_ag`/`verify_core_ag`, `Blake3Setup::{prove_fast_ag, verify_ag}`; prover aarch64-gated via the NEON round 1, verifier portable) and the AG bench set.
- `dump_lincheck_vectors` (the CUDA test-vector dumper, which exists only in this repo) adapts to the `SkipPoint` claim types via the `phi8()` accessor — the RS values it writes are byte-unchanged. This adaptation is new code written for this cherry-pick.

### Stack

PR 2 of 4 (#27 ← **this PR** ← #29 ← #30); based on #27's `ag-public/genus95`, merge bottom-up.

This PR carries the soundness-relevant changes of the port and has not had a detailed review anywhere — please review it as new cryptographic code, not as a done deal.

### Review focus

- **Soundness of the r1 nonce grind** (@bbuenz): the prover grinds a nonce so the verifier lands r1 in one rejection-sampling attempt; the attempt budget, the `BadR1Nonce` rejection paths, and the FS ordering around `hash_kind()` deserve close reading.
- The PCS verify-boundary generalization (`z_skip: F128` → `skip_weights: &[F128]`): callers and weight construction on both bases.
- `SkipPoint::sample_fresh` basis discipline (each claim stays in its own basis; AG seeds a hash-matched DRBG from two F128 squeezes and replays the rejection sampler on both sides).
- The `dump_lincheck_vectors` adaptation (@erabinov): it touches your CUDA test-vector dumper; the emitted byte format is unchanged.

### Validation (evidence, not a substitute for review)

- 390 tests pass, plus the heavy `--ignored` AG roundtrips: identity-R1CS with four tamper cases (incl. the r1 nonce), blake3 e2e, batch-major AG.
- SHA-256 transcripts byte-identical to pre-PR; BLAKE3 arm pinned by a roundtrip test.
- fmt/clippy `-D warnings` clean on aarch64 and the x86_64 (znver4) cross-check.
- Pre-existing, unrelated: `pcs_ligerito_backend_roundtrip -- --ignored` fails identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
