### PR TITLE
perf: Ligerito initial-sumcheck lookahead + NTT deep-pass package

### DIFF
--- a/crates/flock-core/src/ntt/additive_ntt_f128.rs
+++ b/crates/flock-core/src/ntt/additive_ntt_f128.rs
@@ -45,6 +45,21 @@ use crate::field::F128;
 
 mod kernels;
 
+/// A/B toggle: when set, the deep (cache-resident) pass of the interleaved
+/// parallel NTT stays on the caller's (P-core) pool instead of hopping to
+/// [`crate::all_core_pool`] for large transforms. `NTT_DEEP_PCORES_ONLY=1`
+/// in the environment forces the same fallback (production kill-switch); the
+/// AtomicBool exists for paired within-process A/B.
+pub static NTT_DEEP_PCORES_ONLY: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// A/B toggle: when set, the deep pass runs every layer as its own sweep
+/// instead of fusing general-width layer pairs. `NTT_DEEP_NOFUSE=1` env is
+/// the production kill-switch; the AtomicBool is for paired within-process
+/// A/B.
+pub static NTT_DEEP_NOFUSE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 /// Compute the normalized subspace-polynomial evaluation table.
 ///
 /// Returns `evals` where `evals[i] = [Ŵ_i(β_i), Ŵ_i(β_{i+1}), …, Ŵ_i(β_{ℓ-1})]`.
@@ -413,25 +428,85 @@ impl AdditiveNttF128 {
         let sub_size_positions = 1usize << (log_d - n_top);
         let sub_bytes = sub_size_positions * num_ntts;
 
-        data.par_chunks_mut(sub_bytes)
-            .enumerate()
-            .for_each(|(sub_idx, sub_data)| {
-                for layer in n_top.max(start_layer)..log_d {
-                    let layer_in_sub = layer - n_top;
-                    let num_blocks_in_sub = 1usize << layer_in_sub;
-                    let block_size = 1usize << (log_d - layer);
-                    let block_size_half = block_size >> 1;
-                    let block_bytes = block_size * num_ntts;
+        // Within each sub-group, fuse consecutive GENERAL-width layer pairs
+        // into one sweep (halves the sub's L1/L2 traffic and the butterfly
+        // load/store count for those layers — the deep pass is compute-bound,
+        // not DRAM-bound, so in-cache traffic and instruction count are what
+        // matter). The three deepest layers stay single-layer: their twiddles
+        // are all half-width (see `mul_small_twiddle`) and the fast path in
+        // `butterfly_interleaved_block` beats fusion's general muls.
+        // `NTT_DEEP_NOFUSE` restores per-layer sweeps (A/B).
+        let fuse = !NTT_DEEP_NOFUSE.load(std::sync::atomic::Ordering::Relaxed)
+            && std::env::var("NTT_DEEP_NOFUSE").is_err();
+        let halfwidth_start = log_d.saturating_sub(3);
+        let deep = |data: &mut [F128]| {
+            data.par_chunks_mut(sub_bytes)
+                .enumerate()
+                .for_each(|(sub_idx, sub_data)| {
+                    let mut layer = n_top.max(start_layer);
+                    while layer < log_d {
+                        let layer_in_sub = layer - n_top;
+                        let num_blocks_in_sub = 1usize << layer_in_sub;
+                        let block_size = 1usize << (log_d - layer);
+                        let block_bytes = block_size * num_ntts;
 
-                    for block_in_sub in 0..num_blocks_in_sub {
-                        let global_block = sub_idx * num_blocks_in_sub + block_in_sub;
-                        let twiddle = self.twiddle(layer, global_block);
-                        let block_start = block_in_sub * block_bytes;
-                        let block = &mut sub_data[block_start..block_start + block_bytes];
-                        butterfly_interleaved_block(block, twiddle, block_size_half, num_ntts);
+                        if fuse && layer + 2 <= halfwidth_start && block_size >= 4 {
+                            let quarter = block_size >> 2;
+                            for block_in_sub in 0..num_blocks_in_sub {
+                                let global_block = sub_idx * num_blocks_in_sub + block_in_sub;
+                                let t_outer = self.twiddle(layer, global_block);
+                                let t_inner_a = self.twiddle(layer + 1, 2 * global_block);
+                                let t_inner_b = self.twiddle(layer + 1, 2 * global_block + 1);
+                                let block_start = block_in_sub * block_bytes;
+                                let block = &mut sub_data[block_start..block_start + block_bytes];
+                                butterfly_interleaved_fused_2layer_serial(
+                                    block, t_outer, t_inner_a, t_inner_b, quarter, num_ntts,
+                                );
+                            }
+                            layer += 2;
+                        } else {
+                            let block_size_half = block_size >> 1;
+                            for block_in_sub in 0..num_blocks_in_sub {
+                                let global_block = sub_idx * num_blocks_in_sub + block_in_sub;
+                                let twiddle = self.twiddle(layer, global_block);
+                                let block_start = block_in_sub * block_bytes;
+                                let block = &mut sub_data[block_start..block_start + block_bytes];
+                                butterfly_interleaved_block(
+                                    block,
+                                    twiddle,
+                                    block_size_half,
+                                    num_ntts,
+                                );
+                            }
+                            layer += 1;
+                        }
                     }
-                }
-            });
+                });
+        };
+        // The deep pass is a flat parallel-for over independent ~2 MB
+        // sub-groups with a single join — measured ~80% PMULL-compute-bound at
+        // m=30 (one streaming pass of traffic, 11 in-cache layers). Unlike the
+        // barrier-per-block top passes, it drains cleanly around slow cores,
+        // and the E-cores have PMULL too — so large transforms hop to the
+        // all-core (P+E) pool. Pool choice cannot change output bits (each
+        // sub-group is written deterministically). Gate: enough sub-groups to
+        // drain (≥ 4× workers) and ≥ 64 MB of data so the pool switch and
+        // E-core L2 pressure can't hurt small/recursive commits.
+        // `NTT_DEEP_PCORES_ONLY` (atomic or env) restores the caller's pool.
+        let n_subs = data.len() / sub_bytes;
+        let use_all_cores = std::mem::size_of_val(data) >= (64 << 20)
+            && !NTT_DEEP_PCORES_ONLY.load(std::sync::atomic::Ordering::Relaxed)
+            && std::env::var("NTT_DEEP_PCORES_ONLY").is_err()
+            && {
+                let pool = crate::all_core_pool();
+                pool.current_num_threads() > rayon::current_num_threads()
+                    && n_subs >= 4 * pool.current_num_threads()
+            };
+        if use_all_cores {
+            crate::all_core_pool().install(|| deep(data));
+        } else {
+            deep(data);
+        }
     }
 
     /// Scalar reference implementation. Used as the test oracle and on
@@ -720,11 +795,88 @@ fn butterfly_interleaved_block_par_rows(
     }
     let half_offset = block_size_half * num_ntts;
     let (top, bot) = block.split_at_mut(half_offset);
+    // Zero-twiddle fast path (see `butterfly_interleaved_block`).
+    if twiddle == F128::ZERO {
+        top.par_chunks_mut(num_ntts)
+            .zip(bot.par_chunks_mut(num_ntts))
+            .for_each(|(top_row, bot_row)| {
+                for lane in 0..num_ntts {
+                    bot_row[lane] += top_row[lane];
+                }
+            });
+        return;
+    }
     top.par_chunks_mut(num_ntts)
         .zip(bot.par_chunks_mut(num_ntts))
         .for_each(|(top_row, bot_row)| {
             kernels::butterfly_row_pair(top_row, bot_row, twiddle);
         });
+}
+
+/// One quarter-row of the fused 2-layer butterfly, with the zero-twiddle
+/// short-circuit for outer block 0 (`t_outer = t_inner_a = 0` — only the
+/// (c,d) inner butterfly multiplies; the branch is per-row, not per-lane).
+/// The general case delegates to the arch-dispatched
+/// [`kernels::butterfly_fused_2layer`].
+#[inline(always)]
+fn fused_2layer_row_op(
+    row_a: &mut [F128],
+    row_b: &mut [F128],
+    row_c: &mut [F128],
+    row_d: &mut [F128],
+    t_outer: F128,
+    t_inner_a: F128,
+    t_inner_b: F128,
+    zero_block: bool,
+    num_ntts: usize,
+) {
+    if zero_block {
+        for lane in 0..num_ntts {
+            let a = row_a[lane];
+            let b = row_b[lane];
+            // Layer L with t_outer=0: a,b unchanged; c += a; d += b.
+            let c = row_c[lane] + a;
+            let d = row_d[lane] + b;
+            // Layer L+1: (a,b) with t_inner_a=0: a unchanged; b += a.
+            row_b[lane] = b + a;
+            // (c,d) with the real t_inner_b.
+            let new_c2 = c + d * t_inner_b;
+            row_c[lane] = new_c2;
+            row_d[lane] = d + new_c2;
+        }
+        return;
+    }
+    kernels::butterfly_fused_2layer(row_a, row_b, row_c, row_d, t_outer, t_inner_a, t_inner_b);
+}
+
+/// Forced-serial fused 2-layer butterfly for use INSIDE the deep pass's
+/// per-sub-group workers (already running one task per pool worker — nested
+/// row-parallelism would only add dispatch overhead). Same math as
+/// [`butterfly_interleaved_fused_2layer_par_rows`].
+fn butterfly_interleaved_fused_2layer_serial(
+    block: &mut [F128],
+    t_outer: F128,
+    t_inner_a: F128,
+    t_inner_b: F128,
+    quarter: usize,
+    num_ntts: usize,
+) {
+    let stride = quarter * num_ntts;
+    debug_assert_eq!(block.len(), 4 * stride);
+    let zero_block = t_outer == F128::ZERO && t_inner_a == F128::ZERO;
+    let (top_half, bot_half) = block.split_at_mut(2 * stride);
+    let (q1, q2) = top_half.split_at_mut(stride);
+    let (q3, q4) = bot_half.split_at_mut(stride);
+    for r in 0..quarter {
+        let off = r * num_ntts;
+        let (q1r, _) = q1[off..].split_at_mut(num_ntts);
+        let (q2r, _) = q2[off..].split_at_mut(num_ntts);
+        let (q3r, _) = q3[off..].split_at_mut(num_ntts);
+        let (q4r, _) = q4[off..].split_at_mut(num_ntts);
+        fused_2layer_row_op(
+            q1r, q2r, q3r, q4r, t_outer, t_inner_a, t_inner_b, zero_block, num_ntts,
+        );
+    }
 }
 
 /// Fused 2-layer butterfly: combines layer L (twiddle `t_outer`, shared by
@@ -752,12 +904,16 @@ fn butterfly_interleaved_fused_2layer_par_rows(
     let stride = quarter * num_ntts;
     debug_assert_eq!(block.len(), 4 * stride);
 
-    let do_one = |row_a: &mut [F128],
-                  row_b: &mut [F128],
-                  row_c: &mut [F128],
-                  row_d: &mut [F128]| {
-        kernels::butterfly_fused_2layer(row_a, row_b, row_c, row_d, t_outer, t_inner_a, t_inner_b);
-    };
+    // Block 0 of the outer layer has t_outer = 0 AND t_inner_a =
+    // twiddle(L+1, 0) = 0 — only the (c,d) inner butterfly multiplies. The
+    // branch is per-row, not per-lane.
+    let zero_block = t_outer == F128::ZERO && t_inner_a == F128::ZERO;
+    let do_one =
+        |row_a: &mut [F128], row_b: &mut [F128], row_c: &mut [F128], row_d: &mut [F128]| {
+            fused_2layer_row_op(
+                row_a, row_b, row_c, row_d, t_outer, t_inner_a, t_inner_b, zero_block, num_ntts,
+            );
+        };
 
     // Split the block into four quarters, then zip row-wise. Each rayon task
     // processes one quarter-row index = 4 logical rows of work.
@@ -799,6 +955,29 @@ fn butterfly_interleaved_fused_2layer_par_rows(
 /// tried but **regressed** by ~10-30% because the explicit batching prevented
 /// ILP across more than 2 muls and added load/store overhead.
 #[inline]
+/// `v · t` for a HALF-WIDTH twiddle (`t.hi == 0`, i.e. deg(t) ≤ 63): the
+/// schoolbook shrinks to 2 PMULL and the 192-bit product needs only a single
+/// reduction fold (overflow deg ≤ 62+7 < 128) — half the cost of the general
+/// multiply. In the polynomial basis `{1, x, x², …}` the THREE DEEPEST layers'
+/// twiddles are all half-width (they are spans/short combinations of low
+/// basis powers): 3/17 ≈ 18% of all NTT mults.
+#[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
+fn mul_small_twiddle(v: F128, t_lo: u64) -> F128 {
+    use core::arch::aarch64::*;
+    unsafe {
+        let d0 = vreinterpretq_u64_p128(vmull_p64(v.lo, t_lo));
+        let d1 = vreinterpretq_u64_p128(vmull_p64(v.hi, t_lo));
+        // 192-bit product: r0 = d0.lo, r1 = d0.hi ^ d1.lo, r2 = d1.hi (r3 = 0).
+        let r2 = vgetq_lane_u64::<1>(d1);
+        // One fold: r2 · (x^7+x^2+x+1) lands entirely within 128 bits.
+        let h = vreinterpretq_u64_p128(vmull_p64(r2, 0x87));
+        F128 {
+            lo: vgetq_lane_u64::<0>(d0) ^ vgetq_lane_u64::<0>(h),
+            hi: vgetq_lane_u64::<1>(d0) ^ vgetq_lane_u64::<0>(d1) ^ vgetq_lane_u64::<1>(h),
+        }
+    }
+}
+
 fn butterfly_interleaved_block(
     block: &mut [F128],
     twiddle: F128,
@@ -806,6 +985,37 @@ fn butterfly_interleaved_block(
     num_ntts: usize,
 ) {
     let off_bot = block_size_half * num_ntts;
+    // Zero-twiddle fast path: block 0 of EVERY layer has twiddle 0
+    // (`twiddle(l, 0) = span_get(_, 0) = 0`), so its butterfly degenerates to
+    // (u, v + u) — no multiply. Σ_l 2^-l ≈ 1 layer-equivalent ≈ 6% of all NTT
+    // mults, and the NTT is mult-throughput-bound.
+    if twiddle == F128::ZERO {
+        for r in 0..block_size_half {
+            let off_top = r * num_ntts;
+            let off_bot_r = off_top + off_bot;
+            for lane in 0..num_ntts {
+                let u = block[off_top + lane];
+                block[off_bot_r + lane] += u;
+            }
+        }
+        return;
+    }
+    // Half-width-twiddle fast path (see `mul_small_twiddle`): the deep layers
+    // this kernel serves are exactly where all twiddles are half-width.
+    #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
+    if twiddle.hi == 0 {
+        for r in 0..block_size_half {
+            let off_top = r * num_ntts;
+            let off_bot_r = off_top + off_bot;
+            for lane in 0..num_ntts {
+                let v = block[off_bot_r + lane];
+                let new_u = block[off_top + lane] + mul_small_twiddle(v, twiddle.lo);
+                block[off_top + lane] = new_u;
+                block[off_bot_r + lane] = v + new_u;
+            }
+        }
+        return;
+    }
     let (top, bot) = block.split_at_mut(off_bot);
     for r in 0..block_size_half {
         let o = r * num_ntts;

--- a/crates/flock-core/src/pcs.rs
+++ b/crates/flock-core/src/pcs.rs
@@ -146,6 +146,7 @@ pub fn open_batch_mixed_ligerito_with_precomputed_s_hat_v<Ch: Challenger>(
         &prover_data.codeword,
         &prover_data.merkle_tree,
         combined.round0_prime,
+        combined.round1_lookahead,
         challenger,
     );
     if trace {
@@ -173,6 +174,11 @@ struct CombinedClaim {
     /// Round-0 sumcheck `(u_0, u_2)` prime over `packed_witness · b_combined`,
     /// consumed by `recursive_prover_with_basis_precomputed_round0`.
     round0_prime: (F128, F128),
+    /// Quadratic coefficients of Ligerito's ROUND-1 message in the round-0
+    /// fold challenge, accumulated in the same combine pass (fast path with
+    /// no packed-direct claims only). Lets the recursive prover's first lane
+    /// fold be an O(1) skip round — see [`ligerito::FoldLookahead`].
+    round1_lookahead: Option<ligerito::FoldLookahead>,
 }
 
 /// Runs ring_switch over RS claims, observes packed-direct claim values +
@@ -310,57 +316,107 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
     let use_fast =
         !rs_deferred.is_empty() && rs_deferred.len() == rs_results.len() && pd_dense.is_empty();
 
-    // The combine is a flat block-parallel pass that drains cleanly around
-    // slow cores — run it on the all-core (P+E) pool (−29% on the probe on
-    // 4P+4E; a wash-to-slight-loss on 10P+4E, so gated on
-    // [`crate::ecore_rich_topology`], `FLOCK_ALLCORE=1` overrides).
+    // The combine is compute-bound (open_combine_probe: ~4.3 ms traffic floor
+    // vs ~18 ms total at m=30 on 4 P-threads), and its flat block-parallel
+    // shape drains cleanly around slow cores — run it on the all-core (P+E)
+    // pool (−29% on the probe on 4P+4E; a wash-to-slight-loss on 10P+4E, so
+    // gated on [`crate::ecore_rich_topology`], `FLOCK_ALLCORE=1` overrides).
     // PCS_COMBINE_PCORES_ONLY=1 keeps it on the caller's pool (A/B toggle).
     // Thread count never changes the output bits: every slot is written
     // deterministically and the prime is an XOR reduction (associative +
     // commutative, exact).
     let combine_all_cores =
         std::env::var("PCS_COMBINE_PCORES_ONLY").is_err() && crate::ecore_rich_topology();
+    // With no packed-direct claims nothing is scatter-added after the fast
+    // path, so the block tail can also accumulate Ligerito's round-1 message
+    // coefficients (groups of 4; +1 unreduced mul per slot) — the round-0
+    // prime falls out of the same accumulators. See `CombinedClaim`.
+    let want_lookahead = use_fast && packed_direct.is_empty();
+    let mut round1_lookahead: Option<ligerito::FoldLookahead> = None;
+    let b_combined_ref = &mut b_combined;
+    let la_ref = &mut round1_lookahead;
     let mut combine = || {
         if use_fast {
+            use crate::field::F256Unreduced;
             let b = rs_deferred[0].0.len(); // eq_lo.len(); shared across claims (same split)
             debug_assert!(b >= 2 && b.is_multiple_of(2));
             debug_assert!(rs_deferred.iter().all(|d| d.0.len() == b));
-            b_combined
-                .par_chunks_mut(b)
-                .enumerate()
-                .map(|(hi, out_block)| {
-                    // Accumulate each claim's block: first claim writes, rest add.
-                    // `e_hi` is read once per claim per block, then swept over eq_lo.
-                    for (ci, (eq_lo, eq_hi, table, _)) in rs_deferred.iter().enumerate() {
-                        let e_hi = eq_hi[hi];
-                        if ci == 0 {
-                            for (slot, &lo) in out_block.iter_mut().zip(eq_lo.iter()) {
-                                *slot = ring_switch::fold_one_slot(lo * e_hi, table);
-                            }
-                        } else {
-                            for (slot, &lo) in out_block.iter_mut().zip(eq_lo.iter()) {
-                                *slot += ring_switch::fold_one_slot(lo * e_hi, table);
-                            }
+            let fold_block = |hi: usize, out_block: &mut [F128]| {
+                // Accumulate each claim's block: first claim writes, rest add.
+                // `e_hi` is read once per claim per block, then swept over eq_lo.
+                for (ci, (eq_lo, eq_hi, table, _)) in rs_deferred.iter().enumerate() {
+                    let e_hi = eq_hi[hi];
+                    if ci == 0 {
+                        for (slot, &lo) in out_block.iter_mut().zip(eq_lo.iter()) {
+                            *slot = ring_switch::fold_one_slot(lo * e_hi, table);
+                        }
+                    } else {
+                        for (slot, &lo) in out_block.iter_mut().zip(eq_lo.iter()) {
+                            *slot += ring_switch::fold_one_slot(lo * e_hi, table);
                         }
                     }
-                    // Round-0 prime over this block's pairs (b is even, base is even).
-                    let base = hi * b;
-                    let mut u0 = F128::ZERO;
-                    let mut u2 = F128::ZERO;
-                    for t in 0..(b / 2) {
-                        let s0 = out_block[2 * t];
-                        let s1 = out_block[2 * t + 1];
-                        let a0 = packed_witness[base + 2 * t];
-                        let a1 = packed_witness[base + 2 * t + 1];
-                        u0 += a0 * s0;
-                        u2 += (a0 + a1) * (s0 + s1);
-                    }
-                    (u0, u2)
-                })
-                .reduce(
-                    || (F128::ZERO, F128::ZERO),
-                    |(x0, x2), (y0, y2)| (x0 + y0, x2 + y2),
-                )
+                }
+            };
+            if want_lookahead && b.is_multiple_of(4) {
+                // Fused prime + round-1 lookahead tail (groups of 4).
+                let acc = b_combined_ref
+                    .par_chunks_mut(b)
+                    .enumerate()
+                    .map(|(hi, out_block)| {
+                        fold_block(hi, out_block);
+                        let base = hi * b;
+                        let mut acc = [F256Unreduced::ZERO; 8];
+                        for g in 0..(b / 4) {
+                            let i = 4 * g;
+                            let fq = [
+                                packed_witness[base + i],
+                                packed_witness[base + i + 1],
+                                packed_witness[base + i + 2],
+                                packed_witness[base + i + 3],
+                            ];
+                            let bq = [
+                                out_block[i],
+                                out_block[i + 1],
+                                out_block[i + 2],
+                                out_block[i + 3],
+                            ];
+                            ligerito::lookahead_accum_group(&fq, &bq, &mut acc);
+                        }
+                        acc
+                    })
+                    .reduce(|| [F256Unreduced::ZERO; 8], ligerito::xor_acc8);
+                let (msg, la) = ligerito::lookahead_finish(acc);
+                *la_ref = Some(la);
+                (msg.u_0, msg.u_2)
+            } else {
+                let (u0, u2) = b_combined_ref
+                    .par_chunks_mut(b)
+                    .enumerate()
+                    .map(|(hi, out_block)| {
+                        fold_block(hi, out_block);
+                        // Round-0 prime over this block's pairs (b is even, base is
+                        // even). Unreduced 256-bit accumulation, one reduction at
+                        // the very end (XOR-linear, bit-identical to reducing per
+                        // term).
+                        let base = hi * b;
+                        let mut u0 = F256Unreduced::ZERO;
+                        let mut u2 = F256Unreduced::ZERO;
+                        for t in 0..(b / 2) {
+                            let s0 = out_block[2 * t];
+                            let s1 = out_block[2 * t + 1];
+                            let a0 = packed_witness[base + 2 * t];
+                            let a1 = packed_witness[base + 2 * t + 1];
+                            u0 ^= a0.mul_unreduced(s0);
+                            u2 ^= (a0 + a1).mul_unreduced(s0 + s1);
+                        }
+                        (u0, u2)
+                    })
+                    .reduce(
+                        || (F256Unreduced::ZERO, F256Unreduced::ZERO),
+                        |(x0, x2), (y0, y2)| (x0 ^ y0, x2 ^ y2),
+                    );
+                (u0.reduce(), u2.reduce())
+            }
         } else {
             // General path (mixed / sparse / packed-direct): materialize any
             // deferred-dense claims (parallel block fold), then the per-element
@@ -379,7 +435,7 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
                 .collect();
             let mut rs_dense_all: Vec<&[F128]> = rs_baked.clone();
             rs_dense_all.extend(materialized.iter().map(|v| v.as_slice()));
-            let prime = b_combined
+            let prime = b_combined_ref
                 .par_chunks_mut(2)
                 .enumerate()
                 .map(|(i, chunk)| {
@@ -425,6 +481,13 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
     };
     for (_, output) in rs_results.iter() {
         if let ring_switch::RsEqInd::Sparse { entries, .. } = &output.rs_eq_ind {
+            // Post-combine mutation of b_combined: the round-1 lookahead
+            // coefficients (if any) are now stale. Unreachable when they are
+            // emitted (fast path = no sparse RS claims), but keep the
+            // invalidation in case the emission condition ever widens.
+            if !entries.is_empty() {
+                round1_lookahead = None;
+            }
             for &(idx, val) in entries {
                 b_combined[idx] += val;
                 adjust_prime_for_delta(idx, val);
@@ -433,6 +496,7 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
     }
     for (pd, g) in packed_direct.iter().zip(gammas_pd.iter()) {
         if let DirectEqInd::Sparse(eq) = &pd.eq_ind {
+            round1_lookahead = None; // see above — pd claims never emit coeffs
             // Scatter-add the sparse claim and fold its round-0 prime
             // contribution in the SAME pass (O(live positions)), instead of a
             // full O(L) re-pass over b_combined. The prime is linear in
@@ -467,6 +531,7 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
         b_combined,
         target_combined,
         round0_prime: (round0_u0, round0_u2),
+        round1_lookahead,
     }
 }
 

--- a/crates/flock-core/src/pcs/ligerito.rs
+++ b/crates/flock-core/src/pcs/ligerito.rs
@@ -2586,55 +2586,63 @@ fn partial_eval_lsb_one(evals: &mut Vec<F128>, r: F128) {
 /// Returns `(folded_f, folded_b, next_msg)` where `next_msg = round_msg_lsb
 /// (folded_f, folded_b)`. Bit-identical to the unfused sequence.
 fn fold_and_msg_lsb(f: &[F128], b: &[F128], r: F128) -> (Vec<F128>, Vec<F128>, SumcheckMessage) {
+    use crate::field::F256Unreduced;
     use rayon::prelude::*;
     let n = f.len();
     debug_assert!(n.is_power_of_two() && n >= 2);
     debug_assert_eq!(b.len(), n);
     let half = n / 2;
-    let one_plus_r = F128::ONE + r;
 
+    // Fold with ONE mul per output via `v0 + r·(v0 + v1)` (= `(1+r)·v0 + r·v1`
+    // exactly in GF(2^128)), and accumulate the message as unreduced 256-bit
+    // products, reduced once at the end — reduction is XOR-linear, so the
+    // result is bit-identical to the reduced-per-term sum.
     const PAR_THRESHOLD: usize = 4096;
     if half < PAR_THRESHOLD {
         let mut nf = Vec::with_capacity(half);
         let mut nb = Vec::with_capacity(half);
         for j in 0..half {
-            nf.push(f[2 * j] * one_plus_r + f[2 * j + 1] * r);
-            nb.push(b[2 * j] * one_plus_r + b[2 * j + 1] * r);
+            let f0 = f[2 * j];
+            let b0 = b[2 * j];
+            nf.push(f0 + (f0 + f[2 * j + 1]) * r);
+            nb.push(b0 + (b0 + b[2 * j + 1]) * r);
         }
-        let mut u_0 = F128::ZERO;
-        let mut u_2 = F128::ZERO;
+        let mut u_0 = F256Unreduced::ZERO;
+        let mut u_2 = F256Unreduced::ZERO;
         let mut k = 0;
         while k + 1 < half {
             let f0 = nf[k];
             let f1 = nf[k + 1];
             let b0 = nb[k];
             let b1 = nb[k + 1];
-            u_0 += f0 * b0;
-            u_2 += (f0 + f1) * (b0 + b1);
+            u_0 ^= f0.mul_unreduced(b0);
+            u_2 ^= (f0 + f1).mul_unreduced(b0 + b1);
             k += 2;
         }
-        return (nf, nb, SumcheckMessage { u_0, u_2 });
+        return (
+            nf,
+            nb,
+            SumcheckMessage {
+                u_0: u_0.reduce(),
+                u_2: u_2.reduce(),
+            },
+        );
     }
 
     // Parallel path: `half` is a power of two ≥ PAR_THRESHOLD and CHUNK is a
     // power of two, so every chunk has even length and starts at an even
     // global index — message pairs (2k, 2k+1) never straddle a chunk boundary.
+    //
+    // Output buffers come from the scratch pool: a fresh 64 MB alloc per fold
+    // round pays first-touch page faults inside the parallel loop and a
+    // single-threaded munmap on drop of the old buffer — measured as the
+    // dominant cost of the open's initial sumcheck (~18 ms → ~7 ms at m=30
+    // for the 6-fold chain once both buffers recycle through the pool; the
+    // caller returns the outgoing pair via `scratch::give_f128`, see
+    // [`SumcheckProver::fold`]).
     const CHUNK: usize = 2048;
-    // On x86_64, pull the fold outputs from the prewarmed scratch pool (the
-    // prover gives the previous round's buffers back in `SumcheckProver::fold`),
-    // so the initial sumcheck reuses resident pages instead of faulting ~128 MB
-    // of fresh memory every round. On aarch64 this pooling measured slower, so
-    // there we allocate fresh each round.
-    #[cfg(target_arch = "x86_64")]
-    let (mut nf, mut nb) = (
-        crate::scratch::take_f128(half),
-        crate::scratch::take_f128(half),
-    );
-    #[cfg(not(target_arch = "x86_64"))]
-    let (mut nf, mut nb) = (
-        crate::alloc_uninit_f128_vec(half),
-        crate::alloc_uninit_f128_vec(half),
-    );
+    let mut nf = crate::scratch::take_f128(half);
+    let mut nb = crate::scratch::take_f128(half);
     let (u_0, u_2) = nf
         .par_chunks_mut(CHUNK)
         .zip(nb.par_chunks_mut(CHUNK))
@@ -2642,9 +2650,12 @@ fn fold_and_msg_lsb(f: &[F128], b: &[F128], r: F128) -> (Vec<F128>, Vec<F128>, S
         .map(|(ci, (fc, bc))| {
             let base = ci * CHUNK;
             let len = fc.len();
-            let mut u0 = F128::ZERO;
-            let mut u2 = F128::ZERO;
-            // Fold this slice, then pair up the just-folded values for the msg.
+            let mut u0 = F256Unreduced::ZERO;
+            let mut u2 = F256Unreduced::ZERO;
+            // Fold this slice via the arch-dispatched slice kernel (AVX-512 on
+            // x86, NEON on aarch64), then pair up the just-folded values for
+            // the msg. `src[2j]·(1+r) + src[2j+1]·r = v0 + (v0+v1)·r` exactly
+            // in GF(2^128), so the kernel choice cannot change the bits.
             crate::field::f128_slice::fold_pairs(f, base, fc, r);
             crate::field::f128_slice::fold_pairs(b, base, bc, r);
             let mut k = 0;
@@ -2653,17 +2664,266 @@ fn fold_and_msg_lsb(f: &[F128], b: &[F128], r: F128) -> (Vec<F128>, Vec<F128>, S
                 let f1 = fc[k + 1];
                 let b0 = bc[k];
                 let b1 = bc[k + 1];
-                u0 += f0 * b0;
-                u2 += (f0 + f1) * (b0 + b1);
+                u0 ^= f0.mul_unreduced(b0);
+                u2 ^= (f0 + f1).mul_unreduced(b0 + b1);
                 k += 2;
             }
             (u0, u2)
         })
         .reduce(
-            || (F128::ZERO, F128::ZERO),
-            |(a0, a2), (c0, c2)| (a0 + c0, a2 + c2),
+            || (F256Unreduced::ZERO, F256Unreduced::ZERO),
+            |(a0, a2), (c0, c2)| (a0 ^ c0, a2 ^ c2),
         );
-    (nf, nb, SumcheckMessage { u_0, u_2 })
+    (
+        nf,
+        nb,
+        SumcheckMessage {
+            u_0: u_0.reduce(),
+            u_2: u_2.reduce(),
+        },
+    )
+}
+
+/// Quadratic coefficients of the NEXT round's message as a polynomial in the
+/// not-yet-sampled fold challenge `r`:
+/// `u_0(r) = u0[0] + r·u0[1] + r²·u0[2]` (same for `u_2`).
+///
+/// Produced by the lookahead fold passes ([`fold1_lookahead_lsb`] /
+/// [`fold2_lookahead_lsb`]) so the round in between two passes costs an O(1)
+/// polynomial evaluation instead of a full array pass. The evaluated message
+/// equals the direct `round_msg_lsb` over the folded arrays by exact
+/// polynomial identity (every op is exact in GF(2^128)), so the transcript is
+/// bit-identical.
+#[derive(Clone, Copy, Debug)]
+pub struct FoldLookahead {
+    u0: [F128; 3],
+    u2: [F128; 3],
+}
+
+use crate::field::F256Unreduced;
+
+impl FoldLookahead {
+    #[inline]
+    fn eval(&self, r: F128) -> SumcheckMessage {
+        let r2 = r * r;
+        SumcheckMessage {
+            u_0: self.u0[0] + r * self.u0[1] + r2 * self.u0[2],
+            u_2: self.u2[0] + r * self.u2[1] + r2 * self.u2[2],
+        }
+    }
+}
+
+/// Shared per-group-of-4 kernel for the lookahead passes: given 4 freshly
+/// folded consecutive outputs of each array (still in registers), accumulate
+/// - this round's message contribution (pairs `(0,1)` and `(2,3)`), and
+/// - the quadratic coefficients of the NEXT round's message in the future
+///   challenge `r'` (next fold pairs `(0,1)`→slot 0 and `(2,3)`→slot 1; next
+///   message pairs those two slots).
+///
+/// Accumulator layout: `[u0, u2, c0, c1, c2, d0, d1, d2]` where `c*` are the
+/// `u_0(r')` coefficients and `d*` the `u_2(r')` coefficients.
+///
+/// 8 unreduced muls per group (Karatsuba middle terms: the `r'`-linear
+/// coefficient is `m1 + m2 + (A+dA)(B+dB)` — exact in char 2).
+#[inline(always)]
+pub(crate) fn lookahead_accum_group(fq: &[F128; 4], bq: &[F128; 4], acc: &mut [F256Unreduced; 8]) {
+    let a0 = fq[0];
+    let da0 = fq[0] + fq[1];
+    let a1 = fq[2];
+    let da1 = fq[2] + fq[3];
+    let b0 = bq[0];
+    let db0 = bq[0] + bq[1];
+    let b1 = bq[2];
+    let db1 = bq[2] + bq[3];
+
+    let m1 = a0.mul_unreduced(b0);
+    let m2 = da0.mul_unreduced(db0);
+    let m3 = (a0 + da0).mul_unreduced(b0 + db0);
+    let p1 = a1.mul_unreduced(b1);
+    let p2 = da1.mul_unreduced(db1);
+    let n1 = (a0 + a1).mul_unreduced(b0 + b1);
+    let n2 = (da0 + da1).mul_unreduced(db0 + db1);
+    let n3 = (a0 + a1 + da0 + da1).mul_unreduced(b0 + b1 + db0 + db1);
+
+    // This round's message: pairs (0,1) and (2,3).
+    acc[0] ^= m1 ^ p1; // u_0 += A0·B0 + A1·B1
+    acc[1] ^= m2 ^ p2; // u_2 += dA0·dB0 + dA1·dB1
+    // Next round's u_0(r') = Σ (A0 + r'·dA0)(B0 + r'·dB0).
+    acc[2] ^= m1;
+    acc[3] ^= m1 ^ m2 ^ m3;
+    acc[4] ^= m2;
+    // Next round's u_2(r') = Σ (S + r'·dS)(T + r'·dT), S = A0+A1 etc.
+    acc[5] ^= n1;
+    acc[6] ^= n1 ^ n2 ^ n3;
+    acc[7] ^= n2;
+}
+
+/// Reduce the 8 lookahead accumulators into `(msg, coeffs)`.
+#[inline]
+pub(crate) fn lookahead_finish(acc: [F256Unreduced; 8]) -> (SumcheckMessage, FoldLookahead) {
+    (
+        SumcheckMessage {
+            u_0: acc[0].reduce(),
+            u_2: acc[1].reduce(),
+        },
+        FoldLookahead {
+            u0: [acc[2].reduce(), acc[3].reduce(), acc[4].reduce()],
+            u2: [acc[5].reduce(), acc[6].reduce(), acc[7].reduce()],
+        },
+    )
+}
+
+#[inline]
+pub(crate) fn xor_acc8(mut a: [F256Unreduced; 8], b: [F256Unreduced; 8]) -> [F256Unreduced; 8] {
+    for k in 0..8 {
+        a[k] ^= b[k];
+    }
+    a
+}
+
+/// Entry lookahead pass: fold ONE variable (`n → n/2`) and return this
+/// round's message plus the next round's [`FoldLookahead`] coefficients.
+/// Identical fold/message values to [`fold_and_msg_lsb`]; the extra
+/// coefficients cost ~1 extra mul per output in the same pass.
+fn fold1_lookahead_lsb(
+    f: &[F128],
+    b: &[F128],
+    r: F128,
+) -> (Vec<F128>, Vec<F128>, SumcheckMessage, FoldLookahead) {
+    use rayon::prelude::*;
+    let n = f.len();
+    debug_assert_eq!(b.len(), n);
+    let half = n / 2;
+    assert!(
+        n.is_power_of_two() && half >= 4 && half.is_multiple_of(4),
+        "fold1_lookahead_lsb: need n ≥ 8"
+    );
+
+    const CHUNK: usize = 2048;
+    let mut nf = crate::scratch::take_f128(half);
+    let mut nb = crate::scratch::take_f128(half);
+    let acc = nf
+        .par_chunks_mut(CHUNK)
+        .zip(nb.par_chunks_mut(CHUNK))
+        .enumerate()
+        .map(|(ci, (fc, bc))| {
+            let base = ci * CHUNK;
+            let len = fc.len();
+            debug_assert!(len.is_multiple_of(4) || len == half - base);
+            let mut acc = [F256Unreduced::ZERO; 8];
+            // Fold this slice (1 mul per output per array)…
+            for t in 0..len {
+                let j = base + t;
+                let f0 = f[2 * j];
+                let f1 = f[2 * j + 1];
+                let b0 = b[2 * j];
+                let b1 = b[2 * j + 1];
+                fc[t] = f0 + (f0 + f1) * r;
+                bc[t] = b0 + (b0 + b1) * r;
+            }
+            // …then message + lookahead over groups of 4 just-written outputs.
+            let mut g = 0;
+            while g + 4 <= len {
+                let fq = [fc[g], fc[g + 1], fc[g + 2], fc[g + 3]];
+                let bq = [bc[g], bc[g + 1], bc[g + 2], bc[g + 3]];
+                lookahead_accum_group(&fq, &bq, &mut acc);
+                g += 4;
+            }
+            acc
+        })
+        .reduce(|| [F256Unreduced::ZERO; 8], xor_acc8);
+    let (msg, la) = lookahead_finish(acc);
+    (nf, nb, msg, la)
+}
+
+/// Steady-state lookahead pass: fold TWO variables (`n → n/4`, challenges
+/// `r_a` then `r_b`) and return the message after both folds plus the next
+/// round's [`FoldLookahead`]. Values are bit-identical to two sequential
+/// [`fold_and_msg_lsb`] rounds, at ~55% of their memory traffic (the
+/// intermediate half-size arrays are never materialized).
+fn fold2_lookahead_lsb(
+    f: &[F128],
+    b: &[F128],
+    r_a: F128,
+    r_b: F128,
+) -> (Vec<F128>, Vec<F128>, SumcheckMessage, FoldLookahead) {
+    use rayon::prelude::*;
+    let n = f.len();
+    debug_assert_eq!(b.len(), n);
+    let quarter = n / 4;
+    assert!(
+        n.is_power_of_two() && quarter >= 4 && quarter.is_multiple_of(4),
+        "fold2_lookahead_lsb: need n ≥ 16"
+    );
+
+    const CHUNK: usize = 2048;
+    let mut nf = crate::scratch::take_f128(quarter);
+    let mut nb = crate::scratch::take_f128(quarter);
+    let acc = nf
+        .par_chunks_mut(CHUNK)
+        .zip(nb.par_chunks_mut(CHUNK))
+        .enumerate()
+        .map(|(ci, (fc, bc))| {
+            let base = ci * CHUNK;
+            let len = fc.len();
+            let mut acc = [F256Unreduced::ZERO; 8];
+            // Fold 4→1 (3 muls per output per array), 4 outputs per group.
+            let mut g = 0;
+            while g < len {
+                let glen = (len - g).min(4);
+                let mut fq = [F128::ZERO; 4];
+                let mut bq = [F128::ZERO; 4];
+                for t in 0..glen {
+                    let j = base + g + t;
+                    let i = 4 * j;
+                    let gf0 = f[i] + (f[i] + f[i + 1]) * r_a;
+                    let gf1 = f[i + 2] + (f[i + 2] + f[i + 3]) * r_a;
+                    let gb0 = b[i] + (b[i] + b[i + 1]) * r_a;
+                    let gb1 = b[i + 2] + (b[i + 2] + b[i + 3]) * r_a;
+                    let vf = gf0 + (gf0 + gf1) * r_b;
+                    let vb = gb0 + (gb0 + gb1) * r_b;
+                    fc[g + t] = vf;
+                    bc[g + t] = vb;
+                    fq[t] = vf;
+                    bq[t] = vb;
+                }
+                debug_assert_eq!(glen, 4);
+                lookahead_accum_group(&fq, &bq, &mut acc);
+                g += glen;
+            }
+            acc
+        })
+        .reduce(|| [F256Unreduced::ZERO; 8], xor_acc8);
+    let (msg, la) = lookahead_finish(acc);
+    (nf, nb, msg, la)
+}
+
+/// Fold both arrays by `r` with NO message computation (write-only drain for
+/// a pending lookahead challenge at the end of an odd-length schedule).
+fn fold_pair_no_msg(f: &[F128], b: &[F128], r: F128) -> (Vec<F128>, Vec<F128>) {
+    use rayon::prelude::*;
+    let n = f.len();
+    debug_assert_eq!(b.len(), n);
+    let half = n / 2;
+    let mut nf = crate::scratch::take_f128(half);
+    let mut nb = crate::scratch::take_f128(half);
+    const CHUNK: usize = 2048;
+    nf.par_chunks_mut(CHUNK)
+        .zip(nb.par_chunks_mut(CHUNK))
+        .enumerate()
+        .for_each(|(ci, (fc, bc))| {
+            let base = ci * CHUNK;
+            for t in 0..fc.len() {
+                let j = base + t;
+                let f0 = f[2 * j];
+                let f1 = f[2 * j + 1];
+                let b0 = b[2 * j];
+                let b1 = b[2 * j + 1];
+                fc[t] = f0 + (f0 + f1) * r;
+                bc[t] = b0 + (b0 + b1) * r;
+            }
+        });
+    (nf, nb)
 }
 
 pub struct SumcheckProver {
@@ -2676,6 +2936,11 @@ pub struct SumcheckProver {
     t_r: F128,
     transcript: Vec<SumcheckMessage>,
     pending_glue: Option<(Vec<F128>, F128)>,
+    /// Lookahead bookkeeping: a fold challenge whose array fold is deferred
+    /// to the next lookahead pass (the round's message was already produced
+    /// by [`FoldLookahead::eval`]). Must be `None` (drained) before any
+    /// non-lookahead operation touches `f`/`combined_basis`.
+    pending_fold: Option<F128>,
 }
 
 impl SumcheckProver {
@@ -2687,6 +2952,7 @@ impl SumcheckProver {
             t_r: h1,
             transcript: Vec::new(),
             pending_glue: None,
+            pending_fold: None,
         };
         let msg = round_msg_lsb(&inst.f, &inst.combined_basis);
         inst.transcript.push(msg);
@@ -2711,38 +2977,79 @@ impl SumcheckProver {
             t_r: h1,
             transcript: Vec::new(),
             pending_glue: None,
+            pending_fold: None,
         };
         inst.transcript.push(first_msg);
         (inst, first_msg)
     }
 
     pub fn fold(&mut self, r: F128) -> SumcheckMessage {
+        debug_assert!(self.pending_fold.is_none(), "fold with pending lookahead");
         // Fused: fold f and combined_basis at r AND build the next-round
         // message in one parallel pass (was three passes). See
         // [`fold_and_msg_lsb`].
         let (nf, nb, msg) = fold_and_msg_lsb(&self.f, &self.combined_basis, r);
-        // On x86_64, recycle the just-consumed buffers into the scratch pool
-        // (same ownership as the Drop impl) so the next round's
-        // `fold_and_msg_lsb` takes resident pages. aarch64 measured slower with
-        // this pooling, so there we just move the new buffers in and drop the
-        // old ones.
-        #[cfg(target_arch = "x86_64")]
-        {
+        // Recycle the outgoing buffers (the round-0 pair is the 2^(m-7)
+        // packed witness + b_combined) instead of munmap-ing them.
+        crate::scratch::give_f128(std::mem::replace(&mut self.f, nf));
+        crate::scratch::give_f128(std::mem::replace(&mut self.combined_basis, nb));
+        self.transcript.push(msg);
+        msg
+    }
+
+    /// Lookahead entry: like [`Self::fold`] but also returns the next round's
+    /// message coefficients (see [`FoldLookahead`]). Same fold + message
+    /// values as `fold(r)`.
+    pub fn fold1_lookahead(&mut self, r: F128) -> (SumcheckMessage, FoldLookahead) {
+        debug_assert!(self.pending_fold.is_none(), "fold1 with pending lookahead");
+        let (nf, nb, msg, la) = fold1_lookahead_lsb(&self.f, &self.combined_basis, r);
+        crate::scratch::give_f128(std::mem::replace(&mut self.f, nf));
+        crate::scratch::give_f128(std::mem::replace(&mut self.combined_basis, nb));
+        self.transcript.push(msg);
+        (msg, la)
+    }
+
+    /// Lookahead skip round: produce this round's message by evaluating the
+    /// previous pass's coefficients at `r` — O(1), no array pass. The actual
+    /// fold by `r` is deferred to the next [`Self::fold2_lookahead`] (or
+    /// [`Self::drain_pending_fold`]). The message value is identical to
+    /// `fold(r)`'s by exact polynomial identity.
+    pub fn fold_skip(&mut self, la: &FoldLookahead, r: F128) -> SumcheckMessage {
+        debug_assert!(self.pending_fold.is_none(), "double lookahead skip");
+        let msg = la.eval(r);
+        self.pending_fold = Some(r);
+        self.transcript.push(msg);
+        msg
+    }
+
+    /// Lookahead steady state: fold the pending challenge AND `r` in one
+    /// 4→1 pass, returning the post-fold message + next coefficients.
+    pub fn fold2_lookahead(&mut self, r: F128) -> (SumcheckMessage, FoldLookahead) {
+        let r_a = self
+            .pending_fold
+            .take()
+            .expect("fold2_lookahead without pending challenge");
+        let (nf, nb, msg, la) = fold2_lookahead_lsb(&self.f, &self.combined_basis, r_a, r);
+        crate::scratch::give_f128(std::mem::replace(&mut self.f, nf));
+        crate::scratch::give_f128(std::mem::replace(&mut self.combined_basis, nb));
+        self.transcript.push(msg);
+        (msg, la)
+    }
+
+    /// Materialize a pending lookahead fold (message was already sent by
+    /// [`Self::fold_skip`]). No-op when nothing is pending.
+    pub fn drain_pending_fold(&mut self) {
+        if let Some(r) = self.pending_fold.take() {
+            let (nf, nb) = fold_pair_no_msg(&self.f, &self.combined_basis, r);
             crate::scratch::give_f128(std::mem::replace(&mut self.f, nf));
             crate::scratch::give_f128(std::mem::replace(&mut self.combined_basis, nb));
         }
-        #[cfg(not(target_arch = "x86_64"))]
-        {
-            self.f = nf;
-            self.combined_basis = nb;
-        }
-        self.transcript.push(msg);
-        msg
     }
 
     /// Introduce a fresh basis poly with claimed sum `h_new`. Sends the
     /// (u_0, u_2) for `Σ_x f(x) · b_new(x)` at the current dim.
     pub fn introduce_new(&mut self, b_new: Vec<F128>, h_new: F128) -> SumcheckMessage {
+        debug_assert!(self.pending_fold.is_none(), "introduce with pending fold");
         assert_eq!(b_new.len(), self.f.len());
         let msg = round_msg_lsb(&self.f, &b_new);
         self.transcript.push(msg);
@@ -2757,6 +3064,7 @@ impl SumcheckProver {
     /// fold over `f`. Transcript-identical: the caller observes the returned
     /// `h_new` then `(u_0, u_2)`, exactly as the unfused path does.
     pub fn introduce_new_with_eval(&mut self, b_new: Vec<F128>) -> (SumcheckMessage, F128) {
+        debug_assert!(self.pending_fold.is_none(), "introduce with pending fold");
         assert_eq!(b_new.len(), self.f.len());
         let (msg, h_new) = round_msg_and_eval_lsb(&self.f, &b_new);
         self.transcript.push(msg);
@@ -2789,7 +3097,18 @@ impl SumcheckProver {
     }
 
     pub fn f(&self) -> &[F128] {
+        debug_assert!(self.pending_fold.is_none(), "f() with pending fold");
         &self.f
+    }
+
+    /// Current (materialized) array length; a pending lookahead fold is not
+    /// yet applied to it.
+    pub fn f_len(&self) -> usize {
+        self.f.len()
+    }
+
+    pub fn has_pending_fold(&self) -> bool {
+        self.pending_fold.is_some()
     }
 
     pub fn transcript(&self) -> &[SumcheckMessage] {
@@ -3018,6 +3337,7 @@ pub fn recursive_prover_with_basis<Ch: Challenger>(
         l0_codeword,
         l0_tree,
         None,
+        None,
         challenger,
     )
 }
@@ -3036,6 +3356,7 @@ pub fn recursive_prover_with_basis_precomputed_round0<Ch: Challenger>(
     l0_codeword: &[F128],
     l0_tree: &[Hash],
     round0_uv: (F128, F128),
+    round1_lookahead: Option<FoldLookahead>,
     challenger: &mut Ch,
 ) -> LigeritoProof {
     recursive_prover_with_basis_impl(
@@ -3049,6 +3370,7 @@ pub fn recursive_prover_with_basis_precomputed_round0<Ch: Challenger>(
             u_0: round0_uv.0,
             u_2: round0_uv.1,
         }),
+        round1_lookahead,
         challenger,
     )
 }
@@ -3062,6 +3384,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
     l0_codeword: &[F128],
     l0_tree: &[Hash],
     first_msg: Option<SumcheckMessage>,
+    round1_lookahead: Option<FoldLookahead>,
     challenger: &mut Ch,
 ) -> LigeritoProof {
     let log_n = packed_witness.len().trailing_zeros() as usize;
@@ -3129,7 +3452,31 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
     challenger.observe_f128(start_msg.u_0);
     challenger.observe_f128(start_msg.u_2);
 
+    // Lane folds with two-rounds-per-pass lookahead: pass rounds alternate
+    // with O(1) "skip" rounds whose message is evaluated from quadratic
+    // coefficients accumulated in the preceding pass, and the deferred fold
+    // is absorbed by the next pass folding TWO challenges at once (4→1).
+    // Cuts the fold chain's memory traffic ~25% (the intermediate half-size
+    // arrays between paired rounds are never materialized) while producing a
+    // bit-identical transcript (exact polynomial identity — see
+    // [`FoldLookahead`]). LIG_LOOKAHEAD_DISABLE=1 restores the per-round
+    // fused folds (A/B toggle). Small instances (< 2^14, where pass shapes
+    // and scratch reuse don't pay) stay on the per-round path.
+    let use_lookahead = {
+        let n = sc_prover.f_len();
+        // Big enough to pay, and every pass keeps `quarter` a multiple of 4.
+        n >= (1 << 14) && (n >> initial_k) >= 16
+    } && std::env::var("LIG_LOOKAHEAD_DISABLE").is_err();
     let mut r_lane_fold = Vec::with_capacity(initial_k);
+    // Entry coefficients from the pcs combine (computed in the same pass as
+    // the round-0 prime) make round 0 itself a skip round: the full-size
+    // entry pass never runs and the first real pass folds two challenges
+    // straight off the original arrays.
+    let mut lookahead: Option<FoldLookahead> = if use_lookahead {
+        round1_lookahead
+    } else {
+        None
+    };
     for j in 0..initial_k {
         // Fold-challenge grinding: the L0 proximity-gap bad event lives on
         // each of these lane-fold challenges, so each one is individually
@@ -3145,11 +3492,28 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
             fold_grinding_nonces.push(challenger.grind_pow(bits));
         }
         let r = challenger.sample_f128();
-        let msg = sc_prover.fold(r);
+        let msg = if !use_lookahead {
+            sc_prover.fold(r)
+        } else if let Some(la) = lookahead.take() {
+            // Skip round: message from coefficients, fold deferred.
+            sc_prover.fold_skip(&la, r)
+        } else if sc_prover.has_pending_fold() {
+            // Pass round: fold the deferred challenge + this one together.
+            let (msg, la) = sc_prover.fold2_lookahead(r);
+            lookahead = Some(la);
+            msg
+        } else {
+            // Entry pass (round 0): single fold + first coefficients.
+            let (msg, la) = sc_prover.fold1_lookahead(r);
+            lookahead = Some(la);
+            msg
+        };
         challenger.observe_f128(msg.u_0);
         challenger.observe_f128(msg.u_2);
         r_lane_fold.push(r);
     }
+    // Even initial_k ends on a skip round — materialize the deferred fold.
+    sc_prover.drain_pending_fold();
     if trace {
         t_init_sumcheck += _t.elapsed();
     }
@@ -4994,6 +5358,252 @@ pub fn recursive_verifier<Ch: Challenger>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Lookahead fold state machine vs the plain per-round fused folds:
+    /// every round message AND the final arrays must be bit-identical
+    /// (exact polynomial identity). Covers even k (drain needed) and odd k.
+    #[test]
+    fn lookahead_folds_match_plain_folds() {
+        let mut s = 0xFACE_FEED_0123_4567u64;
+        let mut next = move || {
+            s = s.wrapping_add(0x9E3779B97F4A7C15);
+            let mut z = s;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+            z ^ (z >> 31)
+        };
+        let n = 1usize << 12;
+        let f: Vec<F128> = (0..n)
+            .map(|_| F128 {
+                lo: next(),
+                hi: next(),
+            })
+            .collect();
+        let b: Vec<F128> = (0..n)
+            .map(|_| F128 {
+                lo: next(),
+                hi: next(),
+            })
+            .collect();
+        let target = F128 {
+            lo: next(),
+            hi: next(),
+        };
+        let first = SumcheckMessage {
+            u_0: F128 {
+                lo: next(),
+                hi: next(),
+            },
+            u_2: F128 {
+                lo: next(),
+                hi: next(),
+            },
+        };
+        for k in [5usize, 6] {
+            let rs: Vec<F128> = (0..k)
+                .map(|_| F128 {
+                    lo: next(),
+                    hi: next(),
+                })
+                .collect();
+
+            let (mut plain, _) =
+                SumcheckProver::new_with_first_msg(f.clone(), b.clone(), target, first);
+            let plain_msgs: Vec<SumcheckMessage> = rs.iter().map(|&r| plain.fold(r)).collect();
+
+            let (mut la_prover, _) =
+                SumcheckProver::new_with_first_msg(f.clone(), b.clone(), target, first);
+            let mut lookahead: Option<FoldLookahead> = None;
+            let mut la_msgs = Vec::with_capacity(k);
+            for &r in &rs {
+                let msg = if let Some(la) = lookahead.take() {
+                    la_prover.fold_skip(&la, r)
+                } else if la_prover.has_pending_fold() {
+                    let (msg, la) = la_prover.fold2_lookahead(r);
+                    lookahead = Some(la);
+                    msg
+                } else {
+                    let (msg, la) = la_prover.fold1_lookahead(r);
+                    lookahead = Some(la);
+                    msg
+                };
+                la_msgs.push(msg);
+            }
+            la_prover.drain_pending_fold();
+
+            for (j, (pm, lm)) in plain_msgs.iter().zip(la_msgs.iter()).enumerate() {
+                assert_eq!(pm.u_0, lm.u_0, "k={k} round {j}: u_0 mismatch");
+                assert_eq!(pm.u_2, lm.u_2, "k={k} round {j}: u_2 mismatch");
+            }
+            assert_eq!(plain.f(), la_prover.f(), "k={k}: folded f mismatch");
+            assert_eq!(
+                plain.combined_basis, la_prover.combined_basis,
+                "k={k}: folded basis mismatch"
+            );
+        }
+    }
+
+    /// Same-process paired A/B: 6 plain fused folds vs the lookahead
+    /// schedule (P1 + skip + P2 + skip + P2 + skip + drain) at 2^23, order
+    /// swapped every rep. Run with:
+    ///   cargo test --release --lib lookahead_fold_ab_probe -- --ignored --nocapture
+    #[test]
+    #[ignore = "manual perf probe; run with --ignored --nocapture"]
+    fn lookahead_fold_ab_probe() {
+        use std::time::Instant;
+        let _ = crate::init_perf_thread_pool();
+        let n = 1usize << 23;
+        let k = 6usize;
+        let mut s = 0xA5A5_5A5A_1357_9BDFu64;
+        let mut next = move || {
+            s = s.wrapping_add(0x9E3779B97F4A7C15);
+            let mut z = s;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+            z ^ (z >> 31)
+        };
+        let f: Vec<F128> = (0..n)
+            .map(|_| F128 {
+                lo: next(),
+                hi: next(),
+            })
+            .collect();
+        let b: Vec<F128> = (0..n)
+            .map(|_| F128 {
+                lo: next(),
+                hi: next(),
+            })
+            .collect();
+        let rs: Vec<F128> = (0..k)
+            .map(|_| F128 {
+                lo: next(),
+                hi: next(),
+            })
+            .collect();
+        let target = F128::ZERO;
+        let first = SumcheckMessage {
+            u_0: F128::ZERO,
+            u_2: F128::ZERO,
+        };
+
+        let run_plain = |f: &[F128], b: &[F128]| -> (f64, SumcheckMessage) {
+            let (mut p, _) =
+                SumcheckProver::new_with_first_msg(f.to_vec(), b.to_vec(), target, first);
+            let t = Instant::now();
+            let mut last = first;
+            for &r in &rs {
+                last = p.fold(r);
+            }
+            (t.elapsed().as_secs_f64(), last)
+        };
+        let run_la = |f: &[F128], b: &[F128]| -> (f64, SumcheckMessage) {
+            let (mut p, _) =
+                SumcheckProver::new_with_first_msg(f.to_vec(), b.to_vec(), target, first);
+            let t = Instant::now();
+            let mut last = first;
+            let mut lookahead: Option<FoldLookahead> = None;
+            for &r in &rs {
+                last = if let Some(la) = lookahead.take() {
+                    p.fold_skip(&la, r)
+                } else if p.has_pending_fold() {
+                    let (msg, la) = p.fold2_lookahead(r);
+                    lookahead = Some(la);
+                    msg
+                } else {
+                    let (msg, la) = p.fold1_lookahead(r);
+                    lookahead = Some(la);
+                    msg
+                };
+            }
+            p.drain_pending_fold();
+            (t.elapsed().as_secs_f64(), last)
+        };
+
+        // Entry-skip variant (stage 2): round-1 coefficients precomputed
+        // outside the timed region (production fuses them into the pcs
+        // combine's block tail), so the schedule is skip + P2 + skip + P2 +
+        // skip + P2 — the full-size entry pass never runs.
+        let entry_coeffs = {
+            use rayon::prelude::*;
+            let acc = f
+                .par_chunks(4)
+                .zip(b.par_chunks(4))
+                .map(|(fc, bc)| {
+                    let mut acc = [F256Unreduced::ZERO; 8];
+                    lookahead_accum_group(
+                        &[fc[0], fc[1], fc[2], fc[3]],
+                        &[bc[0], bc[1], bc[2], bc[3]],
+                        &mut acc,
+                    );
+                    acc
+                })
+                .reduce(|| [F256Unreduced::ZERO; 8], xor_acc8);
+            lookahead_finish(acc).1
+        };
+        let run_la_entry = |f: &[F128], b: &[F128]| -> (f64, SumcheckMessage) {
+            let (mut p, _) =
+                SumcheckProver::new_with_first_msg(f.to_vec(), b.to_vec(), target, first);
+            let t = Instant::now();
+            let mut last = first;
+            let mut lookahead: Option<FoldLookahead> = Some(entry_coeffs);
+            for &r in &rs {
+                last = if let Some(la) = lookahead.take() {
+                    p.fold_skip(&la, r)
+                } else {
+                    let (msg, la) = p.fold2_lookahead(r);
+                    lookahead = Some(la);
+                    msg
+                };
+            }
+            p.drain_pending_fold();
+            (t.elapsed().as_secs_f64(), last)
+        };
+
+        const REPS: usize = 8;
+        let mut wins = 0;
+        let mut wins2 = 0;
+        let mut a_tot = 0.0;
+        let mut b_tot = 0.0;
+        let mut c_tot = 0.0;
+        for rep in 0..REPS {
+            let (ta, ma, tb, mb, tc, mc) = if rep % 2 == 0 {
+                let (ta, ma) = run_plain(&f, &b);
+                let (tb, mb) = run_la(&f, &b);
+                let (tc, mc) = run_la_entry(&f, &b);
+                (ta, ma, tb, mb, tc, mc)
+            } else {
+                let (tc, mc) = run_la_entry(&f, &b);
+                let (tb, mb) = run_la(&f, &b);
+                let (ta, ma) = run_plain(&f, &b);
+                (ta, ma, tb, mb, tc, mc)
+            };
+            assert_eq!(ma.u_0, mb.u_0);
+            assert_eq!(ma.u_2, mb.u_2);
+            assert_eq!(ma.u_0, mc.u_0);
+            assert_eq!(ma.u_2, mc.u_2);
+            if tb < ta {
+                wins += 1;
+            }
+            if tc < ta {
+                wins2 += 1;
+            }
+            a_tot += ta;
+            b_tot += tb;
+            c_tot += tc;
+            eprintln!(
+                "rep {rep}: plain {:7.2} ms   lookahead {:7.2} ms   entry-skip {:7.2} ms",
+                ta * 1e3,
+                tb * 1e3,
+                tc * 1e3,
+            );
+        }
+        eprintln!(
+            "avg: plain {:7.2} ms   lookahead {:7.2} ms ({wins}/{REPS})   entry-skip {:7.2} ms ({wins2}/{REPS})",
+            a_tot / REPS as f64 * 1e3,
+            b_tot / REPS as f64 * 1e3,
+            c_tot / REPS as f64 * 1e3
+        );
+    }
 
     /// Worked example: `LigeritoSecurityConfig` for BLAKE3 m=29 at rate 1/2.
     /// Paper-compatible m=29 fast example, mechanically derived in the


### PR DESCRIPTION
The two structural perf merges scoped out of the all-core PR — both leave the wire format untouched.

**Ligerito initial-sumcheck lookahead** (wire-identical; prover strategy only):

- `FoldLookahead`: each fold pass accumulates the quadratic coefficients of the NEXT round's message, making alternate rounds O(1) "skip" rounds; the deferred fold is absorbed by the following pass folding two challenges at once (4→1). ~25% less fold-chain memory traffic.
- The pcs combine's fast path (no packed-direct claims) accumulates round-1 coefficients in the SAME pass as the round-0 prime, so the recursive prover's first lane fold is already a skip round.
- `fold_and_msg_lsb`: one-mul folds (v0 + r·(v0+v1)) + unreduced message accumulation + scratch-pooled outputs on all arches (the fresh-alloc page-fault + munmap cycle measured as the dominant initial-sumcheck cost at m=30). The chunk fold routes through the arch-dispatched `field::f128_slice::fold_pairs` — the same field element exactly (src[2j]·(1+r) + src[2j+1]·r = v0 + (v0+v1)·r in GF(2¹²⁸)) — keeping the AVX-512 fold on x86. `LIG_LOOKAHEAD_DISABLE=1` restores per-round folds; gated off below 2^14.

**NTT deep pass** (aarch64-validated; the portable/x86 structure — including the AVX-512 fused-4 top pass and kernel dispatch — is untouched):

- Zero-twiddle fast path (block 0 of every layer: ~6% of NTT mults) and half-width-twiddle fast path (`mul_small_twiddle`: 2-PMULL + single reduction fold; the three deepest layers' twiddles are all half-width, ~18% of mults, +14.7% on the NTT phase on M-series).
- Deep-pass 2-layer fusion (general-width pairs, halving in-cache traffic; `NTT_DEEP_NOFUSE` kill-switch) with the zero-block short-circuit shared between the par-rows and new serial kernels.
- Deep-pass all-core hop for ≥ 64 MB transforms with ≥ 4× sub-groups per worker (`NTT_DEEP_PCORES_ONLY` kill-switch).

Deliberately NOT ported (negative or wash on repeated probes): `NTT_KARA_MUL` hoisted-Karatsuba twiddle mul, vec2-PMULL batching, and the `COMMIT_LEAF_FUSE` streaming leaf fusion (+ its sub_hook plumbing).

### Stack

PR 4 of 4 (#27 ← #28 ← #29 ← **this PR**); based on #29's `ag-public/allcore`, merge bottom-up.

Final PR of the stack, and like the others it needs real review — the lookahead rewrites the initial-sumcheck hot loop that the recursion and CUDA work sit next to.

### Review focus

- Lookahead correctness: the deferred-fold absorption (two challenges folded in one pass, 4→1) and the round-1-in-the-combine-pass emission. A parity test pins every round message and the final array bit-identical vs the plain folds (even and odd k) — worth reading the test to confirm it covers the branchy cases.
- The `fold_and_msg_lsb` routing through `fold_pairs` on x86: the algebraic identity above is the whole argument; check it holds for the chunk boundaries.
- @erabinov / @tamirhemo: this touches the Ligerito initial-sumcheck line adjacent to the CUDA port — worth checking nothing the CUDA test vectors pin has moved (they haven't per the dump-bin outputs, but a second pair of eyes is the point).
- NTT fast-path gating: the zero/half-width twiddle detection and the 2-layer fusion's zero-block short-circuit.

### Validation (evidence, not a substitute for review)

- All 34 NTT oracle tests + full suite + heavy `--ignored` AG/RS roundtrips green; fmt/clippy `-D warnings` clean on aarch64 and the x86_64 (znver4) cross-check.
- Lookahead parity test: every round message and final array bit-identical vs plain folds.
- With the full stack applied, m=30 blake3 e2e prove: AG ~1.27× faster than RS on an M4 Max (matches the research branch's 1.26×).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
