### PR TITLE
ligerito: round-1 lookahead across the F256 ladder (compression + merged/union routes)

### DIFF
--- a/crates/flock-core/src/bits.rs
+++ b/crates/flock-core/src/bits.rs
@@ -8,10 +8,12 @@
 /// silently raise the minimum toolchain by twelve releases for a two-instruction
 /// idiom. (It previously sat behind `#![feature(...)]`, which made the tree
 /// nightly-only, then a hard error on stable once the feature landed.) Do not
-/// "simplify" this back.
+/// "simplify" this back — clippy 1.98's `manual_isolate_lowest_one` tries to,
+/// and the Blackwell CI runner's older toolchain cannot compile the result.
 #[inline(always)]
+#[allow(clippy::manual_isolate_lowest_one)]
 pub fn lowest_one(x: usize) -> usize {
-    x.isolate_lowest_one()
+    x & x.wrapping_neg()
 }
 
 /// Hacker's Delight (Sec. 7-3) 8×8 bit-matrix transpose stored in a `u64`.

--- a/crates/flock-core/src/bits.rs
+++ b/crates/flock-core/src/bits.rs
@@ -11,7 +11,7 @@
 /// "simplify" this back.
 #[inline(always)]
 pub fn lowest_one(x: usize) -> usize {
-    x & x.wrapping_neg()
+    x.isolate_lowest_one()
 }
 
 /// Hacker's Delight (Sec. 7-3) 8×8 bit-matrix transpose stored in a `u64`.

--- a/crates/flock-core/src/challenger.rs
+++ b/crates/flock-core/src/challenger.rs
@@ -1046,7 +1046,9 @@ impl Challenger for FsChallenger {
 fn f128s_from_le_bytes(bytes: &[u8]) -> Vec<F128> {
     debug_assert_eq!(bytes.len() % 16, 0);
     bytes
-        .chunks_exact(16)
+        .as_chunks::<16>()
+        .0
+        .iter()
         .map(|c| F128 {
             lo: u64::from_le_bytes(c[..8].try_into().unwrap()),
             hi: u64::from_le_bytes(c[8..].try_into().unwrap()),

--- a/crates/flock-core/src/pcs.rs
+++ b/crates/flock-core/src/pcs.rs
@@ -401,8 +401,11 @@ struct CombinedClaim {
     /// consumed by `recursive_prover_with_basis_precomputed_round0`.
     round0_prime: (F128, F128),
     /// Quadratic coefficients of Ligerito's ROUND-1 message in the round-0
-    /// fold challenge, accumulated in the same combine pass (fast path with
-    /// no packed-direct claims only). Lets the recursive prover's first lane
+    /// fold challenge, accumulated in the same combine pass. Three paths
+    /// emit them: the plain fast path (LSB-pair coefficients), the fast
+    /// path WITH sparse packed-direct claims (scatter deltas corrected by
+    /// linearity), and the seeded EqPoint path (BLOCKED coefficients, the
+    /// fold's own block pairing). Lets the recursive prover's first lane
     /// fold be an O(1) skip round — see [`ligerito::FoldLookahead`].
     round1_lookahead: Option<ligerito::FoldLookahead>,
 }

--- a/crates/flock-core/src/pcs.rs
+++ b/crates/flock-core/src/pcs.rs
@@ -565,6 +565,49 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
         let mask = (1usize << n_lo) - 1;
         let bs = |u: usize| lo[u & mask] * hi[u >> n_lo];
         let blk = eqpoint_round0_block;
+        if blk == 1 {
+            // The ladder statically rejects a lookahead on this shape:
+            // `fold_block == 1` comes with the factored (JIT) basis, so
+            // `kind_ok` in extension.rs never consumes it. Run the lean
+            // prime-only pass (2 muls/pair) instead of paying the doubled
+            // lookahead accumulation for coefficients nothing reads.
+            const C: usize = 1 << 13;
+            let (round0_u0, round0_u2) = packed_witness
+                .par_chunks(C)
+                .enumerate()
+                .map(|(ci, qc)| {
+                    let base = ci * C;
+                    let mut a = F128::ZERO;
+                    let mut b = F128::ZERO;
+                    for (j, qp) in qc.as_chunks::<2>().0.iter().enumerate() {
+                        let u = base + 2 * j;
+                        let (w0, w1) = (bs(u), bs(u + 1));
+                        a += qp[0] * w0;
+                        b += (qp[0] + qp[1]) * (w0 + w1);
+                    }
+                    (a, b)
+                })
+                .reduce(
+                    || (F128::ZERO, F128::ZERO),
+                    |(x0, x2), (y0, y2)| (x0 + y0, x2 + y2),
+                );
+            if trace {
+                eprintln!(
+                    "  [open_batch] combine (seeded EqPoint, L={l}): {:6.2} ms",
+                    t.elapsed().as_secs_f64() * 1e3
+                );
+            }
+            return CombinedClaim {
+                ring_switches: Vec::new(),
+                batching_nonces,
+                b_combined: Vec::new(),
+                eq_basis: Some((lo, hi, n_lo)),
+                eq_gamma: Some(gammas_pd[0]),
+                target_combined,
+                round0_prime: (round0_u0, round0_u2),
+                round1_lookahead: None,
+            };
+        }
         // The same seeded pass now also accumulates the ROUND-1 message's
         // quadratic coefficients in the round-0 fold challenge, under the
         // fold's own pairing: quad `q` covers the four consecutive

--- a/crates/flock-core/src/pcs.rs
+++ b/crates/flock-core/src/pcs.rs
@@ -562,55 +562,74 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
         let mask = (1usize << n_lo) - 1;
         let bs = |u: usize| lo[u & mask] * hi[u >> n_lo];
         let blk = eqpoint_round0_block;
-        let (round0_u0, round0_u2) = if blk == 1 {
-            const C: usize = 1 << 13;
-            packed_witness
-                .par_chunks(C)
-                .enumerate()
-                .map(|(ci, qc)| {
-                    let base = ci * C;
-                    let mut a = F128::ZERO;
-                    let mut b = F128::ZERO;
-                    for (j, qp) in qc.as_chunks::<2>().0.iter().enumerate() {
-                        let u = base + 2 * j;
-                        let (w0, w1) = (bs(u), bs(u + 1));
-                        a += qp[0] * w0;
-                        b += (qp[0] + qp[1]) * (w0 + w1);
-                    }
-                    (a, b)
-                })
-                .reduce(
-                    || (F128::ZERO, F128::ZERO),
-                    |(x0, x2), (y0, y2)| (x0 + y0, x2 + y2),
-                )
-        } else {
-            // Lane-major round-0: the L0 fold pairs BLOCKS of `blk`
-            // elements (lane 2j with lane 2j+1), so the prime pairs
-            // element t of block 2j with element t of block 2j+1.
-            assert!(blk.is_power_of_two() && l.is_multiple_of(2 * blk));
-            (0..l / (2 * blk))
-                .into_par_iter()
-                .map(|j| {
-                    let b0 = 2 * j * blk;
-                    let b1 = b0 + blk;
-                    let mut u0 = F128::ZERO;
-                    let mut u2 = F128::ZERO;
-                    for t in 0..blk {
-                        let (q0, q1) = (packed_witness[b0 + t], packed_witness[b1 + t]);
-                        let (w0, w1) = (bs(b0 + t), bs(b1 + t));
-                        u0 += q0 * w0;
-                        u2 += (q0 + q1) * (w0 + w1);
-                    }
-                    (u0, u2)
-                })
-                .reduce(
-                    || (F128::ZERO, F128::ZERO),
-                    |(x0, x2), (y0, y2)| (x0 + y0, x2 + y2),
-                )
+        // The same seeded pass now also accumulates the ROUND-1 message's
+        // quadratic coefficients in the round-0 fold challenge, under the
+        // fold's own pairing: quad `q` covers the four consecutive
+        // `blk`-blocks the ladder's first two folds combine, so
+        // `ligerito::lookahead_accum_group` applies verbatim with blocked
+        // gathering (+4 unreduced muls per quad on a pass that already runs;
+        // it buys the ladder a full fold-0 pass). Needs `l ≥ 4·blk`
+        // (initial_k ≥ 2), which every shipped ladder satisfies.
+        use crate::field::F256Unreduced;
+        assert!(blk.is_power_of_two() && l.is_multiple_of(4 * blk));
+        let quad = |q: usize, acc: &mut [F256Unreduced; 8]| {
+            let i0 = 4 * q * blk;
+            for k in 0..blk {
+                let i = i0 + k;
+                let fq = [
+                    packed_witness[i],
+                    packed_witness[i + blk],
+                    packed_witness[i + 2 * blk],
+                    packed_witness[i + 3 * blk],
+                ];
+                let bq = [bs(i), bs(i + blk), bs(i + 2 * blk), bs(i + 3 * blk)];
+                ligerito::lookahead_accum_group(&fq, &bq, acc);
+            }
         };
+        // Parallelize on quads; for the lane-major shape (huge blk, few
+        // quads) split each quad's inner `k` range instead.
+        let n_quads = l / (4 * blk);
+        let acc = if n_quads >= 64 {
+            // ~2^13 elements per task, whatever the block size.
+            let qc = ((1usize << 13) / (4 * blk)).max(1);
+            (0..n_quads.div_ceil(qc))
+                .into_par_iter()
+                .map(|qq| {
+                    let mut acc = [F256Unreduced::ZERO; 8];
+                    for q in (qq * qc)..((qq + 1) * qc).min(n_quads) {
+                        quad(q, &mut acc);
+                    }
+                    acc
+                })
+                .reduce(|| [F256Unreduced::ZERO; 8], ligerito::xor_acc8)
+        } else {
+            const KC: usize = 1 << 12;
+            (0..n_quads * blk.div_ceil(KC))
+                .into_par_iter()
+                .map(|item| {
+                    let chunks_per_quad = blk.div_ceil(KC);
+                    let (q, kc) = (item / chunks_per_quad, item % chunks_per_quad);
+                    let i0 = 4 * q * blk;
+                    let mut acc = [F256Unreduced::ZERO; 8];
+                    for k in (kc * KC)..((kc + 1) * KC).min(blk) {
+                        let i = i0 + k;
+                        let fq = [
+                            packed_witness[i],
+                            packed_witness[i + blk],
+                            packed_witness[i + 2 * blk],
+                            packed_witness[i + 3 * blk],
+                        ];
+                        let bq = [bs(i), bs(i + blk), bs(i + 2 * blk), bs(i + 3 * blk)];
+                        ligerito::lookahead_accum_group(&fq, &bq, &mut acc);
+                    }
+                    acc
+                })
+                .reduce(|| [F256Unreduced::ZERO; 8], ligerito::xor_acc8)
+        };
+        let (round0, la) = ligerito::lookahead_finish(acc);
         if trace {
             eprintln!(
-                "  [open_batch] combine (seeded EqPoint, L={l}): {:6.2} ms",
+                "  [open_batch] combine (seeded EqPoint + lookahead, L={l}): {:6.2} ms",
                 t.elapsed().as_secs_f64() * 1e3
             );
         }
@@ -621,8 +640,8 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
             eq_basis: Some((lo, hi, n_lo)),
             eq_gamma: Some(gammas_pd[0]),
             target_combined,
-            round0_prime: (round0_u0, round0_u2),
-            round1_lookahead: None,
+            round0_prime: (round0.u_0, round0.u_2),
+            round1_lookahead: Some(la),
         };
     }
 
@@ -666,11 +685,13 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
     // commutative, exact).
     let combine_all_cores =
         std::env::var("PCS_COMBINE_PCORES_ONLY").is_err() && crate::ecore_rich_topology();
-    // With no packed-direct claims nothing is scatter-added after the fast
-    // path, so the block tail can also accumulate Ligerito's round-1 message
-    // coefficients (groups of 4; +1 unreduced mul per slot) — the round-0
-    // prime falls out of the same accumulators. See `CombinedClaim`.
-    let want_lookahead = use_fast && packed_direct.is_empty();
+    // The fast path's block tail can also accumulate Ligerito's round-1
+    // message coefficients (groups of 4; +1 unreduced mul per slot) — the
+    // round-0 prime falls out of the same accumulators. Sparse post-combine
+    // scatter-adds no longer disable this: the coefficients are linear in
+    // the basis, so each scattered delta corrects them below. See
+    // `CombinedClaim`.
+    let want_lookahead = use_fast;
     let mut round1_lookahead: Option<ligerito::FoldLookahead> = None;
     let b_combined_ref = &mut b_combined;
     let la_ref = &mut round1_lookahead;
@@ -866,24 +887,38 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
         }
         round0_u2 += (a0 + a1) * delta;
     };
+    // Post-combine b_combined mutations. The round-1 lookahead coefficients
+    // are LINEAR in the basis, so every scattered delta corrects them with
+    // its own quad contribution (`bq` = the delta at one slot, `fq` = the
+    // quad's witness words — 8 unreduced muls per live entry); the prime
+    // keeps its existing incremental adjustment.
+    let mut la_acc = [crate::field::F256Unreduced::ZERO; 8];
+    let la_active = round1_lookahead.is_some();
+    let la_correct = |idx: usize, delta: F128, acc: &mut [crate::field::F256Unreduced; 8]| {
+        let g = idx & !3usize;
+        let fq = [
+            packed_witness[g],
+            packed_witness[g + 1],
+            packed_witness[g + 2],
+            packed_witness[g + 3],
+        ];
+        let mut bq = [F128::ZERO; 4];
+        bq[idx & 3] = delta;
+        ligerito::lookahead_accum_group(&fq, &bq, acc);
+    };
     for (_, output) in rs_results.iter() {
         if let ring_switch::RsEqInd::Sparse { entries, .. } = &output.rs_eq_ind {
-            // Post-combine mutation of b_combined: the round-1 lookahead
-            // coefficients (if any) are now stale. Unreachable when they are
-            // emitted (fast path = no sparse RS claims), but keep the
-            // invalidation in case the emission condition ever widens.
-            if !entries.is_empty() {
-                round1_lookahead = None;
-            }
             for &(idx, val) in entries {
                 b_combined[idx] += val;
                 adjust_prime_for_delta(idx, val);
+                if la_active {
+                    la_correct(idx, val, &mut la_acc);
+                }
             }
         }
     }
     for (pd, g) in packed_direct.iter().zip(gammas_pd.iter()) {
         if let DirectEqInd::Sparse(eq) = &pd.eq_ind {
-            round1_lookahead = None; // see above — pd claims never emit coeffs
             // Scatter-add the sparse claim and fold its round-0 prime
             // contribution in the SAME pass (O(live positions)), instead of a
             // full O(L) re-pass over b_combined. The prime is linear in
@@ -892,7 +927,18 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
             let (du0, du2) = sparse_scatter_add_parallel(&mut b_combined, packed_witness, eq, *g);
             round0_u0 += du0;
             round0_u2 += du2;
+            if la_active {
+                for c in 0..eq.live_tensor.len() {
+                    la_correct(eq.scatter_idx(c), *g * eq.live_tensor[c], &mut la_acc);
+                }
+            }
         }
+    }
+    if let Some(la) = round1_lookahead.as_mut() {
+        // The group kernel's message slots duplicate the prime deltas
+        // already applied above — only the coefficient half is consumed.
+        let (_, delta) = ligerito::lookahead_finish(la_acc);
+        la.add(&delta);
     }
     if trace {
         eprintln!(

--- a/crates/flock-core/src/pcs/jagged.rs
+++ b/crates/flock-core/src/pcs/jagged.rs
@@ -2392,7 +2392,7 @@ fn linear_byte_tables(images: &[F128; 128]) -> Vec<[F128; 256]> {
     let mut tables = vec![[F128::ZERO; 256]; 16];
     for (k, table) in tables.iter_mut().enumerate() {
         for v in 1usize..256 {
-            let low = v.isolate_lowest_one();
+            let low = crate::bits::lowest_one(v);
             table[v] = table[v ^ low] + images[8 * k + low.trailing_zeros() as usize];
         }
     }

--- a/crates/flock-core/src/pcs/jagged.rs
+++ b/crates/flock-core/src/pcs/jagged.rs
@@ -330,7 +330,12 @@ fn generate_f_and_claim(
             let mut acc = F128::ZERO;
             let mut m_one = F128::ZERO;
             let mut m_inf = F128::ZERO;
-            for (bp, qp) in b_chunk.chunks_exact(2).zip(q_chunk.chunks_exact(2)) {
+            for (bp, qp) in b_chunk
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .zip(q_chunk.as_chunks::<2>().0.iter())
+            {
                 let t = qp[1] * bp[1];
                 acc += qp[0] * bp[0] + t;
                 m_one += t;
@@ -2387,7 +2392,7 @@ fn linear_byte_tables(images: &[F128; 128]) -> Vec<[F128; 256]> {
     let mut tables = vec![[F128::ZERO; 256]; 16];
     for (k, table) in tables.iter_mut().enumerate() {
         for v in 1usize..256 {
-            let low = v & v.wrapping_neg();
+            let low = v.isolate_lowest_one();
             table[v] = table[v ^ low] + images[8 * k + low.trailing_zeros() as usize];
         }
     }
@@ -2790,7 +2795,7 @@ fn build_combined_weight_and_msg(
             }
             let mut p1 = F128::ZERO;
             let mut pi = F128::ZERO;
-            for (j, ap) in chunk.chunks_exact(2).enumerate() {
+            for (j, ap) in chunk.as_chunks::<2>().0.iter().enumerate() {
                 let u = start as usize + 2 * j;
                 let q0 = partner.at(eq, u);
                 let q1 = partner.at(eq, u + 1);
@@ -3806,7 +3811,7 @@ struct SparseSeg {
 fn seg_msg(x: &[F128], y: &[F128]) -> (F128, F128) {
     let mut p1 = F128::ZERO;
     let mut pi = F128::ZERO;
-    for (xp, yp) in x.chunks_exact(2).zip(y.chunks_exact(2)) {
+    for (xp, yp) in x.as_chunks::<2>().0.iter().zip(y.as_chunks::<2>().0.iter()) {
         p1 += xp[1] * yp[1];
         pi += (xp[0] + xp[1]) * (yp[0] + yp[1]);
     }

--- a/crates/flock-core/src/pcs/ligerito.rs
+++ b/crates/flock-core/src/pcs/ligerito.rs
@@ -7975,9 +7975,7 @@ mod tests {
 
         // And the proof is a real one.
         let v_cfg = verifier_config_for(log_n, 6, LigeritoProfile::Fast).unwrap();
-        let cap = wtns
-            .cap(v_cfg.l0_cap_depth())
-            .to_vec();
+        let cap = wtns.cap(v_cfg.l0_cap_depth()).to_vec();
         let mut v_ch = crate::challenger::FsChallenger::new(b"la-test");
         assert!(extension::recursive_verifier_with_basis_succinct(
             &v_cfg,

--- a/crates/flock-core/src/pcs/ligerito.rs
+++ b/crates/flock-core/src/pcs/ligerito.rs
@@ -3485,6 +3485,13 @@ pub struct FoldLookahead {
     u2: [F128; 3],
 }
 
+/// In-process A/B override for the F256 ladder's round-1 lookahead skip:
+/// `0` follows the `FLOCK_NO_FOLD_LOOKAHEAD` env knob, `1` forces it on,
+/// `2` forces the plain first-fold path. Byte-identical either way (exact
+/// polynomial identity) — the oracle tests alternate this to prove it.
+pub static FOLD_LOOKAHEAD_OVERRIDE: std::sync::atomic::AtomicU8 =
+    std::sync::atomic::AtomicU8::new(0);
+
 impl FoldLookahead {
     #[inline]
     fn eval(&self, r: F128) -> SumcheckMessage {
@@ -3492,6 +3499,16 @@ impl FoldLookahead {
         SumcheckMessage {
             u_0: self.u0[0] + r * self.u0[1] + r2 * self.u0[2],
             u_2: self.u2[0] + r * self.u2[1] + r2 * self.u2[2],
+        }
+    }
+
+    /// Componentwise addition. The coefficients are LINEAR in the basis, so
+    /// a post-combine basis delta corrects a stored lookahead by adding the
+    /// delta's own coefficients.
+    pub(crate) fn add(&mut self, other: &FoldLookahead) {
+        for i in 0..3 {
+            self.u0[i] += other.u0[i];
+            self.u2[i] += other.u2[i];
         }
     }
 }
@@ -4185,6 +4202,57 @@ fn round_msg_and_eval_eq_point_blocked(
             |(a0, a2, ae), (b0, b2, be)| (a0 + b0, a2 + b2, ae + be),
         );
     (SumcheckMessage { u_0, u_2 }, y)
+}
+
+/// [`round_msg_and_eval_eq_point_blocked`] that ALSO accumulates the round-1
+/// message's quadratic coefficients in the round-0 fold challenge, under the
+/// same BLOCK pairing (`d = 1` is the LSB order). Quad `b` covers the four
+/// consecutive `d`-blocks `[4bd, 4bd+4d)`: fold 0 pairs blocks (0,1) and
+/// (2,3), fold 1 pairs the two results — exactly the fused fold kernels'
+/// geometry, so [`lookahead_accum_group`] applies verbatim with blocked
+/// gathering. Used by the F256 ladder's factored L0 OOD loop to keep a
+/// caller lookahead live across the β-glues.
+pub(crate) fn round_msg_eval_and_lookahead_eq_point_blocked(
+    f: &[F128],
+    point: &[F128],
+    d: usize,
+) -> (SumcheckMessage, F128, FoldLookahead) {
+    use rayon::prelude::*;
+    debug_assert_eq!(f.len(), 1usize << point.len());
+    debug_assert!(d.is_power_of_two() && f.len().is_multiple_of(4 * d));
+    let eq = VirtualEqTerm::new(point.to_vec(), F128::ONE);
+    let (acc, odd) = (0..f.len() / (4 * d))
+        .into_par_iter()
+        .map(|q| {
+            let mut acc = [F256Unreduced::ZERO; 8];
+            let mut odd = F256Unreduced::ZERO;
+            let i0 = 4 * q * d;
+            for k in 0..d {
+                let i = i0 + k;
+                let fq = [f[i], f[i + d], f[i + 2 * d], f[i + 3 * d]];
+                let bq = [
+                    eq.value_at(i),
+                    eq.value_at(i + d),
+                    eq.value_at(i + 2 * d),
+                    eq.value_at(i + 3 * d),
+                ];
+                lookahead_accum_group(&fq, &bq, &mut acc);
+                odd ^= fq[1].mul_unreduced(bq[1]) ^ fq[3].mul_unreduced(bq[3]);
+            }
+            (acc, odd)
+        })
+        .reduce(
+            || ([F256Unreduced::ZERO; 8], F256Unreduced::ZERO),
+            |(a, ao), (b, bo)| {
+                (xor_acc8(a, b), {
+                    let mut o = ao;
+                    o ^= bo;
+                    o
+                })
+            },
+        );
+    let (msg, la) = lookahead_finish(acc);
+    (msg, msg.u_0 + odd.reduce(), la)
 }
 
 pub struct SumcheckProver {

--- a/crates/flock-core/src/pcs/ligerito.rs
+++ b/crates/flock-core/src/pcs/ligerito.rs
@@ -7914,10 +7914,6 @@ mod tests {
         eprintln!("LigeritoProof bincode size: {} bytes", bytes.len());
     }
 
-    /// `recursive_prover_with_basis` + `recursive_verifier_with_basis`
-    /// roundtrip — this is the basefold-compatible signature that
-    /// `pcs::open_batch` will call. Single-claim case (`b = eq(z, ·)`,
-    /// `target = poly(z)`) — must round-trip cleanly.
     /// The round-1 lookahead skip is an exact polynomial identity, so the
     /// F256 ladder must emit BYTE-IDENTICAL proofs with and without it —
     /// including across the L0 OOD β-glues, which the lookahead survives via
@@ -7998,6 +7994,10 @@ mod tests {
         );
     }
 
+    /// `recursive_prover_with_basis` +
+    /// `extension::recursive_verifier_with_basis_succinct` roundtrip.
+    /// Single-claim case (`b = eq(z, ·)`, `target = poly(z)`) — must
+    /// round-trip cleanly.
     #[test]
     fn recursive_prover_with_basis_roundtrip_single_claim() {
         use crate::challenger::Challenger;

--- a/crates/flock-core/src/pcs/ligerito.rs
+++ b/crates/flock-core/src/pcs/ligerito.rs
@@ -7981,7 +7981,7 @@ mod tests {
         // And the proof is a real one.
         let v_cfg = verifier_config_for(log_n, 6, LigeritoProfile::Fast).unwrap();
         let cap = wtns
-            .cap(v_cfg.l0_cap_depth(wtns.block_len.trailing_zeros() as usize))
+            .cap(v_cfg.l0_cap_depth())
             .to_vec();
         let mut v_ch = crate::challenger::FsChallenger::new(b"la-test");
         assert!(extension::recursive_verifier_with_basis_succinct(

--- a/crates/flock-core/src/pcs/ligerito.rs
+++ b/crates/flock-core/src/pcs/ligerito.rs
@@ -3564,6 +3564,54 @@ pub(crate) fn xor_acc8(mut a: [F256Unreduced; 8], b: [F256Unreduced; 8]) -> [F25
     a
 }
 
+/// [`round_msg_and_eval_lsb`] that ALSO accumulates the round-1 message's
+/// quadratic coefficients in the round-0 fold challenge (the entry-pass use
+/// of [`lookahead_accum_group`], plus one odd-dot accumulator for the full
+/// evaluation `y = Σ f·b`). One sweep, LSB pairing (`d = 1`).
+///
+/// The F256 ladder's L0 OOD loop uses this to keep a caller-provided
+/// [`FoldLookahead`] LIVE across the OOD β-glues: the coefficients are
+/// linear in the basis, so `b += β·eq_z` corrects the lookahead by
+/// `β · (coefficients of (f, eq_z))` — which this returns.
+pub(crate) fn round_msg_eval_and_lookahead(
+    f: &[F128],
+    b: &[F128],
+) -> (SumcheckMessage, F128, FoldLookahead) {
+    use rayon::prelude::*;
+    debug_assert_eq!(f.len(), b.len());
+    debug_assert!(f.len() >= 4 && f.len().is_multiple_of(4));
+    // 9 accumulators: the 8 lookahead slots + the odd dot (y = u_0 + odd).
+    let group =
+        |fq: &[F128; 4], bq: &[F128; 4], acc: &mut [F256Unreduced; 8], odd: &mut F256Unreduced| {
+            lookahead_accum_group(fq, bq, acc);
+            *odd ^= fq[1].mul_unreduced(bq[1]) ^ fq[3].mul_unreduced(bq[3]);
+        };
+    const CHUNK: usize = 1 << 12;
+    let (acc, odd) = f
+        .par_chunks(CHUNK)
+        .zip(b.par_chunks(CHUNK))
+        .map(|(fc, bc)| {
+            let mut acc = [F256Unreduced::ZERO; 8];
+            let mut odd = F256Unreduced::ZERO;
+            for (fq, bq) in fc.as_chunks::<4>().0.iter().zip(bc.as_chunks::<4>().0) {
+                group(fq, bq, &mut acc, &mut odd);
+            }
+            (acc, odd)
+        })
+        .reduce(
+            || ([F256Unreduced::ZERO; 8], F256Unreduced::ZERO),
+            |(a, ao), (b, bo)| {
+                (xor_acc8(a, b), {
+                    let mut o = ao;
+                    o ^= bo;
+                    o
+                })
+            },
+        );
+    let (msg, la) = lookahead_finish(acc);
+    (msg, msg.u_0 + odd.reduce(), la)
+}
+
 /// Entry lookahead pass: fold ONE variable (`n → n/2`) and return this
 /// round's message plus the next round's [`FoldLookahead`] coefficients.
 /// Identical fold/message values to [`fold_and_msg_lsb`]; the extra
@@ -9105,6 +9153,88 @@ mod tests {
     /// roundtrip — this is the basefold-compatible signature that
     /// `pcs::open_batch` will call. Single-claim case (`b = eq(z, ·)`,
     /// `target = poly(z)`) — must round-trip cleanly.
+    /// The round-1 lookahead skip is an exact polynomial identity, so the
+    /// F256 ladder must emit BYTE-IDENTICAL proofs with and without it —
+    /// including across the L0 OOD β-glues, which the lookahead survives via
+    /// the per-OOD coefficient correction ([`round_msg_eval_and_lookahead`]).
+    /// Registered m22 fast config (ood_samples[0] = 1, real PoW schedule),
+    /// plus an ood_samples[0] = 2 variant to exercise repeated corrections;
+    /// the registered-config proof is also verified.
+    #[test]
+    fn f256_round1_lookahead_is_byte_identical() {
+        use crate::challenger::Challenger;
+        let log_n = 15;
+        let cfg = prover_config_for(log_n, 6, LigeritoProfile::Fast).unwrap();
+
+        let mut rng = crate::challenger::RandomChallenger::new(0x10_0CA_4EAD);
+        let f: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
+        let b: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
+
+        // The combine pass's entry accumulation: round-0 message + round-1
+        // coefficients in one sweep (also pins the fused y against the plain
+        // message pass). The true inner product is the sumcheck target.
+        let (first, y, la) = round_msg_eval_and_lookahead(&f, &b);
+        let (first_plain, y_plain) = round_msg_and_eval_blocked(&f, &b, 1);
+        assert_eq!(first, first_plain);
+        assert_eq!(y, y_plain);
+        let target = y;
+
+        let log_msg_cols_0 = log_n - cfg.initial_k;
+        let ntt = AdditiveNttF128::standard(log_msg_cols_0 + cfg.log_inv_rates[0]);
+        let wtns = ligero_commit(
+            &f,
+            log_msg_cols_0,
+            cfg.initial_k,
+            cfg.log_inv_rates[0],
+            &ntt,
+            cfg.merkle_hash,
+        );
+
+        let prove = |cfg: &ProverConfig, la: Option<FoldLookahead>| -> LigeritoProof {
+            let mut ch = crate::challenger::FsChallenger::new(b"la-test");
+            recursive_prover_with_basis_precomputed_round0(
+                cfg,
+                f.clone(),
+                b.clone(),
+                target,
+                &wtns.mat,
+                &wtns.tree,
+                (first.u_0, first.u_2),
+                la,
+                &mut ch,
+            )
+        };
+        let with_la = prove(&cfg, Some(la));
+        let without = prove(&cfg, None);
+        assert_eq!(with_la, without, "lookahead skip must not move a byte");
+
+        // And the proof is a real one.
+        let v_cfg = verifier_config_for(log_n, 6, LigeritoProfile::Fast).unwrap();
+        let cap = wtns
+            .cap(v_cfg.l0_cap_depth(wtns.block_len.trailing_zeros() as usize))
+            .to_vec();
+        let mut v_ch = crate::challenger::FsChallenger::new(b"la-test");
+        assert!(extension::recursive_verifier_with_basis_succinct(
+            &v_cfg,
+            &with_la,
+            log_n,
+            target,
+            &cap,
+            1 << cfg.initial_k,
+            |ris, residual_log| extension::evaluate_dense_at_residual(&b, ris, residual_log),
+            &mut v_ch,
+        ));
+
+        // Two L0 OODs → two lookahead corrections.
+        let mut cfg2 = cfg.clone();
+        cfg2.ood_samples[0] = 2;
+        assert_eq!(
+            prove(&cfg2, Some(la)),
+            prove(&cfg2, None),
+            "lookahead must survive repeated OOD β-glues"
+        );
+    }
+
     #[test]
     fn recursive_prover_with_basis_roundtrip_single_claim() {
         use crate::challenger::Challenger;

--- a/crates/flock-core/src/pcs/ligerito.rs
+++ b/crates/flock-core/src/pcs/ligerito.rs
@@ -3485,10 +3485,13 @@ pub struct FoldLookahead {
     u2: [F128; 3],
 }
 
-/// In-process A/B override for the F256 ladder's round-1 lookahead skip:
-/// `0` follows the `FLOCK_NO_FOLD_LOOKAHEAD` env knob, `1` forces it on,
-/// `2` forces the plain first-fold path. Byte-identical either way (exact
-/// polynomial identity) — the oracle tests alternate this to prove it.
+/// In-process A/B override for the F256 ladder's WHOLE alternating fold
+/// schedule — the round-1 lookahead skip AND every mid-ladder `La256`
+/// production + skip round it seeds, through the initial folds and all
+/// recursive levels: `0` follows the `FLOCK_NO_FOLD_LOOKAHEAD` env knob,
+/// `1` forces the schedule on, `2` forces the plain per-round folds.
+/// Byte-identical either way (exact polynomial identity) — the oracle
+/// tests alternate this to prove it.
 pub static FOLD_LOOKAHEAD_OVERRIDE: std::sync::atomic::AtomicU8 =
     std::sync::atomic::AtomicU8::new(0);
 

--- a/crates/flock-core/src/pcs/ligerito/extension.rs
+++ b/crates/flock-core/src/pcs/ligerito/extension.rs
@@ -1431,6 +1431,12 @@ impl SumcheckProver256 {
         d: usize,
         want_la: bool,
     ) -> (SumcheckMessage256, Option<La256>) {
+        // The message needs a blocked pair; the degenerate shape below
+        // fabricates a zero message and belongs to the drains only.
+        debug_assert!(
+            self.f.len() >= 8 * d,
+            "mid_fold2 needs a blocked message pair; drains own the degenerate shape"
+        );
         let (nf, nb, msg, la) =
             fused_fold2_msg_ext(&self.f, &self.combined_basis, r0, r1, d, want_la);
         crate::scratch::give_f256(std::mem::replace(&mut self.f, nf));
@@ -1639,13 +1645,15 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
     l0_jit_basis: Option<BasisWindowFn<'_>>,
     l0_virtual_basis: Option<VirtualEqBasis>,
     mut first_msg: Option<SumcheckMessage>,
-    // Round-1 coefficients from the pcs combine's fused lookahead pass. The
-    // F128 driver consumed these via the fold_skip/fold2 state machine; this
-    // F256-ladder driver has no lookahead kernels yet, so they are accepted
-    // (the combine computes them either way) and unused — porting the
-    // two-rounds-per-pass schedule onto the ladder's fused folds is the
-    // recorded follow-up. Ignoring them cannot change the transcript: the
-    // lookahead is an exact polynomial identity over the same messages.
+    // Round-1 coefficients from the pcs combine's fused lookahead pass —
+    // the entry of the ladder's ALTERNATING SCHEDULE: round 1 becomes an
+    // O(1) skip (the coefficients evaluated at the F256 challenge, exact
+    // over the extension), the deferred fold fuses into the next pass, and
+    // every subsequent fold pass can emit the next round's La256 (the
+    // `alternation`/shape gates at the consumption site below decide).
+    // Byte-identical either way: the skip is an exact polynomial identity
+    // over the same messages, so `None` (or the A/B override) just takes
+    // the plain fold path.
     round1_lookahead: Option<FoldLookahead>,
     challenger: &mut Ch,
 ) -> LigeritoProof {
@@ -1819,6 +1827,10 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
         let challenge = challenger.sample_f256();
         lane_challenges.push(challenge);
         let last = j + 1 == initial_k;
+        // La production pays only when the NEXT round exists to consume it
+        // as a skip — the last round drains into the switch, so producing
+        // there is pure waste (+4 F256 muls per output quad).
+        let want_la = alternation && j + 2 < initial_k;
         let path;
         if last {
             // Materialize through any deferred challenge, then switch; the
@@ -1900,15 +1912,15 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
                     vb.fold_coord(p, r0);
                     vb.fold_coord(p, challenge);
                     let (msg, la) =
-                        sumcheck.first_fold2_virtual(r0, challenge, fold_block, &vb, alternation);
+                        sumcheck.first_fold2_virtual(r0, challenge, fold_block, &vb, want_la);
                     la_mid = la;
                     msg
                 } else {
                     path = "fold2";
                     let (msg, la) = if sumcheck.initial_pending() {
-                        sumcheck.first_fold2_materialized(r0, challenge, alternation)
+                        sumcheck.first_fold2_materialized(r0, challenge, want_la)
                     } else {
-                        sumcheck.mid_fold2(r0, challenge, fold_block, alternation)
+                        sumcheck.mid_fold2(r0, challenge, fold_block, want_la)
                     };
                     la_mid = la;
                     msg
@@ -1932,7 +1944,7 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
                         }
                         None => sumcheck.first_fold_jit(challenge, fold_block, fill),
                     }
-                } else if alternation && fold_block == 1 {
+                } else if want_la && fold_block == 1 {
                     path = "fold+la";
                     let (msg, la) = sumcheck.first_fold_materialized_la(challenge);
                     la_mid = la;
@@ -2057,6 +2069,10 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
             let challenge = challenger.sample_f256();
             level_challenges.push(challenge);
             let switching = j + 1 == k && i + 1 != r;
+            // As in the init loop: produce La only when the NEXT round
+            // consumes it — the pre-switch round of a non-final level
+            // drains, so its predecessor's La would be dead weight.
+            let want_la = alternation && (j + 2 < k || i + 1 == r);
             if switching {
                 // No message of this round's own survives (the switch's
                 // replaces it) — materialize through the deferred and
@@ -2076,10 +2092,10 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
                     level_pending = Some(challenge);
                     msg
                 } else if let Some(r0) = level_pending.take() {
-                    let (msg, la) = sumcheck.mid_fold2(r0, challenge, 1, alternation);
+                    let (msg, la) = sumcheck.mid_fold2(r0, challenge, 1, want_la);
                     level_la = la;
                     msg
-                } else if j == 0 && alternation {
+                } else if j == 0 && want_la {
                     let (msg, la) = sumcheck.fold_after_switch_la(challenge);
                     level_la = la;
                     msg

--- a/crates/flock-core/src/pcs/ligerito/extension.rs
+++ b/crates/flock-core/src/pcs/ligerito/extension.rs
@@ -461,59 +461,428 @@ fn lookahead_add_scaled(la: &mut FoldLookahead, ood: &FoldLookahead, beta: F128)
     }
 }
 
-/// FUSED double fold from the BASE arrays: fold by `r0` then `r1` (LSB
-/// pairing, `d = 1`) writing only the QUARTER-size outputs, and accumulate
-/// the next round's `(u_0, u_2)` — the deferred-fold half of the round-1
-/// lookahead skip. The half-size intermediate never exists.
-///
-/// VALUE-IDENTICAL to `fold_base(r0)` → `fold_extension(r1)` →
-/// `next_round_msg`: the per-element expression composes the two fold steps
-/// verbatim (`lo/hi = fold_step_base`, then `lo + r1·(hi + lo)`), and
-/// `u_0`/`u_2` are XOR-additive sums, so chunk order cannot change them.
+/// Mid-ladder alternation state: the NEXT round's message as a quadratic in
+/// its not-yet-sampled F256 fold challenge — the extension-coefficient
+/// counterpart of the combine pass's base-field [`FoldLookahead`]. Produced
+/// INSIDE fold passes (over the freshly folded outputs, +4 muls per output
+/// quad, four of the eight products shared with this round's message);
+/// consumed as an O(1) skip. Exact polynomial identity → transcripts are
+/// bit-identical to the fold-then-message path.
+/// Output-size cap for producing mid-chain coefficients: above it, the
+/// accumulation's extra products (and the wide accumulator's register
+/// pressure) measurably lose to the fold pass they would save (M4 Max,
+/// m32 lane-major: +10 ms at 2^23 outputs vs a ~7 ms fold); below it, the
+/// skip is a clean win by both traffic and product counts. The caller
+/// lookahead (free coefficients from the combine pass) is not capped.
+const LA_MAX_OUTPUTS: usize = 1 << 19;
+
+#[derive(Clone, Copy)]
+pub(super) struct La256 {
+    u0: [F256; 3],
+    u2: [F256; 3],
+}
+
+impl La256 {
+    #[inline]
+    fn eval(&self, r: F256) -> SumcheckMessage256 {
+        let r2 = r * r;
+        SumcheckMessage256 {
+            u_0: self.u0[0] + r * self.u0[1] + r2 * self.u0[2],
+            u_2: self.u2[0] + r * self.u2[1] + r2 * self.u2[2],
+        }
+    }
+}
+
+/// Per-quad accumulation over FOLDED outputs, under the pairing the NEXT
+/// fold uses: this round's message (pairs `(0,1)`, `(2,3)`) plus the next
+/// round's quadratic coefficients (next fold pairs `(0,1)`→slot 0,
+/// `(2,3)`→slot 1; next message pairs the slots). Char-2 collapses the
+/// Karatsuba middle factors: `A0+dA0 = af[1]`, `S+dS = af[1]+af[3]`.
+/// Accumulator layout: `[u0, u2, c0, c1, c2, d0, d1, d2]`.
+#[inline(always)]
+fn la_msg_quad(af: &[F256; 4], ab: &[F256; 4], acc: &mut [F256; 8]) {
+    let m1 = af[0] * ab[0];
+    let p1 = af[2] * ab[2];
+    let m2 = (af[0] + af[1]) * (ab[0] + ab[1]);
+    let p2 = (af[2] + af[3]) * (ab[2] + ab[3]);
+    let m3 = af[1] * ab[1];
+    let n1 = (af[0] + af[2]) * (ab[0] + ab[2]);
+    let n3 = (af[1] + af[3]) * (ab[1] + ab[3]);
+    let n2 = (af[0] + af[1] + af[2] + af[3]) * (ab[0] + ab[1] + ab[2] + ab[3]);
+    acc[0] += m1 + p1;
+    acc[1] += m2 + p2;
+    acc[2] += m1;
+    acc[3] += m1 + m2 + m3;
+    acc[4] += m2;
+    acc[5] += n1;
+    acc[6] += n1 + n2 + n3;
+    acc[7] += n2;
+}
+
+#[inline]
+fn acc8_add(mut a: [F256; 8], b: [F256; 8]) -> [F256; 8] {
+    for k in 0..8 {
+        a[k] += b[k];
+    }
+    a
+}
+
+#[inline]
+fn acc8_finish(acc: [F256; 8]) -> (SumcheckMessage256, La256) {
+    (
+        SumcheckMessage256 {
+            u_0: acc[0],
+            u_2: acc[1],
+        },
+        La256 {
+            u0: [acc[2], acc[3], acc[4]],
+            u2: [acc[5], acc[6], acc[7]],
+        },
+    )
+}
+
+#[inline]
+fn fold2_step_base(a: &[F128], i: usize, r0: F256, r1: F256) -> F256 {
+    let lo = F256::from(a[i]) + r0 * (a[i + 1] + a[i]);
+    let hi = F256::from(a[i + 2]) + r0 * (a[i + 3] + a[i + 2]);
+    lo + r1 * (hi + lo)
+}
+
+#[inline]
+fn fold2_step_ext_blocked(a: &[F256], i: usize, d: usize, r0: F256, r1: F256) -> F256 {
+    let lo = fold_step_ext(a, i, i + d, r0);
+    let hi = fold_step_ext(a, i + 2 * d, i + 3 * d, r0);
+    lo + r1 * (hi + lo)
+}
+
+/// FUSED double fold from the BASE arrays (LSB pairing): fold by `(r0, r1)`
+/// straight to the quarter-size state — the half-size intermediate never
+/// exists — and accumulate the next round's message plus, when `want_la`,
+/// the round after's coefficients ([`La256`]) over the same in-register
+/// outputs. VALUE-IDENTICAL to the unfused chain: the per-element
+/// expression composes the fold steps verbatim and all sums are
+/// XOR-additive.
 fn fused_fold2_msg_base(
     f: &[F128],
     b: &[F128],
     r0: F256,
     r1: F256,
-) -> (Vec<F256>, Vec<F256>, SumcheckMessage256) {
+    want_la: bool,
+) -> (Vec<F256>, Vec<F256>, SumcheckMessage256, Option<La256>) {
     debug_assert_eq!(f.len(), b.len());
     let quarter = f.len() / 4;
     debug_assert!(quarter >= 2 && quarter.is_power_of_two());
-    let zero2 = || (F256::ZERO, F256::ZERO);
-    let sum2 = |(a0, a2): (F256, F256), (b0, b2): (F256, F256)| (a0 + b0, a2 + b2);
+    let want_la = want_la && (4..=LA_MAX_OUTPUTS).contains(&quarter);
     let mut nf = crate::scratch::take_f256(quarter);
     let mut nb = crate::scratch::take_f256(quarter);
-    let fold2 = |a: &[F128], i: usize| -> F256 {
-        let lo = F256::from(a[i]) + r0 * (a[i + 1] + a[i]);
-        let hi = F256::from(a[i + 2]) + r0 * (a[i + 3] + a[i + 2]);
-        lo + r1 * (hi + lo)
-    };
-    // Chunk on message-block boundaries (2 outputs per block).
-    let chunk = (1usize << 12).clamp(2, quarter);
-    debug_assert!(chunk.is_multiple_of(2));
-    let (u_0, u_2) = nf
+    let gran = if want_la { 4 } else { 2 };
+    let chunk = (1usize << 12).clamp(gran, quarter);
+    debug_assert!(chunk.is_multiple_of(gran));
+    let acc = nf
         .par_chunks_mut(chunk)
         .zip(nb.par_chunks_mut(chunk))
         .enumerate()
         .map(|(ci, (fo, bo))| {
             let out0 = ci * chunk;
+            let mut acc = [F256::ZERO; 8];
             for (k, (fslot, bslot)) in fo.iter_mut().zip(bo.iter_mut()).enumerate() {
                 let i = 4 * (out0 + k);
-                *fslot = fold2(f, i);
-                *bslot = fold2(b, i);
+                *fslot = fold2_step_base(f, i, r0, r1);
+                *bslot = fold2_step_base(b, i, r0, r1);
             }
-            let mut u0 = F256::ZERO;
-            let mut u2 = F256::ZERO;
-            for j in 0..fo.len() / 2 {
-                let (f0, f1) = (fo[2 * j], fo[2 * j + 1]);
-                let (b0, b1) = (bo[2 * j], bo[2 * j + 1]);
-                u0 += f0 * b0;
-                u2 += (f0 + f1) * (b0 + b1);
+            if want_la {
+                for (fq, bq) in fo.as_chunks::<4>().0.iter().zip(bo.as_chunks::<4>().0) {
+                    la_msg_quad(fq, bq, &mut acc);
+                }
+            } else {
+                for j in 0..fo.len() / 2 {
+                    acc[0] += fo[2 * j] * bo[2 * j];
+                    acc[1] += (fo[2 * j] + fo[2 * j + 1]) * (bo[2 * j] + bo[2 * j + 1]);
+                }
             }
-            (u0, u2)
+            acc
         })
-        .reduce(zero2, sum2);
-    (nf, nb, SumcheckMessage256 { u_0, u_2 })
+        .reduce(|| [F256::ZERO; 8], acc8_add);
+    let (msg, la) = acc8_finish(acc);
+    (nf, nb, msg, want_la.then_some(la))
+}
+
+/// FUSED double fold of the EXTENSION state (block pairing `d`): the
+/// mid-chain pass of the alternating schedule — absorbs the deferred skip
+/// challenge `r0` and this round's `r1` in one sweep, quarter-size outputs,
+/// message + optional next-round coefficients. The lane-major geometry
+/// (few huge 4d-superblocks) splits the k dimension.
+fn fused_fold2_msg_ext(
+    f: &[F256],
+    b: &[F256],
+    r0: F256,
+    r1: F256,
+    d: usize,
+    want_la: bool,
+) -> (Vec<F256>, Vec<F256>, SumcheckMessage256, Option<La256>) {
+    debug_assert_eq!(f.len(), b.len());
+    let quarter = f.len() / 4;
+    // `quarter >= d` is the fold's own requirement; the MESSAGE additionally
+    // needs a blocked pair (`quarter >= 2d`) — drains (which discard it) are
+    // the only callers below that.
+    debug_assert!(d.is_power_of_two() && quarter.is_power_of_two() && quarter >= d);
+    let want_la = want_la && quarter >= 4 * d && quarter <= LA_MAX_OUTPUTS;
+    let sblock = if want_la { 4 * d } else { 2 * d };
+    let mut nf = crate::scratch::take_f256(quarter);
+    let mut nb = crate::scratch::take_f256(quarter);
+    // Output o = b·d + w composes inputs {4bd+w, +d, +2d, +3d}; a superblock
+    // of `sblock` outputs reads the 4·sblock inputs at 4·(superblock start).
+    // The split-based big-block branch requires FULL superblocks; smaller
+    // arrays (the big-d drain shapes) take the chunked branch, whose
+    // n_segs-aware loop writes every output.
+    if quarter == d {
+        // Degenerate (drain-only) shape: one block, no message pairs —
+        // parallelize the k dimension directly. The message/coefficients
+        // are meaningless here (callers discard them).
+        nf.par_chunks_mut(1 << 12)
+            .zip(nb.par_chunks_mut(1 << 12))
+            .enumerate()
+            .for_each(|(ci, (fo, bo))| {
+                let k0 = ci << 12;
+                for (k, (fs, bs)) in fo.iter_mut().zip(bo.iter_mut()).enumerate() {
+                    *fs = fold2_step_ext_blocked(f, k0 + k, d, r0, r1);
+                    *bs = fold2_step_ext_blocked(b, k0 + k, d, r0, r1);
+                }
+            });
+        return (
+            nf,
+            nb,
+            SumcheckMessage256 {
+                u_0: F256::ZERO,
+                u_2: F256::ZERO,
+            },
+            None,
+        );
+    }
+    let acc = if sblock >= (1 << 16) && quarter >= sblock {
+        // Few huge superblocks: split each segment's k dimension too.
+        const KC: usize = 1 << 13;
+        nf.par_chunks_mut(sblock)
+            .zip(nb.par_chunks_mut(sblock))
+            .enumerate()
+            .map(|(jb, (fblk, bblk))| {
+                let out0 = jb * sblock;
+                let in0 = 4 * out0;
+                if want_la {
+                    // 4 d-segments per superblock (the la quad).
+                    let (f0, fr) = fblk.split_at_mut(d);
+                    let (f1, fr2) = fr.split_at_mut(d);
+                    let (f2, f3) = fr2.split_at_mut(d);
+                    let (b0, br) = bblk.split_at_mut(d);
+                    let (b1, br2) = br.split_at_mut(d);
+                    let (b2, b3) = br2.split_at_mut(d);
+                    f0.par_chunks_mut(KC)
+                        .zip(f1.par_chunks_mut(KC))
+                        .zip(f2.par_chunks_mut(KC).zip(f3.par_chunks_mut(KC)))
+                        .zip(
+                            b0.par_chunks_mut(KC)
+                                .zip(b1.par_chunks_mut(KC))
+                                .zip(b2.par_chunks_mut(KC).zip(b3.par_chunks_mut(KC))),
+                        )
+                        .enumerate()
+                        .map(
+                            |(kc, (((fc0, fc1), (fc2, fc3)), ((bc0, bc1), (bc2, bc3))))| {
+                                let k0 = kc * KC;
+                                let mut acc = [F256::ZERO; 8];
+                                for k in 0..fc0.len() {
+                                    let i = in0 + k0 + k;
+                                    let af = [
+                                        fold2_step_ext_blocked(f, i, d, r0, r1),
+                                        fold2_step_ext_blocked(f, i + 4 * d, d, r0, r1),
+                                        fold2_step_ext_blocked(f, i + 8 * d, d, r0, r1),
+                                        fold2_step_ext_blocked(f, i + 12 * d, d, r0, r1),
+                                    ];
+                                    let ab = [
+                                        fold2_step_ext_blocked(b, i, d, r0, r1),
+                                        fold2_step_ext_blocked(b, i + 4 * d, d, r0, r1),
+                                        fold2_step_ext_blocked(b, i + 8 * d, d, r0, r1),
+                                        fold2_step_ext_blocked(b, i + 12 * d, d, r0, r1),
+                                    ];
+                                    fc0[k] = af[0];
+                                    fc1[k] = af[1];
+                                    fc2[k] = af[2];
+                                    fc3[k] = af[3];
+                                    bc0[k] = ab[0];
+                                    bc1[k] = ab[1];
+                                    bc2[k] = ab[2];
+                                    bc3[k] = ab[3];
+                                    la_msg_quad(&af, &ab, &mut acc);
+                                }
+                                acc
+                            },
+                        )
+                        .reduce(|| [F256::ZERO; 8], acc8_add)
+                } else {
+                    // 2 d-segments (message pairs only — the drain shape).
+                    let (f0, f1) = fblk.split_at_mut(d);
+                    let (b0, b1) = bblk.split_at_mut(d);
+                    f0.par_chunks_mut(KC)
+                        .zip(f1.par_chunks_mut(KC))
+                        .zip(b0.par_chunks_mut(KC).zip(b1.par_chunks_mut(KC)))
+                        .enumerate()
+                        .map(|(kc, ((fc0, fc1), (bc0, bc1)))| {
+                            let k0 = kc * KC;
+                            let mut acc = [F256::ZERO; 8];
+                            for k in 0..fc0.len() {
+                                let i = in0 + k0 + k;
+                                let flo = fold2_step_ext_blocked(f, i, d, r0, r1);
+                                let fhi = fold2_step_ext_blocked(f, i + 4 * d, d, r0, r1);
+                                let blo = fold2_step_ext_blocked(b, i, d, r0, r1);
+                                let bhi = fold2_step_ext_blocked(b, i + 4 * d, d, r0, r1);
+                                fc0[k] = flo;
+                                fc1[k] = fhi;
+                                bc0[k] = blo;
+                                bc1[k] = bhi;
+                                acc[0] += flo * blo;
+                                acc[1] += (flo + fhi) * (blo + bhi);
+                            }
+                            acc
+                        })
+                        .reduce(|| [F256::ZERO; 8], acc8_add)
+                }
+            })
+            .reduce(|| [F256::ZERO; 8], acc8_add)
+    } else {
+        let chunk = sblock.max(1 << 12).min(quarter);
+        debug_assert!(chunk.is_multiple_of(sblock) || chunk == quarter);
+        let dd = d.min(quarter);
+        nf.par_chunks_mut(chunk)
+            .zip(nb.par_chunks_mut(chunk))
+            .enumerate()
+            .map(|(ci, (fo, bo))| {
+                let out0 = ci * chunk;
+                let mut acc = [F256::ZERO; 8];
+                for (js, (fblk, bblk)) in
+                    fo.chunks_mut(sblock).zip(bo.chunks_mut(sblock)).enumerate()
+                {
+                    let ob = out0 + js * sblock;
+                    let in0 = 4 * ob;
+                    let n_segs = fblk.len() / dd;
+                    for k in 0..dd {
+                        let mut outs = [F256::ZERO; 4];
+                        let mut outsb = [F256::ZERO; 4];
+                        for s in 0..n_segs {
+                            outs[s] = fold2_step_ext_blocked(f, in0 + 4 * s * d + k, d, r0, r1);
+                            outsb[s] = fold2_step_ext_blocked(b, in0 + 4 * s * d + k, d, r0, r1);
+                            fblk[s * dd + k] = outs[s];
+                            bblk[s * dd + k] = outsb[s];
+                        }
+                        if n_segs == 4 {
+                            la_msg_quad(&outs, &outsb, &mut acc);
+                        } else if n_segs >= 2 {
+                            acc[0] += outs[0] * outsb[0];
+                            acc[1] += (outs[0] + outs[1]) * (outsb[0] + outsb[1]);
+                        }
+                    }
+                }
+                acc
+            })
+            .reduce(|| [F256::ZERO; 8], acc8_add)
+    };
+    let (msg, la) = acc8_finish(acc);
+    (nf, nb, msg, want_la.then_some(la))
+}
+
+/// FUSED single fold + message + next-round coefficients for a level's
+/// FIRST round (the just-split base-valued f-side, LSB pairing) — the
+/// alternation ENTRY of every recursive level: the pass that already runs
+/// also produces the coefficients that make the level's second round a
+/// skip.
+fn fused_fold_msg_la_fbase(
+    f: &[F256],
+    b: &[F256],
+    r: F256,
+) -> (Vec<F256>, Vec<F256>, SumcheckMessage256, Option<La256>) {
+    debug_assert_eq!(f.len(), b.len());
+    let half = f.len() / 2;
+    debug_assert!(half.is_power_of_two() && half >= 4);
+    debug_assert!(half <= LA_MAX_OUTPUTS, "caller gates by size");
+    let mut nf = crate::scratch::take_f256(half);
+    let mut nb = crate::scratch::take_f256(half);
+    let chunk = (1usize << 12).clamp(4, half);
+    debug_assert!(chunk.is_multiple_of(4));
+    let acc = nf
+        .par_chunks_mut(chunk)
+        .zip(nb.par_chunks_mut(chunk))
+        .enumerate()
+        .map(|(ci, (fo, bo))| {
+            let out0 = ci * chunk;
+            let mut acc = [F256::ZERO; 8];
+            for (q, (fq_o, bq_o)) in fo
+                .as_chunks_mut::<4>()
+                .0
+                .iter_mut()
+                .zip(bo.as_chunks_mut::<4>().0)
+                .enumerate()
+            {
+                let base = 2 * (out0 + 4 * q);
+                let mut af = [F256::ZERO; 4];
+                let mut ab = [F256::ZERO; 4];
+                for t in 0..4 {
+                    af[t] = fold_step_split_base(f, base + 2 * t, base + 2 * t + 1, r);
+                    ab[t] = fold_step_ext(b, base + 2 * t, base + 2 * t + 1, r);
+                }
+                *fq_o = af;
+                *bq_o = ab;
+                la_msg_quad(&af, &ab, &mut acc);
+            }
+            acc
+        })
+        .reduce(|| [F256::ZERO; 8], acc8_add);
+    let (msg, la) = acc8_finish(acc);
+    (nf, nb, msg, Some(la))
+}
+
+/// [`fused_fold_msg_la_fbase`] for the ladder-entry BASE arrays (both sides
+/// F128, LSB): the no-caller-lookahead fallback that still starts the
+/// alternating schedule at round 0.
+fn fused_fold_msg_la_base(
+    f: &[F128],
+    b: &[F128],
+    r: F256,
+) -> (Vec<F256>, Vec<F256>, SumcheckMessage256, Option<La256>) {
+    debug_assert_eq!(f.len(), b.len());
+    let half = f.len() / 2;
+    debug_assert!(half.is_power_of_two() && half >= 4);
+    let mut nf = crate::scratch::take_f256(half);
+    let mut nb = crate::scratch::take_f256(half);
+    let chunk = (1usize << 12).clamp(4, half);
+    debug_assert!(chunk.is_multiple_of(4));
+    let acc = nf
+        .par_chunks_mut(chunk)
+        .zip(nb.par_chunks_mut(chunk))
+        .enumerate()
+        .map(|(ci, (fo, bo))| {
+            let out0 = ci * chunk;
+            let mut acc = [F256::ZERO; 8];
+            for (q, (fq_o, bq_o)) in fo
+                .as_chunks_mut::<4>()
+                .0
+                .iter_mut()
+                .zip(bo.as_chunks_mut::<4>().0)
+                .enumerate()
+            {
+                let base = 2 * (out0 + 4 * q);
+                let mut af = [F256::ZERO; 4];
+                let mut ab = [F256::ZERO; 4];
+                for t in 0..4 {
+                    af[t] = fold_step_base(f, base + 2 * t, base + 2 * t + 1, r);
+                    ab[t] = fold_step_base(b, base + 2 * t, base + 2 * t + 1, r);
+                }
+                *fq_o = af;
+                *bq_o = ab;
+                la_msg_quad(&af, &ab, &mut acc);
+            }
+            acc
+        })
+        .reduce(|| [F256::ZERO; 8], acc8_add);
+    let (msg, la) = acc8_finish(acc);
+    (nf, nb, msg, Some(la))
 }
 
 /// FUSED first virtual fold: one sweep folds `f` by `r`, EVALUATES the
@@ -615,106 +984,159 @@ fn fused_first_fold_virtual(
 /// FUSED double fold with a VIRTUAL basis: fold `f` by `(r0, r1)` (block
 /// pairing `d`) straight to the quarter-size state, EVALUATE the
 /// twice-folded virtual basis directly into `nb`, and accumulate the next
-/// round's message — the factored-basis counterpart of
-/// [`fused_fold2_msg_base`], and the lane-major consumer of the seeded
-/// EqPoint combine's round-1 lookahead. `basis` must already be folded by
-/// BOTH challenges (two `fold_coord`s); its index space is exactly the
-/// output's. Value-identical to fold → materialize → fold → message: the
-/// fold expression composes the two steps verbatim, `nb[o]` is the same
-/// per-term XOR-sum `fill` writes, the message pairing matches
-/// `next_round_msg(nf, nb, d)`, and the sums are XOR-additive.
+/// round's message plus (when `want_la`) the round after's coefficients —
+/// the lane-major alternation entry. `basis` must already be folded by BOTH
+/// challenges; its index space is exactly the output's. Value-identical to
+/// fold → materialize → fold → message: the fold expression composes the two
+/// steps verbatim, `nb[o]` is the same per-term XOR-sum `fill` writes, the
+/// pairings match `next_round_msg(nf, nb, d)`, and all sums are
+/// XOR-additive.
 fn fused_first_fold2_virtual(
     f: &[F128],
     basis: &VirtualEqBasis256,
     r0: F256,
     r1: F256,
     d: usize,
-) -> (Vec<F256>, Vec<F256>, SumcheckMessage256) {
+    want_la: bool,
+) -> (Vec<F256>, Vec<F256>, SumcheckMessage256, Option<La256>) {
     let quarter = f.len() / 4;
     debug_assert_eq!(basis.len(), quarter);
     debug_assert!(d.is_power_of_two() && quarter.is_power_of_two() && quarter >= 2 * d);
-    let block = 2 * d;
-    let zero2 = || (F256::ZERO, F256::ZERO);
-    let sum2 = |(a0, a2): (F256, F256), (b0, b2): (F256, F256)| (a0 + b0, a2 + b2);
+    let want_la = want_la && quarter >= 4 * d && quarter <= LA_MAX_OUTPUTS;
+    let sblock = if want_la { 4 * d } else { 2 * d };
     let mut nf = crate::scratch::take_f256(quarter);
     let mut nb = crate::scratch::take_f256(quarter);
-    // Output o = b·d + w composes inputs {4bd+w, +d, +2d, +3d}; a message
-    // block of 2d outputs therefore reads the 8d inputs at 4·(block start).
+    // Output o = b·d + w composes f inputs {4bd+w, +d, +2d, +3d}.
     let fold2 = |i: usize| -> F256 {
         let lo = F256::from(f[i]) + r0 * (f[i + d] + f[i]);
         let hi = F256::from(f[i + 2 * d]) + r0 * (f[i + 3 * d] + f[i + 2 * d]);
         lo + r1 * (hi + lo)
     };
-    let (u_0, u_2) = if block >= (1 << 16) {
+    let acc = if sblock >= (1 << 16) && quarter >= sblock {
         const KC: usize = 1 << 13;
-        nf.par_chunks_mut(block)
-            .zip(nb.par_chunks_mut(block))
+        nf.par_chunks_mut(sblock)
+            .zip(nb.par_chunks_mut(sblock))
             .enumerate()
             .map(|(jb, (fblk, bblk))| {
-                let out0 = jb * block;
+                let out0 = jb * sblock;
                 let in0 = 4 * out0;
-                let (flo_h, fhi_h) = fblk.split_at_mut(d);
-                let (blo_h, bhi_h) = bblk.split_at_mut(d);
-                flo_h
-                    .par_chunks_mut(KC)
-                    .zip(fhi_h.par_chunks_mut(KC))
-                    .zip(blo_h.par_chunks_mut(KC).zip(bhi_h.par_chunks_mut(KC)))
-                    .enumerate()
-                    .map(|(kc, ((flc, fhc), (blc, bhc)))| {
-                        let k0 = kc * KC;
-                        let mut u0 = F256::ZERO;
-                        let mut u2 = F256::ZERO;
-                        for k in 0..flc.len() {
-                            let i = in0 + k0 + k;
-                            let o = out0 + k0 + k;
-                            let flo = fold2(i);
-                            let fhi = fold2(i + 4 * d);
-                            let blo = basis.value_sum_at(o);
-                            let bhi = basis.value_sum_at(o + d);
-                            flc[k] = flo;
-                            fhc[k] = fhi;
-                            blc[k] = blo;
-                            bhc[k] = bhi;
-                            u0 += flo * blo;
-                            u2 += (flo + fhi) * (blo + bhi);
-                        }
-                        (u0, u2)
-                    })
-                    .reduce(zero2, sum2)
+                if want_la {
+                    let (f0, fr) = fblk.split_at_mut(d);
+                    let (f1, fr2) = fr.split_at_mut(d);
+                    let (f2, f3) = fr2.split_at_mut(d);
+                    let (b0, br) = bblk.split_at_mut(d);
+                    let (b1, br2) = br.split_at_mut(d);
+                    let (b2, b3) = br2.split_at_mut(d);
+                    f0.par_chunks_mut(KC)
+                        .zip(f1.par_chunks_mut(KC))
+                        .zip(f2.par_chunks_mut(KC).zip(f3.par_chunks_mut(KC)))
+                        .zip(
+                            b0.par_chunks_mut(KC)
+                                .zip(b1.par_chunks_mut(KC))
+                                .zip(b2.par_chunks_mut(KC).zip(b3.par_chunks_mut(KC))),
+                        )
+                        .enumerate()
+                        .map(
+                            |(kc, (((fc0, fc1), (fc2, fc3)), ((bc0, bc1), (bc2, bc3))))| {
+                                let k0 = kc * KC;
+                                let mut acc = [F256::ZERO; 8];
+                                for k in 0..fc0.len() {
+                                    let i = in0 + k0 + k;
+                                    let o = out0 + k0 + k;
+                                    let af = [
+                                        fold2(i),
+                                        fold2(i + 4 * d),
+                                        fold2(i + 8 * d),
+                                        fold2(i + 12 * d),
+                                    ];
+                                    let ab = [
+                                        basis.value_sum_at(o),
+                                        basis.value_sum_at(o + d),
+                                        basis.value_sum_at(o + 2 * d),
+                                        basis.value_sum_at(o + 3 * d),
+                                    ];
+                                    fc0[k] = af[0];
+                                    fc1[k] = af[1];
+                                    fc2[k] = af[2];
+                                    fc3[k] = af[3];
+                                    bc0[k] = ab[0];
+                                    bc1[k] = ab[1];
+                                    bc2[k] = ab[2];
+                                    bc3[k] = ab[3];
+                                    la_msg_quad(&af, &ab, &mut acc);
+                                }
+                                acc
+                            },
+                        )
+                        .reduce(|| [F256::ZERO; 8], acc8_add)
+                } else {
+                    let (f0, f1) = fblk.split_at_mut(d);
+                    let (b0, b1) = bblk.split_at_mut(d);
+                    f0.par_chunks_mut(KC)
+                        .zip(f1.par_chunks_mut(KC))
+                        .zip(b0.par_chunks_mut(KC).zip(b1.par_chunks_mut(KC)))
+                        .enumerate()
+                        .map(|(kc, ((fc0, fc1), (bc0, bc1)))| {
+                            let k0 = kc * KC;
+                            let mut acc = [F256::ZERO; 8];
+                            for k in 0..fc0.len() {
+                                let i = in0 + k0 + k;
+                                let o = out0 + k0 + k;
+                                let flo = fold2(i);
+                                let fhi = fold2(i + 4 * d);
+                                let blo = basis.value_sum_at(o);
+                                let bhi = basis.value_sum_at(o + d);
+                                fc0[k] = flo;
+                                fc1[k] = fhi;
+                                bc0[k] = blo;
+                                bc1[k] = bhi;
+                                acc[0] += flo * blo;
+                                acc[1] += (flo + fhi) * (blo + bhi);
+                            }
+                            acc
+                        })
+                        .reduce(|| [F256::ZERO; 8], acc8_add)
+                }
             })
-            .reduce(zero2, sum2)
+            .reduce(|| [F256::ZERO; 8], acc8_add)
     } else {
-        let chunk = block.max(1 << 12).min(quarter);
-        debug_assert!(chunk.is_multiple_of(block) || chunk == quarter);
+        let chunk = sblock.max(1 << 12).min(quarter);
+        debug_assert!(chunk.is_multiple_of(sblock) || chunk == quarter);
         nf.par_chunks_mut(chunk)
             .zip(nb.par_chunks_mut(chunk))
             .enumerate()
             .map(|(ci, (fo, bo))| {
-                let mut u0 = F256::ZERO;
-                let mut u2 = F256::ZERO;
                 let out0 = ci * chunk;
-                for (jo, (fblk, bblk)) in fo.chunks_mut(block).zip(bo.chunks_mut(block)).enumerate()
+                let mut acc = [F256::ZERO; 8];
+                for (js, (fblk, bblk)) in
+                    fo.chunks_mut(sblock).zip(bo.chunks_mut(sblock)).enumerate()
                 {
-                    let ob = out0 + jo * block;
+                    let ob = out0 + js * sblock;
                     let in0 = 4 * ob;
+                    let n_segs = fblk.len() / d;
                     for k in 0..d {
-                        let flo = fold2(in0 + k);
-                        let fhi = fold2(in0 + 4 * d + k);
-                        let blo = basis.value_sum_at(ob + k);
-                        let bhi = basis.value_sum_at(ob + d + k);
-                        fblk[k] = flo;
-                        fblk[d + k] = fhi;
-                        bblk[k] = blo;
-                        bblk[d + k] = bhi;
-                        u0 += flo * blo;
-                        u2 += (flo + fhi) * (blo + bhi);
+                        let mut af = [F256::ZERO; 4];
+                        let mut ab = [F256::ZERO; 4];
+                        for s in 0..n_segs {
+                            af[s] = fold2(in0 + 4 * s * d + k);
+                            ab[s] = basis.value_sum_at(ob + s * d + k);
+                            fblk[s * d + k] = af[s];
+                            bblk[s * d + k] = ab[s];
+                        }
+                        if n_segs == 4 {
+                            la_msg_quad(&af, &ab, &mut acc);
+                        } else {
+                            acc[0] += af[0] * ab[0];
+                            acc[1] += (af[0] + af[1]) * (ab[0] + ab[1]);
+                        }
                     }
                 }
-                (u0, u2)
+                acc
             })
-            .reduce(zero2, sum2)
+            .reduce(|| [F256::ZERO; 8], acc8_add)
     };
-    (nf, nb, SumcheckMessage256 { u_0, u_2 })
+    let (msg, la) = acc8_finish(acc);
+    (nf, nb, msg, want_la.then_some(la))
 }
 
 struct VirtualEqTerm256 {
@@ -906,26 +1328,39 @@ impl SumcheckProver256 {
         msg
     }
 
-    /// Round-1 SKIP: the message came from the caller's lookahead evaluated
-    /// at the round-0 challenge ([`lookahead_eval256`]); record it — the
-    /// array fold is deferred into [`Self::first_fold2_materialized`].
-    pub(super) fn skip_first_fold(&mut self, msg: SumcheckMessage256) {
+    /// A SKIP round: the message came from a lookahead evaluation (the
+    /// caller's base-field coefficients at round 1, or a mid-ladder
+    /// [`La256`]); record it — the array fold is deferred into the next
+    /// fold2 pass (or a drain).
+    pub(super) fn push_skip_message(&mut self, msg: SumcheckMessage256) {
         self.transcript.push(msg);
     }
 
-    /// The deferred round-0 fold fused with round 1's: double-fold the base
+    /// Whether the ladder-entry base arrays are still unconsumed (the first
+    /// fold has not run) — decides which fold2 variant a deferred challenge
+    /// takes.
+    pub(super) fn initial_pending(&self) -> bool {
+        self.initial_f.is_some()
+    }
+
+    /// The deferred fold fused with this round's: double-fold the base
     /// arrays by `(r0, r1)` in ONE pass straight to the quarter-size F256
-    /// state ([`fused_fold2_msg_base`]) — the half-size intermediate is
-    /// never written. LSB pairing only (the lookahead never arrives on the
-    /// lane-major path).
-    pub(super) fn first_fold2_materialized(&mut self, r0: F256, r1: F256) -> SumcheckMessage256 {
+    /// state — the half-size intermediate is never written. LSB pairing
+    /// only (the caller lookahead never arrives on the lane-major
+    /// materialized path).
+    pub(super) fn first_fold2_materialized(
+        &mut self,
+        r0: F256,
+        r1: F256,
+        want_la: bool,
+    ) -> (SumcheckMessage256, Option<La256>) {
         let f = self.initial_f.take().expect("first fold already consumed");
         let b = self.initial_b.take().expect("materialized basis missing");
-        let (nf, nb, msg) = fused_fold2_msg_base(&f, &b, r0, r1);
+        let (nf, nb, msg, la) = fused_fold2_msg_base(&f, &b, r0, r1, want_la);
         self.f = nf;
         self.combined_basis = nb;
         self.transcript.push(msg);
-        msg
+        (msg, la)
     }
 
     /// [`Self::first_fold2_materialized`] for the VIRTUAL basis (the
@@ -936,13 +1371,90 @@ impl SumcheckProver256 {
         r1: F256,
         d: usize,
         basis: &VirtualEqBasis256,
-    ) -> SumcheckMessage256 {
+        want_la: bool,
+    ) -> (SumcheckMessage256, Option<La256>) {
         let f = self.initial_f.take().expect("first fold already consumed");
-        let (nf, nb, msg) = fused_first_fold2_virtual(&f, basis, r0, r1, d);
+        let (nf, nb, msg, la) = fused_first_fold2_virtual(&f, basis, r0, r1, d, want_la);
         self.f = nf;
         self.combined_basis = nb;
         self.transcript.push(msg);
-        msg
+        (msg, la)
+    }
+
+    /// Ladder-entry single fold + message + next-round coefficients (base
+    /// arrays, LSB): starts the alternating schedule when no caller
+    /// lookahead arrived. Falls back to the plain fused fold when the
+    /// arrays are too small for coefficient quads.
+    pub(super) fn first_fold_materialized_la(
+        &mut self,
+        r: F256,
+    ) -> (SumcheckMessage256, Option<La256>) {
+        if self
+            .initial_f
+            .as_ref()
+            .is_none_or(|f| f.len() < 8 || f.len() / 2 > LA_MAX_OUTPUTS)
+        {
+            return (self.first_fold_materialized(r, 1), None);
+        }
+        let f = self.initial_f.take().expect("first fold already consumed");
+        let b = self.initial_b.take().expect("materialized basis missing");
+        let (nf, nb, msg, la) = fused_fold_msg_la_base(&f, &b, r);
+        self.f = nf;
+        self.combined_basis = nb;
+        self.transcript.push(msg);
+        (msg, la)
+    }
+
+    /// A recursive level's FIRST fold + the level's alternation entry: the
+    /// fbase fold pass also emits the next round's coefficients. Runs AFTER
+    /// every glue, so the coefficients are always fresh — no corrections.
+    pub(super) fn fold_after_switch_la(&mut self, r: F256) -> (SumcheckMessage256, Option<La256>) {
+        if !fused_fold_applies(self.f.len(), 1)
+            || self.f.len() < 8
+            || self.f.len() / 2 > LA_MAX_OUTPUTS
+        {
+            return (self.fold_after_switch(r), None);
+        }
+        let (nf, nb, msg, la) = fused_fold_msg_la_fbase(&self.f, &self.combined_basis, r);
+        crate::scratch::give_f256(std::mem::replace(&mut self.f, nf));
+        crate::scratch::give_f256(std::mem::replace(&mut self.combined_basis, nb));
+        self.transcript.push(msg);
+        (msg, la)
+    }
+
+    /// Mid-chain double fold (extension state, block pairing `d`): absorbs
+    /// the deferred skip challenge and this round's in one pass.
+    pub(super) fn mid_fold2(
+        &mut self,
+        r0: F256,
+        r1: F256,
+        d: usize,
+        want_la: bool,
+    ) -> (SumcheckMessage256, Option<La256>) {
+        let (nf, nb, msg, la) =
+            fused_fold2_msg_ext(&self.f, &self.combined_basis, r0, r1, d, want_la);
+        crate::scratch::give_f256(std::mem::replace(&mut self.f, nf));
+        crate::scratch::give_f256(std::mem::replace(&mut self.combined_basis, nb));
+        self.transcript.push(msg);
+        (msg, la)
+    }
+
+    /// Message-free double fold — the pre-switch drain when the previous
+    /// round was a skip (the switch's own message replaces this round's).
+    pub(super) fn fold2_drain(&mut self, r0: F256, r1: F256, d: usize) {
+        let (nf, nb, _msg, _) =
+            fused_fold2_msg_ext(&self.f, &self.combined_basis, r0, r1, d, false);
+        crate::scratch::give_f256(std::mem::replace(&mut self.f, nf));
+        crate::scratch::give_f256(std::mem::replace(&mut self.combined_basis, nb));
+    }
+
+    /// Message-free single fold — the drain before a switch (or the final
+    /// residual) when this round's message came from a skip or is replaced.
+    pub(super) fn drain(&mut self, r: F256, d: usize) {
+        let nf = fold_extension(&self.f, r, d);
+        let nb = fold_extension(&self.combined_basis, r, d);
+        crate::scratch::give_f256(std::mem::replace(&mut self.f, nf));
+        crate::scratch::give_f256(std::mem::replace(&mut self.combined_basis, nb));
     }
 
     pub(super) fn fold_materialized(&mut self, r: F256, d: usize) -> SumcheckMessage256 {
@@ -988,17 +1500,32 @@ impl SumcheckProver256 {
     /// a representation change at the same sumcheck boundary.
     pub(super) fn code_switch_and_replace_message(&mut self) -> SumcheckMessage256 {
         assert!(self.pending.is_none());
-        let words = split_coordinates(&self.f);
-        let split_f = words.into_iter().map(F256::from).collect();
-        crate::scratch::give_f256(std::mem::replace(&mut self.f, split_f));
-        let split_b = split_basis(&self.combined_basis);
-        crate::scratch::give_f256(std::mem::replace(&mut self.combined_basis, split_b));
-        let msg = round_msg_fbase(&self.f, &self.combined_basis);
+        let msg = self.code_switch_message();
         *self
             .transcript
             .last_mut()
             .expect("a fold message must precede a code switch") = msg;
         msg
+    }
+
+    /// The code switch when the last fold round emitted NO message (it was
+    /// a skip or a drain under the alternating schedule): the switch's
+    /// message is PUSHED as that round's — same transcript contents as
+    /// fold-then-replace, one entry per round either way.
+    pub(super) fn code_switch_and_push_message(&mut self) -> SumcheckMessage256 {
+        assert!(self.pending.is_none());
+        let msg = self.code_switch_message();
+        self.transcript.push(msg);
+        msg
+    }
+
+    fn code_switch_message(&mut self) -> SumcheckMessage256 {
+        let words = split_coordinates(&self.f);
+        let split_f = words.into_iter().map(F256::from).collect();
+        crate::scratch::give_f256(std::mem::replace(&mut self.f, split_f));
+        let split_b = split_basis(&self.combined_basis);
+        crate::scratch::give_f256(std::mem::replace(&mut self.combined_basis, split_b));
+        round_msg_fbase(&self.f, &self.combined_basis)
     }
 
     fn introduce_extension(&mut self, basis: Vec<F256>, claim: F256) -> SumcheckMessage256 {
@@ -1187,14 +1714,14 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
     // (len ≥ 8·d). FLOCK_NO_FOLD_LOOKAHEAD=1 / FOLD_LOOKAHEAD_OVERRIDE is
     // the A/B knob — value-identical either way (exact polynomial
     // identity), so proofs are byte-equal.
+    let alternation = match FOLD_LOOKAHEAD_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed) {
+        1 => true,
+        2 => false,
+        _ => std::env::var_os("FLOCK_NO_FOLD_LOOKAHEAD").is_none(),
+    };
     let mut lookahead = round1_lookahead.filter(|_| {
-        let knob = match FOLD_LOOKAHEAD_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed) {
-            1 => true,
-            2 => false,
-            _ => std::env::var_os("FLOCK_NO_FOLD_LOOKAHEAD").is_none(),
-        };
         let kind_ok = virtual_basis.is_some() || (l0_jit_basis.is_none() && fold_block == 1);
-        knob && kind_ok && initial_k >= 2 && packed_witness.len() >= 8 * fold_block
+        alternation && kind_ok && initial_k >= 2 && packed_witness.len() >= 8 * fold_block
     });
     let _t = std::time::Instant::now();
     for _ in 0..ood_count(0) {
@@ -1278,76 +1805,148 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
     let mut virtual_basis = virtual_basis.map(VirtualEqBasis256::from_base);
     let mut jit = l0_jit_basis;
     let mut lane_challenges = Vec::with_capacity(initial_k);
+    // The alternating schedule: a skip round evaluates a lookahead (the
+    // caller's base-field coefficients at round 0, [`La256`] mid-chain) and
+    // DEFERS its fold; the next fold pass absorbs both challenges and emits
+    // the following round's coefficients. The chain's last round never emits
+    // its own message (the code switch's replaces it), so a trailing
+    // deferred fold DRAINS message-free into the switch.
     let mut pending_r0: Option<F256> = None;
+    let mut la_mid: Option<La256> = None;
     let _t = std::time::Instant::now();
     let mut t_fold_j = std::time::Instant::now();
     for j in 0..initial_k {
         let challenge = challenger.sample_f256();
-        let path = if j == 0 && lookahead.is_some() {
-            "lookahead-skip"
-        } else if j == 1 && pending_r0.is_some() {
-            "fold2"
-        } else if j > 0 {
-            "materialized"
-        } else if virtual_basis.is_some() {
-            "virtual-once"
-        } else if jit.is_some() {
-            "jit"
+        lane_challenges.push(challenge);
+        let last = j + 1 == initial_k;
+        let path;
+        if last {
+            // Materialize through any deferred challenge, then switch; the
+            // switch's fbase message is this round's transcript entry.
+            match pending_r0.take() {
+                Some(r0) => {
+                    path = "drain2+switch";
+                    if let Some(mut vb) = virtual_basis.take() {
+                        let p = fold_block.trailing_zeros() as usize;
+                        vb.fold_coord(p, r0);
+                        vb.fold_coord(p, challenge);
+                        let _ = sumcheck.first_fold2_virtual(r0, challenge, fold_block, &vb, false);
+                        // first_fold2_virtual pushes its message; the switch
+                        // replaces it — same shape as the plain path.
+                        let msg = sumcheck.code_switch_and_replace_message();
+                        observe_message(challenger, msg);
+                    } else if sumcheck.initial_pending() {
+                        let _ = sumcheck.first_fold2_materialized(r0, challenge, false);
+                        let msg = sumcheck.code_switch_and_replace_message();
+                        observe_message(challenger, msg);
+                    } else {
+                        sumcheck.fold2_drain(r0, challenge, fold_block);
+                        let msg = sumcheck.code_switch_and_push_message();
+                        observe_message(challenger, msg);
+                    }
+                }
+                None => {
+                    path = "fold+switch";
+                    // Plain (non-alternating) tail: fold with a message the
+                    // switch replaces, exactly the historical shape.
+                    let _ = if j == 0 {
+                        if let Some(mut vb) = virtual_basis.take() {
+                            vb.fold_coord(fold_block.trailing_zeros() as usize, challenge);
+                            sumcheck.first_fold_virtual(challenge, fold_block, &vb)
+                        } else if let Some(fill) = jit.take() {
+                            match jit_ood_basis.as_ref() {
+                                Some(ood) => {
+                                    let combined = |out: &mut [F128], offset: usize| {
+                                        fill(out, offset);
+                                        ood.add_to(out, offset);
+                                    };
+                                    sumcheck.first_fold_jit(challenge, fold_block, &combined)
+                                }
+                                None => sumcheck.first_fold_jit(challenge, fold_block, fill),
+                            }
+                        } else {
+                            sumcheck.first_fold_materialized(challenge, fold_block)
+                        }
+                    } else {
+                        sumcheck.fold_materialized(challenge, fold_block)
+                    };
+                    let msg = sumcheck.code_switch_and_replace_message();
+                    observe_message(challenger, msg);
+                }
+            }
         } else {
-            "materialized"
-        };
-        // The virtual basis serves exactly ONE fill: fold its description by
-        // the first challenge, materialize the folded half, and from then on
-        // it is ordinary materialized state (the LazyRsPair design). Every
-        // later fold rides the fused materialized kernel.
-        let _pre_switch = if j == 0 {
-            if let Some(la) = lookahead.as_ref() {
+            let msg = if let (0, Some(la)) = (j, lookahead.as_ref()) {
+                path = "lookahead-skip";
                 // O(1) skip: round 1's message by polynomial identity; the
-                // array fold is deferred into the j = 1 double-fold pass.
+                // fold is deferred into the next double-fold pass.
                 let msg = lookahead_eval256(la, challenge);
-                sumcheck.skip_first_fold(msg);
+                sumcheck.push_skip_message(msg);
                 pending_r0 = Some(challenge);
                 msg
-            } else if let Some(mut vb) = virtual_basis.take() {
-                vb.fold_coord(fold_block.trailing_zeros() as usize, challenge);
-                sumcheck.first_fold_virtual(challenge, fold_block, &vb)
-            } else if let Some(fill) = jit.take() {
-                match jit_ood_basis.as_ref() {
-                    Some(ood) => {
-                        let combined = |out: &mut [F128], offset: usize| {
-                            fill(out, offset);
-                            ood.add_to(out, offset);
-                        };
-                        sumcheck.first_fold_jit(challenge, fold_block, &combined)
+            } else if let Some(la) = la_mid.take() {
+                path = "skip";
+                let msg = la.eval(challenge);
+                sumcheck.push_skip_message(msg);
+                pending_r0 = Some(challenge);
+                msg
+            } else if let Some(r0) = pending_r0.take() {
+                if let Some(mut vb) = virtual_basis.take() {
+                    path = "fold2-virtual";
+                    // The deferred fold and this one both bind the variable
+                    // at bit log2(d): fold_coord removes it, so the second
+                    // bind at the SAME position takes the next block
+                    // variable — the ladder's successive block-d folds.
+                    let p = fold_block.trailing_zeros() as usize;
+                    vb.fold_coord(p, r0);
+                    vb.fold_coord(p, challenge);
+                    let (msg, la) =
+                        sumcheck.first_fold2_virtual(r0, challenge, fold_block, &vb, alternation);
+                    la_mid = la;
+                    msg
+                } else {
+                    path = "fold2";
+                    let (msg, la) = if sumcheck.initial_pending() {
+                        sumcheck.first_fold2_materialized(r0, challenge, alternation)
+                    } else {
+                        sumcheck.mid_fold2(r0, challenge, fold_block, alternation)
+                    };
+                    la_mid = la;
+                    msg
+                }
+            } else if j == 0 {
+                // No caller lookahead: start the alternation at round 0 on
+                // the materialized path; virtual/jit first folds stay plain.
+                if let Some(mut vb) = virtual_basis.take() {
+                    path = "virtual-once";
+                    vb.fold_coord(fold_block.trailing_zeros() as usize, challenge);
+                    sumcheck.first_fold_virtual(challenge, fold_block, &vb)
+                } else if let Some(fill) = jit.take() {
+                    path = "jit";
+                    match jit_ood_basis.as_ref() {
+                        Some(ood) => {
+                            let combined = |out: &mut [F128], offset: usize| {
+                                fill(out, offset);
+                                ood.add_to(out, offset);
+                            };
+                            sumcheck.first_fold_jit(challenge, fold_block, &combined)
+                        }
+                        None => sumcheck.first_fold_jit(challenge, fold_block, fill),
                     }
-                    None => sumcheck.first_fold_jit(challenge, fold_block, fill),
+                } else if alternation && fold_block == 1 {
+                    path = "fold+la";
+                    let (msg, la) = sumcheck.first_fold_materialized_la(challenge);
+                    la_mid = la;
+                    msg
+                } else {
+                    path = "materialized";
+                    sumcheck.first_fold_materialized(challenge, fold_block)
                 }
             } else {
-                sumcheck.first_fold_materialized(challenge, fold_block)
-            }
-        } else if let Some(r0) = pending_r0.take() {
-            if let Some(mut vb) = virtual_basis.take() {
-                // The deferred fold-0 and fold-1 both bind the variable at
-                // bit log2(d): fold_coord removes it, so the second bind at
-                // the SAME position takes the next block variable — exactly
-                // the ladder's successive block-d folds.
-                let p = fold_block.trailing_zeros() as usize;
-                vb.fold_coord(p, r0);
-                vb.fold_coord(p, challenge);
-                sumcheck.first_fold2_virtual(r0, challenge, fold_block, &vb)
-            } else {
-                sumcheck.first_fold2_materialized(r0, challenge)
-            }
-        } else {
-            sumcheck.fold_materialized(challenge, fold_block)
-        };
-        let msg = if j + 1 == initial_k {
-            sumcheck.code_switch_and_replace_message()
-        } else {
-            _pre_switch
-        };
-        observe_message(challenger, msg);
-        lane_challenges.push(challenge);
+                path = "materialized";
+                sumcheck.fold_materialized(challenge, fold_block)
+            };
+            observe_message(challenger, msg);
+        }
         if trace {
             eprintln!(
                 "    init fold {j} ({path}, d {}): {:.2} ms",
@@ -1446,22 +2045,56 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
         assert!(current_split_dim >= k);
         let mut level_challenges = Vec::with_capacity(k);
         let _t = std::time::Instant::now();
+        // The level's alternating schedule. j = 0 is the entry: the fbase
+        // fold pass (which runs AFTER every glue, so its coefficients are
+        // always fresh) also emits the next round's La256 → j = 1 skips,
+        // j = 2 double-folds, … A pre-switch round emits no message of its
+        // own (the switch's replaces it), so a trailing deferred challenge
+        // drains message-free into the switch.
+        let mut level_pending: Option<F256> = None;
+        let mut level_la: Option<La256> = None;
         for j in 0..k {
             let challenge = challenger.sample_f256();
-            // j == 0 folds the just-switched (base-valued) table — the
-            // f-side products are 2 muls there, not 3.
-            let pre_switch = if j == 0 {
-                sumcheck.fold_after_switch(challenge)
-            } else {
-                sumcheck.fold(challenge)
-            };
-            let msg = if j + 1 == k && i + 1 != r {
-                sumcheck.code_switch_and_replace_message()
-            } else {
-                pre_switch
-            };
-            observe_message(challenger, msg);
             level_challenges.push(challenge);
+            let switching = j + 1 == k && i + 1 != r;
+            if switching {
+                // No message of this round's own survives (the switch's
+                // replaces it) — materialize through the deferred and
+                // current challenges message-free, then switch-push. The
+                // level state is always F256 here, so the generic extension
+                // fold covers the base-valued j = 0 edge too.
+                match level_pending.take() {
+                    Some(r0) => sumcheck.fold2_drain(r0, challenge, 1),
+                    None => sumcheck.drain(challenge, 1),
+                }
+                let msg = sumcheck.code_switch_and_push_message();
+                observe_message(challenger, msg);
+            } else {
+                let msg = if let Some(la) = level_la.take() {
+                    let msg = la.eval(challenge);
+                    sumcheck.push_skip_message(msg);
+                    level_pending = Some(challenge);
+                    msg
+                } else if let Some(r0) = level_pending.take() {
+                    let (msg, la) = sumcheck.mid_fold2(r0, challenge, 1, alternation);
+                    level_la = la;
+                    msg
+                } else if j == 0 && alternation {
+                    let (msg, la) = sumcheck.fold_after_switch_la(challenge);
+                    level_la = la;
+                    msg
+                } else if j == 0 {
+                    sumcheck.fold_after_switch(challenge)
+                } else {
+                    sumcheck.fold(challenge)
+                };
+                observe_message(challenger, msg);
+            }
+        }
+        // FINAL level only: a trailing skip leaves one deferred fold —
+        // materialize before the residual ships.
+        if let Some(r0) = level_pending.take() {
+            sumcheck.drain(r0, 1);
         }
         if trace {
             t_folds += _t.elapsed();

--- a/crates/flock-core/src/pcs/ligerito/extension.rs
+++ b/crates/flock-core/src/pcs/ligerito/extension.rs
@@ -438,6 +438,84 @@ fn fused_fold_applies(len: usize, d: usize) -> bool {
     if d == 1 { half >= 2 } else { half >= 2 * d }
 }
 
+/// Evaluate a round-1 [`FoldLookahead`] (base-field quadratic coefficients
+/// from the combine pass) at an EXTENSION fold challenge — the F256 ladder's
+/// O(1) skip message. Exact polynomial identity (`u(r) = c₀ + r·c₁ + r²·c₂`
+/// holds over any extension of the coefficient field), so the transcript is
+/// bit-identical to the fold-then-message path.
+fn lookahead_eval256(la: &FoldLookahead, r: F256) -> SumcheckMessage256 {
+    let r2 = r * r;
+    SumcheckMessage256 {
+        u_0: F256::from(la.u0[0]) + r * la.u0[1] + r2 * la.u0[2],
+        u_2: F256::from(la.u2[0]) + r * la.u2[1] + r2 * la.u2[2],
+    }
+}
+
+/// Correct a round-1 lookahead for an L0 OOD β-glue: the coefficients are
+/// LINEAR in the basis, so `b += β·eq_z` adds `β ·` (the (f, eq_z) pair's
+/// own coefficients, from [`round_msg_eval_and_lookahead`]).
+fn lookahead_add_scaled(la: &mut FoldLookahead, ood: &FoldLookahead, beta: F128) {
+    for i in 0..3 {
+        la.u0[i] += beta * ood.u0[i];
+        la.u2[i] += beta * ood.u2[i];
+    }
+}
+
+/// FUSED double fold from the BASE arrays: fold by `r0` then `r1` (LSB
+/// pairing, `d = 1`) writing only the QUARTER-size outputs, and accumulate
+/// the next round's `(u_0, u_2)` — the deferred-fold half of the round-1
+/// lookahead skip. The half-size intermediate never exists.
+///
+/// VALUE-IDENTICAL to `fold_base(r0)` → `fold_extension(r1)` →
+/// `next_round_msg`: the per-element expression composes the two fold steps
+/// verbatim (`lo/hi = fold_step_base`, then `lo + r1·(hi + lo)`), and
+/// `u_0`/`u_2` are XOR-additive sums, so chunk order cannot change them.
+fn fused_fold2_msg_base(
+    f: &[F128],
+    b: &[F128],
+    r0: F256,
+    r1: F256,
+) -> (Vec<F256>, Vec<F256>, SumcheckMessage256) {
+    debug_assert_eq!(f.len(), b.len());
+    let quarter = f.len() / 4;
+    debug_assert!(quarter >= 2 && quarter.is_power_of_two());
+    let zero2 = || (F256::ZERO, F256::ZERO);
+    let sum2 = |(a0, a2): (F256, F256), (b0, b2): (F256, F256)| (a0 + b0, a2 + b2);
+    let mut nf = crate::scratch::take_f256(quarter);
+    let mut nb = crate::scratch::take_f256(quarter);
+    let fold2 = |a: &[F128], i: usize| -> F256 {
+        let lo = F256::from(a[i]) + r0 * (a[i + 1] + a[i]);
+        let hi = F256::from(a[i + 2]) + r0 * (a[i + 3] + a[i + 2]);
+        lo + r1 * (hi + lo)
+    };
+    // Chunk on message-block boundaries (2 outputs per block).
+    let chunk = (1usize << 12).clamp(2, quarter);
+    debug_assert!(chunk.is_multiple_of(2));
+    let (u_0, u_2) = nf
+        .par_chunks_mut(chunk)
+        .zip(nb.par_chunks_mut(chunk))
+        .enumerate()
+        .map(|(ci, (fo, bo))| {
+            let out0 = ci * chunk;
+            for (k, (fslot, bslot)) in fo.iter_mut().zip(bo.iter_mut()).enumerate() {
+                let i = 4 * (out0 + k);
+                *fslot = fold2(f, i);
+                *bslot = fold2(b, i);
+            }
+            let mut u0 = F256::ZERO;
+            let mut u2 = F256::ZERO;
+            for j in 0..fo.len() / 2 {
+                let (f0, f1) = (fo[2 * j], fo[2 * j + 1]);
+                let (b0, b1) = (bo[2 * j], bo[2 * j + 1]);
+                u0 += f0 * b0;
+                u2 += (f0 + f1) * (b0 + b1);
+            }
+            (u0, u2)
+        })
+        .reduce(zero2, sum2);
+    (nf, nb, SumcheckMessage256 { u_0, u_2 })
+}
+
 /// FUSED first virtual fold: one sweep folds `f` by `r`, EVALUATES the
 /// (already-folded) virtual basis directly into `nb`, and accumulates the
 /// next round message — the fold-0 counterpart of [`fused_fold_msg!`],
@@ -723,6 +801,28 @@ impl SumcheckProver256 {
         msg
     }
 
+    /// Round-1 SKIP: the message came from the caller's lookahead evaluated
+    /// at the round-0 challenge ([`lookahead_eval256`]); record it — the
+    /// array fold is deferred into [`Self::first_fold2_materialized`].
+    pub(super) fn skip_first_fold(&mut self, msg: SumcheckMessage256) {
+        self.transcript.push(msg);
+    }
+
+    /// The deferred round-0 fold fused with round 1's: double-fold the base
+    /// arrays by `(r0, r1)` in ONE pass straight to the quarter-size F256
+    /// state ([`fused_fold2_msg_base`]) — the half-size intermediate is
+    /// never written. LSB pairing only (the lookahead never arrives on the
+    /// lane-major path).
+    pub(super) fn first_fold2_materialized(&mut self, r0: F256, r1: F256) -> SumcheckMessage256 {
+        let f = self.initial_f.take().expect("first fold already consumed");
+        let b = self.initial_b.take().expect("materialized basis missing");
+        let (nf, nb, msg) = fused_fold2_msg_base(&f, &b, r0, r1);
+        self.f = nf;
+        self.combined_basis = nb;
+        self.transcript.push(msg);
+        msg
+    }
+
     pub(super) fn fold_materialized(&mut self, r: F256, d: usize) -> SumcheckMessage256 {
         let msg = if fused_fold_applies(self.f.len(), d) {
             let (nf, nb, msg) = fused_fold_msg_ext(&self.f, &self.combined_basis, r, d);
@@ -897,7 +997,7 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
     // two-rounds-per-pass schedule onto the ladder's fused folds is the
     // recorded follow-up. Ignoring them cannot change the transcript: the
     // lookahead is an exact polynomial identity over the same messages.
-    _round1_lookahead: Option<FoldLookahead>,
+    round1_lookahead: Option<FoldLookahead>,
     challenger: &mut Ch,
 ) -> LigeritoProof {
     let log_n = packed_witness.len().trailing_zeros() as usize;
@@ -954,9 +1054,24 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
     let factored = l0_jit_basis.is_some() || l0_virtual_basis.is_some();
     let mut virtual_basis = l0_virtual_basis;
     let mut jit_ood_basis: Option<VirtualEqBasis> = None;
+    // The combine pass's round-1 lookahead (message coefficients in the
+    // round-0 challenge) makes round 1 an O(1) skip and fuses the deferred
+    // fold-0 into fold 1's pass. It only ever arrives on the standard
+    // materialized path (pd claims and the lane-major inner open never emit
+    // coefficients); the double fold needs two initial rounds and ≥ 8 base
+    // words. FLOCK_NO_FOLD_LOOKAHEAD=1 is the A/B knob — value-identical
+    // either way (exact polynomial identity), so proofs are byte-equal.
+    let mut lookahead = round1_lookahead.filter(|_| {
+        !factored
+            && fold_block == 1
+            && initial_k >= 2
+            && packed_witness.len() >= 8
+            && std::env::var_os("FLOCK_NO_FOLD_LOOKAHEAD").is_none()
+    });
     let _t = std::time::Instant::now();
     for _ in 0..ood_count(0) {
         let z = challenger.sample_f128_vec(log_n);
+        let mut ood_la = None;
         let (ood_msg, y, eq_z) = if factored {
             let (msg, y) = round_msg_and_eval_eq_point_blocked(&packed_witness, &z, fold_block);
             (msg, y, None)
@@ -964,7 +1079,15 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
             // Same doubling recurrence as `build_eq_table`, parallel —
             // value-identical (seed ONE), and this table is 2^log_n words.
             let eq_z = crate::pcs::ring_switch::build_eq_scaled_parallel(&z, F128::ONE);
-            let (msg, y) = round_msg_and_eval_blocked(&packed_witness, &eq_z, fold_block);
+            let (msg, y) = if lookahead.is_some() {
+                // Same sweep, plus the (f, eq_z) pair's own round-1
+                // coefficients so the lookahead survives the β-glue below.
+                let (msg, y, la) = round_msg_eval_and_lookahead(&packed_witness, &eq_z);
+                ood_la = Some(la);
+                (msg, y)
+            } else {
+                round_msg_and_eval_blocked(&packed_witness, &eq_z, fold_block)
+            };
             (msg, y, Some(eq_z))
         };
         challenger.observe_f128(y);
@@ -975,6 +1098,9 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
         if let Some(msg) = first_msg.as_mut() {
             msg.u_0 += beta * ood_msg.u_0;
             msg.u_2 += beta * ood_msg.u_2;
+        }
+        if let (Some(la), Some(ood)) = (lookahead.as_mut(), ood_la.as_ref()) {
+            lookahead_add_scaled(la, ood, beta);
         }
         if let Some(vb) = virtual_basis.as_mut() {
             vb.add_term(z, beta);
@@ -1015,11 +1141,16 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
     let mut virtual_basis = virtual_basis.map(VirtualEqBasis256::from_base);
     let mut jit = l0_jit_basis;
     let mut lane_challenges = Vec::with_capacity(initial_k);
+    let mut pending_r0: Option<F256> = None;
     let _t = std::time::Instant::now();
     let mut t_fold_j = std::time::Instant::now();
     for j in 0..initial_k {
         let challenge = challenger.sample_f256();
-        let path = if j > 0 {
+        let path = if j == 0 && lookahead.is_some() {
+            "lookahead-skip"
+        } else if j == 1 && pending_r0.is_some() {
+            "fold2"
+        } else if j > 0 {
             "materialized"
         } else if virtual_basis.is_some() {
             "virtual-once"
@@ -1033,7 +1164,14 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
         // it is ordinary materialized state (the LazyRsPair design). Every
         // later fold rides the fused materialized kernel.
         let _pre_switch = if j == 0 {
-            if let Some(mut vb) = virtual_basis.take() {
+            if let Some(la) = lookahead.as_ref() {
+                // O(1) skip: round 1's message by polynomial identity; the
+                // array fold is deferred into the j = 1 double-fold pass.
+                let msg = lookahead_eval256(la, challenge);
+                sumcheck.skip_first_fold(msg);
+                pending_r0 = Some(challenge);
+                msg
+            } else if let Some(mut vb) = virtual_basis.take() {
                 vb.fold_coord(fold_block.trailing_zeros() as usize, challenge);
                 sumcheck.first_fold_virtual(challenge, fold_block, &vb)
             } else if let Some(fill) = jit.take() {
@@ -1050,6 +1188,8 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
             } else {
                 sumcheck.first_fold_materialized(challenge, fold_block)
             }
+        } else if let Some(r0) = pending_r0.take() {
+            sumcheck.first_fold2_materialized(r0, challenge)
         } else {
             sumcheck.fold_materialized(challenge, fold_block)
         };

--- a/crates/flock-core/src/pcs/ligerito/extension.rs
+++ b/crates/flock-core/src/pcs/ligerito/extension.rs
@@ -612,6 +612,111 @@ fn fused_first_fold_virtual(
     (nf, nb, SumcheckMessage256 { u_0, u_2 })
 }
 
+/// FUSED double fold with a VIRTUAL basis: fold `f` by `(r0, r1)` (block
+/// pairing `d`) straight to the quarter-size state, EVALUATE the
+/// twice-folded virtual basis directly into `nb`, and accumulate the next
+/// round's message — the factored-basis counterpart of
+/// [`fused_fold2_msg_base`], and the lane-major consumer of the seeded
+/// EqPoint combine's round-1 lookahead. `basis` must already be folded by
+/// BOTH challenges (two `fold_coord`s); its index space is exactly the
+/// output's. Value-identical to fold → materialize → fold → message: the
+/// fold expression composes the two steps verbatim, `nb[o]` is the same
+/// per-term XOR-sum `fill` writes, the message pairing matches
+/// `next_round_msg(nf, nb, d)`, and the sums are XOR-additive.
+fn fused_first_fold2_virtual(
+    f: &[F128],
+    basis: &VirtualEqBasis256,
+    r0: F256,
+    r1: F256,
+    d: usize,
+) -> (Vec<F256>, Vec<F256>, SumcheckMessage256) {
+    let quarter = f.len() / 4;
+    debug_assert_eq!(basis.len(), quarter);
+    debug_assert!(d.is_power_of_two() && quarter.is_power_of_two() && quarter >= 2 * d);
+    let block = 2 * d;
+    let zero2 = || (F256::ZERO, F256::ZERO);
+    let sum2 = |(a0, a2): (F256, F256), (b0, b2): (F256, F256)| (a0 + b0, a2 + b2);
+    let mut nf = crate::scratch::take_f256(quarter);
+    let mut nb = crate::scratch::take_f256(quarter);
+    // Output o = b·d + w composes inputs {4bd+w, +d, +2d, +3d}; a message
+    // block of 2d outputs therefore reads the 8d inputs at 4·(block start).
+    let fold2 = |i: usize| -> F256 {
+        let lo = F256::from(f[i]) + r0 * (f[i + d] + f[i]);
+        let hi = F256::from(f[i + 2 * d]) + r0 * (f[i + 3 * d] + f[i + 2 * d]);
+        lo + r1 * (hi + lo)
+    };
+    let (u_0, u_2) = if block >= (1 << 16) {
+        const KC: usize = 1 << 13;
+        nf.par_chunks_mut(block)
+            .zip(nb.par_chunks_mut(block))
+            .enumerate()
+            .map(|(jb, (fblk, bblk))| {
+                let out0 = jb * block;
+                let in0 = 4 * out0;
+                let (flo_h, fhi_h) = fblk.split_at_mut(d);
+                let (blo_h, bhi_h) = bblk.split_at_mut(d);
+                flo_h
+                    .par_chunks_mut(KC)
+                    .zip(fhi_h.par_chunks_mut(KC))
+                    .zip(blo_h.par_chunks_mut(KC).zip(bhi_h.par_chunks_mut(KC)))
+                    .enumerate()
+                    .map(|(kc, ((flc, fhc), (blc, bhc)))| {
+                        let k0 = kc * KC;
+                        let mut u0 = F256::ZERO;
+                        let mut u2 = F256::ZERO;
+                        for k in 0..flc.len() {
+                            let i = in0 + k0 + k;
+                            let o = out0 + k0 + k;
+                            let flo = fold2(i);
+                            let fhi = fold2(i + 4 * d);
+                            let blo = basis.value_sum_at(o);
+                            let bhi = basis.value_sum_at(o + d);
+                            flc[k] = flo;
+                            fhc[k] = fhi;
+                            blc[k] = blo;
+                            bhc[k] = bhi;
+                            u0 += flo * blo;
+                            u2 += (flo + fhi) * (blo + bhi);
+                        }
+                        (u0, u2)
+                    })
+                    .reduce(zero2, sum2)
+            })
+            .reduce(zero2, sum2)
+    } else {
+        let chunk = block.max(1 << 12).min(quarter);
+        debug_assert!(chunk.is_multiple_of(block) || chunk == quarter);
+        nf.par_chunks_mut(chunk)
+            .zip(nb.par_chunks_mut(chunk))
+            .enumerate()
+            .map(|(ci, (fo, bo))| {
+                let mut u0 = F256::ZERO;
+                let mut u2 = F256::ZERO;
+                let out0 = ci * chunk;
+                for (jo, (fblk, bblk)) in fo.chunks_mut(block).zip(bo.chunks_mut(block)).enumerate()
+                {
+                    let ob = out0 + jo * block;
+                    let in0 = 4 * ob;
+                    for k in 0..d {
+                        let flo = fold2(in0 + k);
+                        let fhi = fold2(in0 + 4 * d + k);
+                        let blo = basis.value_sum_at(ob + k);
+                        let bhi = basis.value_sum_at(ob + d + k);
+                        fblk[k] = flo;
+                        fblk[d + k] = fhi;
+                        bblk[k] = blo;
+                        bblk[d + k] = bhi;
+                        u0 += flo * blo;
+                        u2 += (flo + fhi) * (blo + bhi);
+                    }
+                }
+                (u0, u2)
+            })
+            .reduce(zero2, sum2)
+    };
+    (nf, nb, SumcheckMessage256 { u_0, u_2 })
+}
+
 struct VirtualEqTerm256 {
     coords: Vec<F128>,
     scale: F256,
@@ -817,6 +922,23 @@ impl SumcheckProver256 {
         let f = self.initial_f.take().expect("first fold already consumed");
         let b = self.initial_b.take().expect("materialized basis missing");
         let (nf, nb, msg) = fused_fold2_msg_base(&f, &b, r0, r1);
+        self.f = nf;
+        self.combined_basis = nb;
+        self.transcript.push(msg);
+        msg
+    }
+
+    /// [`Self::first_fold2_materialized`] for the VIRTUAL basis (the
+    /// lane-major merged opens): `basis` must already carry both fold_coords.
+    pub(super) fn first_fold2_virtual(
+        &mut self,
+        r0: F256,
+        r1: F256,
+        d: usize,
+        basis: &VirtualEqBasis256,
+    ) -> SumcheckMessage256 {
+        let f = self.initial_f.take().expect("first fold already consumed");
+        let (nf, nb, msg) = fused_first_fold2_virtual(&f, basis, r0, r1, d);
         self.f = nf;
         self.combined_basis = nb;
         self.transcript.push(msg);
@@ -1056,24 +1178,39 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
     let mut jit_ood_basis: Option<VirtualEqBasis> = None;
     // The combine pass's round-1 lookahead (message coefficients in the
     // round-0 challenge) makes round 1 an O(1) skip and fuses the deferred
-    // fold-0 into fold 1's pass. It only ever arrives on the standard
-    // materialized path (pd claims and the lane-major inner open never emit
-    // coefficients); the double fold needs two initial rounds and ≥ 8 base
-    // words. FLOCK_NO_FOLD_LOOKAHEAD=1 is the A/B knob — value-identical
-    // either way (exact polynomial identity), so proofs are byte-equal.
+    // fold-0 into fold 1's pass. Consumed on the materialized (d = 1,
+    // compression-proof) path AND the virtual-basis lane-major path (the
+    // merged-transport inner opens — the seeded EqPoint combine emits
+    // blocked coefficients); the jit fallback (FLOCK_NO_VIRTUAL_B) keeps
+    // the plain first fold. The double fold needs two initial rounds and a
+    // quarter table that still supports the blocked message pairing
+    // (len ≥ 8·d). FLOCK_NO_FOLD_LOOKAHEAD=1 / FOLD_LOOKAHEAD_OVERRIDE is
+    // the A/B knob — value-identical either way (exact polynomial
+    // identity), so proofs are byte-equal.
     let mut lookahead = round1_lookahead.filter(|_| {
-        !factored
-            && fold_block == 1
-            && initial_k >= 2
-            && packed_witness.len() >= 8
-            && std::env::var_os("FLOCK_NO_FOLD_LOOKAHEAD").is_none()
+        let knob = match FOLD_LOOKAHEAD_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed) {
+            1 => true,
+            2 => false,
+            _ => std::env::var_os("FLOCK_NO_FOLD_LOOKAHEAD").is_none(),
+        };
+        let kind_ok = virtual_basis.is_some() || (l0_jit_basis.is_none() && fold_block == 1);
+        knob && kind_ok && initial_k >= 2 && packed_witness.len() >= 8 * fold_block
     });
     let _t = std::time::Instant::now();
     for _ in 0..ood_count(0) {
         let z = challenger.sample_f128_vec(log_n);
         let mut ood_la = None;
         let (ood_msg, y, eq_z) = if factored {
-            let (msg, y) = round_msg_and_eval_eq_point_blocked(&packed_witness, &z, fold_block);
+            let (msg, y) = if lookahead.is_some() {
+                // Same factored sweep, plus the (f, eq_z) pair's own BLOCKED
+                // round-1 coefficients so the lookahead survives the β-glue.
+                let (msg, y, la) =
+                    round_msg_eval_and_lookahead_eq_point_blocked(&packed_witness, &z, fold_block);
+                ood_la = Some(la);
+                (msg, y)
+            } else {
+                round_msg_and_eval_eq_point_blocked(&packed_witness, &z, fold_block)
+            };
             (msg, y, None)
         } else {
             // Same doubling recurrence as `build_eq_table`, parallel —
@@ -1189,7 +1326,18 @@ pub(super) fn recursive_prover_with_basis_impl<Ch: Challenger>(
                 sumcheck.first_fold_materialized(challenge, fold_block)
             }
         } else if let Some(r0) = pending_r0.take() {
-            sumcheck.first_fold2_materialized(r0, challenge)
+            if let Some(mut vb) = virtual_basis.take() {
+                // The deferred fold-0 and fold-1 both bind the variable at
+                // bit log2(d): fold_coord removes it, so the second bind at
+                // the SAME position takes the next block variable — exactly
+                // the ladder's successive block-d folds.
+                let p = fold_block.trailing_zeros() as usize;
+                vb.fold_coord(p, r0);
+                vb.fold_coord(p, challenge);
+                sumcheck.first_fold2_virtual(r0, challenge, fold_block, &vb)
+            } else {
+                sumcheck.first_fold2_materialized(r0, challenge)
+            }
         } else {
             sumcheck.fold_materialized(challenge, fold_block)
         };

--- a/crates/flock-core/src/pcs/ring_switch.rs
+++ b/crates/flock-core/src/pcs/ring_switch.rs
@@ -3325,7 +3325,9 @@ mod tests {
             let mut folded: Vec<F256> = dense.into_iter().map(F256::from).collect();
             for &r in &q {
                 folded = folded
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|pair| pair[0] + r * (pair[0] + pair[1]))
                     .collect();
             }

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -1810,14 +1810,13 @@ impl Blake3Setup {
         crate::prover::ProvePhaseTimings,
     ) {
         assert_eq!(blocks.len(), self.n_blocks);
-        // The DIRECT commit shape, like `prove_fast_ag`/`verify_ag` — the
-        // union-shaped `self.pcs_params` fails the commit length assert.
-        let pcs_params = self.direct_pcs_params();
         let t0 = std::time::Instant::now();
         let (z_packed, a_packed_f128, b_packed_f128, z_packed_lincheck) =
             self.generate_witness_ab(blocks);
         let witness_s = t0.elapsed().as_secs_f64();
         let lc_circuit = self.r1cs.csc_lincheck_circuit();
+        // The DIRECT commit shape, like `prove_fast_ag`/`verify_ag` — the
+        // union-shaped `self.pcs_params` fails the commit length assert.
         let pcs_params = self.direct_pcs_params();
         let (proof, commitment, claim, mut timings) = crate::prover::prove_fast_ligerito_ag_timed(
             &self.r1cs,

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -1712,6 +1712,25 @@ impl Blake3Setup {
     /// so both row-major and batch-major setups work. aarch64-only (NEON
     /// round-1 kernel).
     #[cfg(target_arch = "aarch64")]
+    /// The AG-skip prover runs the DIRECT (dense pow2-lane) commit — the
+    /// standard-pack shape its zerocheck and claims are wired for — while
+    /// `prove_fast` moved to the single-slot UNION commit (dense stack +
+    /// integer lanes). These params are the direct shape at the r1cs's own
+    /// `m`; the commitment carries them, so [`Self::verify_ag`] follows.
+    fn direct_pcs_params(&self) -> PcsParams {
+        PcsParams {
+            m: self.r1cs.m,
+            log_inv_rate: self.pcs_params.log_inv_rate,
+            log_batch_size: flock_core::pcs::ligerito::embedded_initial_k_or_default(
+                self.r1cs.m,
+                self.pcs_params.profile,
+            ),
+            profile: self.pcs_params.profile,
+            num_lanes: None,
+            merkle_hash: self.pcs_params.merkle_hash,
+        }
+    }
+
     pub fn prove_fast_ag<Ch: Challenger>(
         &self,
         blocks: &[Compression],
@@ -1722,14 +1741,15 @@ impl Blake3Setup {
         R1csClaim,
     ) {
         assert_eq!(blocks.len(), self.n_blocks);
+        let pcs_params = self.direct_pcs_params();
         let (codeword, (z_packed, a_packed_f128, b_packed_f128, z_packed_lincheck)) =
-            flock_core::pcs::prefault_codeword_during(&self.pcs_params, || {
+            flock_core::pcs::prefault_codeword_during(&pcs_params, || {
                 self.generate_witness_ab(blocks)
             });
         let lc_circuit = self.r1cs.csc_lincheck_circuit();
         crate::prover::prove_fast_ligerito_ag_from_witness(
             &self.r1cs,
-            &self.pcs_params,
+            &pcs_params,
             z_packed,
             a_packed_f128,
             b_packed_f128,
@@ -1822,7 +1842,7 @@ impl Blake3Setup {
             commitment,
             proof,
             lc_circuit,
-            &self.pcs_params,
+            &self.direct_pcs_params(),
             challenger,
         )
     }

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -1711,7 +1711,6 @@ impl Blake3Setup {
     /// is shared. Witness generation dispatches on the r1cs's witness layout,
     /// so both row-major and batch-major setups work. aarch64-only (NEON
     /// round-1 kernel).
-    #[cfg(target_arch = "aarch64")]
     /// The AG-skip prover runs the DIRECT (dense pow2-lane) commit — the
     /// standard-pack shape its zerocheck and claims are wired for — while
     /// `prove_fast` moved to the single-slot UNION commit (dense stack +
@@ -1731,6 +1730,7 @@ impl Blake3Setup {
         }
     }
 
+    #[cfg(target_arch = "aarch64")]
     pub fn prove_fast_ag<Ch: Challenger>(
         &self,
         blocks: &[Compression],

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -1705,12 +1705,6 @@ impl Blake3Setup {
         )
     }
 
-    /// AG-skip mirror of [`Self::prove_fast`]: round 1 of the zerocheck runs
-    /// on the genus-95 AG multiplication code instead of the RS additive-NTT
-    /// skip; everything else (witness gen, commit, lincheck, ring-switch open)
-    /// is shared. Witness generation dispatches on the r1cs's witness layout,
-    /// so both row-major and batch-major setups work. aarch64-only (NEON
-    /// round-1 kernel).
     /// The AG-skip prover runs the DIRECT (dense pow2-lane) commit — the
     /// standard-pack shape its zerocheck and claims are wired for — while
     /// `prove_fast` moved to the single-slot UNION commit (dense stack +
@@ -1730,6 +1724,12 @@ impl Blake3Setup {
         }
     }
 
+    /// AG-skip mirror of [`Self::prove_fast`]: round 1 of the zerocheck runs
+    /// on the genus-95 AG multiplication code instead of the RS additive-NTT
+    /// skip; everything else (witness gen, commit, lincheck, ring-switch open)
+    /// is shared. Witness generation dispatches on the r1cs's witness layout,
+    /// so both row-major and batch-major setups work. aarch64-only (NEON
+    /// round-1 kernel).
     #[cfg(target_arch = "aarch64")]
     pub fn prove_fast_ag<Ch: Challenger>(
         &self,
@@ -1779,9 +1779,10 @@ impl Blake3Setup {
             self.generate_witness_ab(blocks);
         let witness_s = t0.elapsed().as_secs_f64();
         let lc_circuit = self.r1cs.csc_lincheck_circuit();
+        let pcs_params = self.direct_pcs_params();
         let (proof, commitment, claim, mut timings) = crate::prover::prove_fast_ligerito_timed(
             &self.r1cs,
-            &self.pcs_params,
+            &pcs_params,
             z_packed,
             a_packed_f128,
             b_packed_f128,
@@ -1809,6 +1810,9 @@ impl Blake3Setup {
         crate::prover::ProvePhaseTimings,
     ) {
         assert_eq!(blocks.len(), self.n_blocks);
+        // The DIRECT commit shape, like `prove_fast_ag`/`verify_ag` — the
+        // union-shaped `self.pcs_params` fails the commit length assert.
+        let pcs_params = self.direct_pcs_params();
         let t0 = std::time::Instant::now();
         let (z_packed, a_packed_f128, b_packed_f128, z_packed_lincheck) =
             self.generate_witness_ab(blocks);
@@ -1816,7 +1820,7 @@ impl Blake3Setup {
         let lc_circuit = self.r1cs.csc_lincheck_circuit();
         let (proof, commitment, claim, mut timings) = crate::prover::prove_fast_ligerito_ag_timed(
             &self.r1cs,
-            &self.pcs_params,
+            &pcs_params,
             z_packed,
             a_packed_f128,
             b_packed_f128,
@@ -2357,8 +2361,9 @@ mod tests {
     /// through the full commit → AG zerocheck → lincheck → ring-switch
     /// Ligerito open pipeline.
     #[cfg(target_arch = "aarch64")]
-    #[test]
-    #[ignore] // Heavy — run with `cargo test prove_fast_ligerito_ag_roundtrip -- --ignored`
+    #[test] // Default-run: this is the guard for the direct-shape params
+    // class of stranding (the union migration broke prove_fast_ag and the
+    // ignore gate hid it; the timed twin then broke the same way).
     fn prove_fast_ligerito_ag_roundtrip() {
         use flock_core::challenger::FsChallenger;
         let setup = Blake3Setup::new(256);

--- a/crates/flock-prover/src/tower.rs
+++ b/crates/flock-prover/src/tower.rs
@@ -4279,7 +4279,9 @@ fn native_cap_layers(cap: &[[u8; 32]], n_layers: usize, hash: HashKind) -> Vec<V
         let next: Vec<[u8; 32]> = layers
             .last()
             .unwrap()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|p| core_merkle::hash_pair(&p[0], &p[1], hash))
             .collect();
         layers.push(next);
@@ -5009,7 +5011,7 @@ fn emit_residual_region(
                 let out = sb.gate(acc_slot, &g_in);
                 for (dst, src) in accs[h * chunk..(h + 1) * chunk]
                     .iter_mut()
-                    .zip(out.chunks_exact(2))
+                    .zip(out.as_chunks::<2>().0.iter())
                 {
                     *dst = [src[0], src[1]];
                 }

--- a/crates/flock-prover/tests/fold_lookahead.rs
+++ b/crates/flock-prover/tests/fold_lookahead.rs
@@ -41,7 +41,7 @@ fn blocks(n: usize, seed: u64) -> Vec<Compression> {
 fn assert_byte_identical(n_blocks: usize, seed: u64) {
     let setup = Blake3Setup::new(n_blocks);
     let inputs = blocks(n_blocks, seed);
-    let mut prove = |force: u8| {
+    let prove = |force: u8| {
         FOLD_LOOKAHEAD_OVERRIDE.store(force, Ordering::Relaxed);
         let mut ch = FsChallenger::new(b"la-union-test");
         let out = setup.prove_fast(&inputs, &mut ch);

--- a/crates/flock-prover/tests/fold_lookahead.rs
+++ b/crates/flock-prover/tests/fold_lookahead.rs
@@ -39,6 +39,13 @@ fn blocks(n: usize, seed: u64) -> Vec<Compression> {
 }
 
 fn assert_byte_identical(n_blocks: usize, seed: u64) {
+    // The override is PROCESS-GLOBAL and the harness runs tests on parallel
+    // threads: without serialization, a concurrent store can land between
+    // this store and the prover's read, both proves take the same arm, and
+    // the byte-equality assert passes vacuously (an A/A). One lock per
+    // A/B, released only after the override is reset.
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let setup = Blake3Setup::new(n_blocks);
     let inputs = blocks(n_blocks, seed);
     let prove = |force: u8| {

--- a/crates/flock-prover/tests/fold_lookahead.rs
+++ b/crates/flock-prover/tests/fold_lookahead.rs
@@ -76,3 +76,11 @@ fn union_prove_fast_lookahead_is_byte_identical_m22() {
 fn union_prove_fast_lookahead_is_byte_identical_m23() {
     assert_byte_identical(512, 0xCD);
 }
+
+/// m27: the lane-major block hits the ≥2^16 superblock kernels (the KC-split
+/// branches) AND the degenerate pre-switch drain whose array is smaller than
+/// a superblock — the shape the small arms never reach.
+#[test]
+fn union_prove_fast_lookahead_is_byte_identical_m27() {
+    assert_byte_identical(8192, 0xEF);
+}

--- a/crates/flock-prover/tests/fold_lookahead.rs
+++ b/crates/flock-prover/tests/fold_lookahead.rs
@@ -1,0 +1,78 @@
+//! In-process A/B oracle for the F256 ladder's round-1 lookahead skip on the
+//! MERGED transport — the union / `prove_fast` route, where the seeded
+//! EqPoint combine emits BLOCKED coefficients and the ladder consumes them
+//! through the virtual-basis double fold. The skip is an exact polynomial
+//! identity, so proofs must be byte-identical with it forced on vs forced
+//! off (`FOLD_LOOKAHEAD_OVERRIDE`), across the L0 OOD β-glues the blocked
+//! coefficient corrections keep it live through.
+//!
+//! (The compression-proof / materialized path's identity is pinned by
+//! `f256_round1_lookahead_is_byte_identical` in flock-core; the historical
+//! byte anchors are the union m6 fixtures + the mixed-class pins.)
+
+use std::sync::atomic::Ordering;
+
+use flock_prover::challenger::FsChallenger;
+use flock_prover::pcs::ligerito::FOLD_LOOKAHEAD_OVERRIDE;
+use flock_prover::r1cs_hashes::blake3::{Blake3Setup, Compression};
+
+struct Rng(u64);
+impl Rng {
+    fn next_u32(&mut self) -> u32 {
+        self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        (z ^ (z >> 31)) as u32
+    }
+}
+
+fn blocks(n: usize, seed: u64) -> Vec<Compression> {
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|_| {
+            let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
+            let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+            (cv, m, rng.next_u32() as u64, 64u32, 11u32)
+        })
+        .collect()
+}
+
+fn assert_byte_identical(n_blocks: usize, seed: u64) {
+    let setup = Blake3Setup::new(n_blocks);
+    let inputs = blocks(n_blocks, seed);
+    let mut prove = |force: u8| {
+        FOLD_LOOKAHEAD_OVERRIDE.store(force, Ordering::Relaxed);
+        let mut ch = FsChallenger::new(b"la-union-test");
+        let out = setup.prove_fast(&inputs, &mut ch);
+        FOLD_LOOKAHEAD_OVERRIDE.store(0, Ordering::Relaxed);
+        out
+    };
+    let (p_on, c_on, _) = prove(1);
+    let (p_off, c_off, _) = prove(2);
+    assert_eq!(
+        c_on.cap, c_off.cap,
+        "commitment moved (n_blocks={n_blocks})"
+    );
+    assert_eq!(
+        p_on, p_off,
+        "lookahead skip moved a byte on the merged transport (n_blocks={n_blocks})"
+    );
+    let mut ch = FsChallenger::new(b"la-union-test");
+    setup
+        .verify(&c_on, &p_on, &mut ch)
+        .expect("lookahead-path proof must verify");
+}
+
+/// Registered m22 fast config: L0 OOD samples > 0, so the blocked per-OOD
+/// coefficient corrections are on the line.
+#[test]
+fn union_prove_fast_lookahead_is_byte_identical_m22() {
+    assert_byte_identical(256, 0xAB);
+}
+
+/// A second registered shape (m23) and seed.
+#[test]
+fn union_prove_fast_lookahead_is_byte_identical_m23() {
+    assert_byte_identical(512, 0xCD);
+}

--- a/crates/flock-prover/tests/merkle_glue.rs
+++ b/crates/flock-prover/tests/merkle_glue.rs
@@ -228,7 +228,10 @@ fn bit_spread_zero_mask_is_enforced() {
     assert_eq!(a, r1cs.apply_a(&z));
     assert_eq!(b, r1cs.apply_b(&z));
 
-    let forbidden_bit = word.isolate_lowest_one();
+    // Manual on purpose: the std method needs 1.97+, above the Blackwell
+    // CI runner's toolchain (see flock_core::bits::lowest_one).
+    #[allow(clippy::manual_isolate_lowest_one)]
+    let forbidden_bit = word & word.wrapping_neg();
     let rejected = BitSpreadInput {
         word,
         zero_mask: forbidden_bit,

--- a/crates/flock-prover/tests/merkle_glue.rs
+++ b/crates/flock-prover/tests/merkle_glue.rs
@@ -228,7 +228,7 @@ fn bit_spread_zero_mask_is_enforced() {
     assert_eq!(a, r1cs.apply_a(&z));
     assert_eq!(b, r1cs.apply_b(&z));
 
-    let forbidden_bit = word & word.wrapping_neg();
+    let forbidden_bit = word.isolate_lowest_one();
     let rejected = BitSpreadInput {
         word,
         zero_mask: forbidden_bit,


### PR DESCRIPTION
Closes the recorded follow-up from the main re-merge — the combine pass's `FoldLookahead` (PR #30) was carried into the F256 driver and ignored — and extends it to the routes production actually runs.

**Commit 1 — compression-proof path** (the direct ab+c open: `prove_ligerito`, keccak3/sha2): round 1 becomes an O(1) skip (the base-field quadratic evaluated at the F256 challenge — exact over the extension); the deferred round-0 fold fuses into round 1's pass so the half-size F256 intermediate is never written. The L0 OOD β-glues are corrected with each `(f, eq_z)` pair's own coefficients (linearity), which is the blocker that had the driver ignoring the lookahead.

**Commit 2 — merged transport** (the `prove_fast`/union route = every tower leaf/node open):
- the seeded EqPoint combine emits the coefficients in the same pass as the round-0 prime, under the fold's own **block pairing** (+4 unreduced muls/quad);
- the driver consumes them through the **virtual-basis double fold**: the twice-folded basis evaluates directly into the quarter-size state — neither the half-size `f` intermediate nor the half-size basis materialize ever exists;
- blocked L0 OODs get the same linearity correction; the mixed fast path (rs + sparse pd: chain/merkle proves) corrects for sparse scatters instead of disabling.

**Byte-identity** (the skip is an exact polynomial identity): union m6 merged fixtures + passable union_element pins hold unchanged (the 3 red MIXED fixtures are the pre-existing rot in the fixture ledger — identical on the pristine tip); `fold_lookahead.rs` proves on/off byte-equality on real `Blake3Setup::prove_fast` at m22/m23 + verify; `f256_round1_lookahead_is_byte_identical` pins the direct path; **677 workspace tests green**. `FLOCK_NO_FOLD_LOOKAHEAD` / `FOLD_LOOKAHEAD_OVERRIDE` are the A/B knobs.

**Measured** (M4 Max):
- direct ab+c open (keccak3, 24576): init-folds phase 10.4 → 7.6 ms median (−27%)
- union route (blake3 `prove_fast`, m30): folds 0+1 **8.9 → 4.6 ms (−48%)**, init-folds phase **~14.4 → ~9.8 ms (−32%)**, best prove 117.8 → 111.7 ms



🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Commit 3 — the full alternating schedule.** Completes the F128 prover's skip/double-fold alternation through the whole F256 ladder: every fold pass can emit the next round's coefficients (`La256`, +4 products per output quad, 4 of 8 shared with the message), making every other round an O(1) skip — through the remaining initial folds and every recursive level, both routes. Pre-switch rounds drain message-free (the switch's message is pushed, not replaced — same transcript, one entry per round). `LA_MAX_OUTPUTS = 2^19` caps coefficient production where the wide accumulator measurably loses to the fold it saves (m32 lane-major's giant early passes keep just the entry skip + first double fold — never a regression). Development flushed a real bug the small oracles couldn't see: the superblock split produced an empty segment on the big-`d` drain shape, leaving pool garbage as folded state — caught by `mixed_class_cost_probe`, fixed, and now pinned by a new m27 oracle arm that exercises exactly the big-block kernels and that drain shape.

Final numbers (M4 Max): direct route init-folds **11.1 → 7.9 ms (−29%)**; m32 union holds the entry win (phase ~33 ms, **best prove 434.3 ms = 603.6k compr/s**) with recursive levels alternating below the cap. Byte-identity: on/off oracles at m22/23/27 + verify, m6 merged pins byte-stable, 678 workspace tests green.

Draft while PR #26 is in flight — based on `recursion_circuit`; retarget to `main` once #26 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)