### PR TITLE
AG-skip zerocheck on the union route

### DIFF
--- a/crates/flock-core/src/challenger.rs
+++ b/crates/flock-core/src/challenger.rs
@@ -1078,8 +1078,10 @@ fn blake3_pow_preimage(state_digest: &[u8; 32], nonce: u64) -> [u8; 64] {
 /// serialized byte, the one PoW bit convention everywhere (the fused
 /// transcript PoW here, the recursion circuit's `PowMaskTable`, and the AG
 /// fused sampling nonce in `genus95_curve_code::evaluation_point_from_nonce_pow`).
+/// Public: the recursion tower's native replicas assert it beside the
+/// in-circuit PowMask rows.
 #[inline]
-pub(crate) fn has_leading_zero_bits(h: &[u8], bits: u32) -> bool {
+pub fn has_leading_zero_bits(h: &[u8], bits: u32) -> bool {
     let full_bytes = (bits / 8) as usize;
     let extra = bits % 8;
     for &b in h.iter().take(full_bytes) {

--- a/crates/flock-core/src/challenger.rs
+++ b/crates/flock-core/src/challenger.rs
@@ -1074,9 +1074,12 @@ fn blake3_pow_preimage(state_digest: &[u8; 32], nonce: u64) -> [u8; 64] {
     pre
 }
 
-/// Whether `h` has at least `bits` leading zero bits.
+/// Whether `h` has at least `bits` leading zero bits — MSB-first within each
+/// serialized byte, the one PoW bit convention everywhere (the fused
+/// transcript PoW here, the recursion circuit's `PowMaskTable`, and the AG
+/// fused sampling nonce in `genus95_curve_code::evaluation_point_from_nonce_pow`).
 #[inline]
-fn has_leading_zero_bits(h: &[u8], bits: u32) -> bool {
+pub(crate) fn has_leading_zero_bits(h: &[u8], bits: u32) -> bool {
     let full_bytes = (bits / 8) as usize;
     let extra = bits % 8;
     for &b in h.iter().take(full_bytes) {

--- a/crates/flock-core/src/genus95_curve_code/mod.rs
+++ b/crates/flock-core/src/genus95_curve_code/mod.rs
@@ -37,6 +37,8 @@ mod slp_derived;
 mod tables;
 
 pub use base_evaluator::{BaseFunctional, base_evaluation_functional, evaluate_base_functional};
+#[cfg(test)]
+pub(crate) use constants::BASE_Y_DEGREE;
 pub use constants::{BASE_MESSAGE_BITS, PRODUCT_MESSAGE_BITS};
 pub use evaluator::{
     EvaluationPoint, ProductFunctional, evaluate_product_functional, product_evaluation_functional,
@@ -48,7 +50,7 @@ pub use rand_core::RngCore;
 pub use rng::{Blake3Rng, FsRng, Sha256Rng};
 pub use sampling::{
     SAMPLE_ATTEMPT_BUDGET, SampleError, evaluation_point_from_nonce,
-    sample_random_evaluation_point, try_evaluation_point,
+    evaluation_point_from_nonce_pow, sample_random_evaluation_point, try_evaluation_point,
 };
 
 #[cfg(test)]

--- a/crates/flock-core/src/genus95_curve_code/round1.rs
+++ b/crates/flock-core/src/genus95_curve_code/round1.rs
@@ -3668,6 +3668,164 @@ pub fn round1_slp_packed_banks_fused(
         )
 }
 
+/// [`round1_slp_packed_banks_fused`] over a witness run-list: ONE parallel
+/// pass over the LIVE blocks only — Dead blocks are skipped (their honest
+/// contribution is zero), Partial blocks are cleansed into zeroed scratch
+/// inline ([`crate::zerocheck::cleanse_block`], so no declared-dead bit is
+/// ever read), and consecutive Full live blocks pair for the two-source
+/// c-transpose exactly like the dense kernel. The accumulation is XOR
+/// (char-2), so the changed visit order is value-identical; per-element
+/// cost matches the dense kernel — no per-segment call barriers (the
+/// segment-wrapper prototype paid ~450 rayon bridges at the envelope's
+/// per-column run structure and LOST to the dense scan).
+pub fn round1_slp_packed_banks_fused_padded(
+    a_packed: &[u8],
+    b_packed: &[u8],
+    c_packed: &[u8],
+    eq: &[F128],
+    coverage: &[crate::zerocheck::BlockCoverage],
+) -> ([F128; 160], [F128; 64], [F128; 64]) {
+    use crate::zerocheck::BlockCoverage;
+    use rayon::prelude::*;
+    let n = a_packed.len() / 1024;
+    assert_eq!(eq.len(), n, "one eq weight per block");
+    assert_eq!(coverage.len(), n, "one coverage entry per block");
+    let live: Vec<u32> = (0..n)
+        .filter(|&o| !matches!(coverage[o], BlockCoverage::Dead))
+        .map(|o| o as u32)
+        .collect();
+    let nl = live.len();
+    let nthreads = rayon::current_num_threads().max(1);
+    let chunk0 = nl.div_ceil(8 * nthreads).max(1);
+    let chunk = chunk0 + (chunk0 & 1);
+    let nchunks = nl.div_ceil(chunk);
+    (0..nchunks)
+        .into_par_iter()
+        .map(|ci| {
+            let start = ci * chunk;
+            let end = ((ci + 1) * chunk).min(nl);
+            let z = unsafe { vdupq_n_u8(0) };
+            let z64 = unsafe { vdupq_n_u64(0) };
+            let mut res = [[z64; 3]; 160];
+            let mut bank0 = [[z64; 3]; 64];
+            let mut bank1 = [[z64; 3]; 64];
+            let mut af = [z; 160];
+            let mut bf = [z; 160];
+            let mut pab = [z; 128];
+            // The SINGLE path (a cleansed partial, or an unpaired full):
+            // the dense kernel's tail branch, source-parameterized so a
+            // 1024-byte scratch block passes with base 0.
+            let single = |a_src: &[u8],
+                              b_src: &[u8],
+                              c_src: &[u8],
+                              base: usize,
+                              eq_o: F128,
+                              af: &mut [uint8x16_t; 160],
+                              bf: &mut [uint8x16_t; 160],
+                              pab: &mut [uint8x16_t; 128],
+                              res: &mut [UnredAcc; 160],
+                              bank0: &mut [UnredAcc; 64],
+                              bank1: &mut [UnredAcc; 64]| {
+                let mut pc = [z; 128];
+                let mut buf = [0u8; 128 * 16];
+                bitslice_block_into(c_src, base, &mut buf, &mut pc);
+                unsafe {
+                    process_block_fused(a_src, b_src, base, eq_o, pab, af, bf, res);
+                    let even = vdupq_n_u64(C_EVEN_MASK);
+                    let odd = vdupq_n_u64(C_ODD_MASK);
+                    for k in 0..64 {
+                        let x = vreinterpretq_u64_u8(pc[k]);
+                        mul_acc_unred(&mut bank0[k], eq_o, vandq_u64(x, even));
+                        mul_acc_unred(&mut bank1[k], eq_o, vandq_u64(x, odd));
+                    }
+                }
+            };
+            let mut i = start;
+            while i < end {
+                let o = live[i] as usize;
+                match &coverage[o] {
+                    BlockCoverage::Full => {
+                        // Pair with the NEXT live entry when it is Full too
+                        // (2src transpose takes two independent offsets).
+                        let o2 = if i + 1 < end { live[i + 1] as usize } else { o };
+                        if i + 1 < end && matches!(coverage[o2], BlockCoverage::Full) {
+                            transpose_fold_c_banks_2src(
+                                c_packed,
+                                o * 1024,
+                                o2 * 1024,
+                                eq[o],
+                                eq[o2],
+                                &mut bank0,
+                                &mut bank1,
+                            );
+                            unsafe {
+                                process_block_fused(
+                                    a_packed, b_packed, o * 1024, eq[o], &mut pab, &mut af,
+                                    &mut bf, &mut res,
+                                );
+                                process_block_fused(
+                                    a_packed,
+                                    b_packed,
+                                    o2 * 1024,
+                                    eq[o2],
+                                    &mut pab,
+                                    &mut af,
+                                    &mut bf,
+                                    &mut res,
+                                );
+                            }
+                            i += 2;
+                            continue;
+                        }
+                        single(
+                            a_packed, b_packed, c_packed, o * 1024, eq[o], &mut af, &mut bf,
+                            &mut pab, &mut res, &mut bank0, &mut bank1,
+                        );
+                        i += 1;
+                    }
+                    BlockCoverage::Partial(ranges) => {
+                        let mut a_buf = [0u8; 1024];
+                        let mut b_buf = [0u8; 1024];
+                        let mut c_buf = [0u8; 1024];
+                        crate::zerocheck::cleanse_block(a_packed, o * 1024, ranges, &mut a_buf);
+                        crate::zerocheck::cleanse_block(b_packed, o * 1024, ranges, &mut b_buf);
+                        crate::zerocheck::cleanse_block(c_packed, o * 1024, ranges, &mut c_buf);
+                        single(
+                            &a_buf, &b_buf, &c_buf, 0, eq[o], &mut af, &mut bf, &mut pab,
+                            &mut res, &mut bank0, &mut bank1,
+                        );
+                        i += 1;
+                    }
+                    BlockCoverage::Dead => unreachable!("the live list has no dead entry"),
+                }
+            }
+            let mut res_r = [F128::ZERO; 160];
+            let mut b0_r = [F128::ZERO; 64];
+            let mut b1_r = [F128::ZERO; 64];
+            for j in 0..160 {
+                res_r[j] = reduce_unred(&res[j]);
+            }
+            for k in 0..64 {
+                b0_r[k] = reduce_unred(&bank0[k]);
+                b1_r[k] = reduce_unred(&bank1[k]);
+            }
+            (res_r, b0_r, b1_r)
+        })
+        .reduce(
+            || ([F128::ZERO; 160], [F128::ZERO; 64], [F128::ZERO; 64]),
+            |(mut r1, mut a0, mut a1), (r2, b0, b1)| {
+                for j in 0..160 {
+                    r1[j] += r2[j];
+                }
+                for k in 0..64 {
+                    a0[k] += b0[k];
+                    a1[k] += b1[k];
+                }
+                (r1, a0, a1)
+            },
+        )
+}
+
 /// Bit-slice one 1024-byte block at `base` into 64 low planes (the high 64 of the
 /// 128-wide transpose are the zero pad). `buf`'s high 8 bytes/row stay zero.
 #[inline]

--- a/crates/flock-core/src/genus95_curve_code/round1.rs
+++ b/crates/flock-core/src/genus95_curve_code/round1.rs
@@ -3716,16 +3716,16 @@ pub fn round1_slp_packed_banks_fused_padded(
             // the dense kernel's tail branch, source-parameterized so a
             // 1024-byte scratch block passes with base 0.
             let single = |a_src: &[u8],
-                              b_src: &[u8],
-                              c_src: &[u8],
-                              base: usize,
-                              eq_o: F128,
-                              af: &mut [uint8x16_t; 160],
-                              bf: &mut [uint8x16_t; 160],
-                              pab: &mut [uint8x16_t; 128],
-                              res: &mut [UnredAcc; 160],
-                              bank0: &mut [UnredAcc; 64],
-                              bank1: &mut [UnredAcc; 64]| {
+                          b_src: &[u8],
+                          c_src: &[u8],
+                          base: usize,
+                          eq_o: F128,
+                          af: &mut [uint8x16_t; 160],
+                          bf: &mut [uint8x16_t; 160],
+                          pab: &mut [uint8x16_t; 128],
+                          res: &mut [UnredAcc; 160],
+                          bank0: &mut [UnredAcc; 64],
+                          bank1: &mut [UnredAcc; 64]| {
                 let mut pc = [z; 128];
                 let mut buf = [0u8; 128 * 16];
                 bitslice_block_into(c_src, base, &mut buf, &mut pc);
@@ -3760,8 +3760,14 @@ pub fn round1_slp_packed_banks_fused_padded(
                             );
                             unsafe {
                                 process_block_fused(
-                                    a_packed, b_packed, o * 1024, eq[o], &mut pab, &mut af,
-                                    &mut bf, &mut res,
+                                    a_packed,
+                                    b_packed,
+                                    o * 1024,
+                                    eq[o],
+                                    &mut pab,
+                                    &mut af,
+                                    &mut bf,
+                                    &mut res,
                                 );
                                 process_block_fused(
                                     a_packed,
@@ -3778,8 +3784,17 @@ pub fn round1_slp_packed_banks_fused_padded(
                             continue;
                         }
                         single(
-                            a_packed, b_packed, c_packed, o * 1024, eq[o], &mut af, &mut bf,
-                            &mut pab, &mut res, &mut bank0, &mut bank1,
+                            a_packed,
+                            b_packed,
+                            c_packed,
+                            o * 1024,
+                            eq[o],
+                            &mut af,
+                            &mut bf,
+                            &mut pab,
+                            &mut res,
+                            &mut bank0,
+                            &mut bank1,
                         );
                         i += 1;
                     }
@@ -3791,8 +3806,8 @@ pub fn round1_slp_packed_banks_fused_padded(
                         crate::zerocheck::cleanse_block(b_packed, o * 1024, ranges, &mut b_buf);
                         crate::zerocheck::cleanse_block(c_packed, o * 1024, ranges, &mut c_buf);
                         single(
-                            &a_buf, &b_buf, &c_buf, 0, eq[o], &mut af, &mut bf, &mut pab,
-                            &mut res, &mut bank0, &mut bank1,
+                            &a_buf, &b_buf, &c_buf, 0, eq[o], &mut af, &mut bf, &mut pab, &mut res,
+                            &mut bank0, &mut bank1,
                         );
                         i += 1;
                     }

--- a/crates/flock-core/src/genus95_curve_code/sampling.rs
+++ b/crates/flock-core/src/genus95_curve_code/sampling.rs
@@ -70,8 +70,11 @@ pub fn evaluation_point_from_nonce(
 
 /// [`evaluation_point_from_nonce`] with a FUSED proof-of-work criterion: the
 /// nonce is valid only when its DRBG seed `H(seed ‖ LE32(nonce))` ALSO clears
-/// the PoW target (low `pow_bits` bits of the seed's first 8 bytes, read LE,
-/// all zero) — both criteria on the same hash, so a prover iterating nonces
+/// the PoW target — at least `pow_bits` leading zero bits of the seed's
+/// SECOND 16-byte word (bytes 16..32, MSB-first within each byte: the same
+/// predicate word and bit convention as the transcript PoW and the recursion
+/// circuit's `PowMaskTable`, so the eventual in-circuit check is a gadget
+/// reuse) — both criteria on the same hash, so a prover iterating nonces
 /// pays the PoW lottery on every sampling attempt and vice versa.
 ///
 /// Success per nonce is exactly `p · 2^-pow_bits`, where `p` is the sampler's
@@ -92,10 +95,9 @@ pub fn evaluation_point_from_nonce_pow(
     kind: crate::hash::HashKind,
     pow_bits: u32,
 ) -> Option<EvaluationPoint> {
-    debug_assert!(pow_bits < 64);
+    debug_assert!(pow_bits <= 64);
     let ns = nonce_seed(seed, nonce, kind);
-    let word = u64::from_le_bytes(ns[0..8].try_into().expect("8 bytes"));
-    if word & ((1u64 << pow_bits) - 1) != 0 {
+    if !crate::challenger::has_leading_zero_bits(&ns[16..32], pow_bits) {
         return None;
     }
     try_evaluation_point(&mut super::rng::FsRng::new(kind, ns))

--- a/crates/flock-core/src/genus95_curve_code/sampling.rs
+++ b/crates/flock-core/src/genus95_curve_code/sampling.rs
@@ -30,17 +30,9 @@ pub fn sample_random_evaluation_point(
     Err(SampleError::AttemptsExceeded)
 }
 
-/// One attempt from a 32-byte transcript seed and a grinding nonce: the
-/// attempt's DRBG is `FsRng::new(kind, H(seed ‖ LE32(nonce)))` where `H` and
-/// the DRBG follow the transcript hash `kind` (SHA-256 counter mode or BLAKE3
-/// XOF — see [`super::rng::FsRng`]), so each nonce yields an independent
-/// uniform draw and no second primitive enters the soundness argument.
-/// `None` = this nonce is rejected.
-pub fn evaluation_point_from_nonce(
-    seed: &[u8; 32],
-    nonce: u32,
-    kind: crate::hash::HashKind,
-) -> Option<EvaluationPoint> {
+/// The per-nonce DRBG seed `H(seed ‖ LE32(nonce))`, where `H` follows the
+/// transcript hash `kind`. Shared by the plain and PoW-fused nonce attempts.
+fn nonce_seed(seed: &[u8; 32], nonce: u32, kind: crate::hash::HashKind) -> [u8; 32] {
     let mut nonce_seed = [0u8; 32];
     match kind {
         crate::hash::HashKind::Sha256 => {
@@ -56,7 +48,57 @@ pub fn evaluation_point_from_nonce(
             nonce_seed.copy_from_slice(h.finalize().as_bytes());
         }
     }
-    try_evaluation_point(&mut super::rng::FsRng::new(kind, nonce_seed))
+    nonce_seed
+}
+
+/// One attempt from a 32-byte transcript seed and a grinding nonce: the
+/// attempt's DRBG is `FsRng::new(kind, H(seed ‖ LE32(nonce)))` where `H` and
+/// the DRBG follow the transcript hash `kind` (SHA-256 counter mode or BLAKE3
+/// XOF — see [`super::rng::FsRng`]), so each nonce yields an independent
+/// uniform draw and no second primitive enters the soundness argument.
+/// `None` = this nonce is rejected.
+pub fn evaluation_point_from_nonce(
+    seed: &[u8; 32],
+    nonce: u32,
+    kind: crate::hash::HashKind,
+) -> Option<EvaluationPoint> {
+    try_evaluation_point(&mut super::rng::FsRng::new(
+        kind,
+        nonce_seed(seed, nonce, kind),
+    ))
+}
+
+/// [`evaluation_point_from_nonce`] with a FUSED proof-of-work criterion: the
+/// nonce is valid only when its DRBG seed `H(seed ‖ LE32(nonce))` ALSO clears
+/// the PoW target (low `pow_bits` bits of the seed's first 8 bytes, read LE,
+/// all zero) — both criteria on the same hash, so a prover iterating nonces
+/// pays the PoW lottery on every sampling attempt and vice versa.
+///
+/// Success per nonce is exactly `p · 2^-pow_bits`, where `p` is the sampler's
+/// acceptance probability. `p = (1/32)·(1 ± 2^-56)` PROVABLY: the sampler
+/// weights every reachable cover point at exactly `1/(2^128 · 4 · 8)` (the
+/// `BASE_Y_DEGREE` slot flattening plus the three all-or-nothing
+/// Artin–Schreier choice bits — see [`try_evaluation_point`]), and Hasse–Weil
+/// bounds the genus-95 cover's point count within `2·95·2^64` of `2^128`
+/// (denominator-pole and infinity exclusions are a few hundred points). The
+/// rejection sampling therefore contributes `log2(32) = 5` bits of grinding
+/// on top of `pow_bits` — a protocol constant, not an empirical estimate —
+/// which is how the AG challenge sites reach their strict 128-bit budgets
+/// with small explicit PoW (see `zerocheck::ag_skip::AG_SAMPLING_CREDIT_BITS`
+/// and the guard tests tying the constants together).
+pub fn evaluation_point_from_nonce_pow(
+    seed: &[u8; 32],
+    nonce: u32,
+    kind: crate::hash::HashKind,
+    pow_bits: u32,
+) -> Option<EvaluationPoint> {
+    debug_assert!(pow_bits < 64);
+    let ns = nonce_seed(seed, nonce, kind);
+    let word = u64::from_le_bytes(ns[0..8].try_into().expect("8 bytes"));
+    if word & ((1u64 << pow_bits) - 1) != 0 {
+        return None;
+    }
+    try_evaluation_point(&mut super::rng::FsRng::new(kind, ns))
 }
 
 /// One rejection-sampling attempt: draw `x` and lift `(y, z1, z2, z3)`,

--- a/crates/flock-core/src/genus95_curve_code/tests.rs
+++ b/crates/flock-core/src/genus95_curve_code/tests.rs
@@ -361,3 +361,25 @@ fn gf128_row_rank(mut rows: Vec<[F128; PRODUCT_MESSAGE_BITS]>) -> usize {
     }
     rank
 }
+
+/// The rejection sampler's acceptance rate is the protocol constant
+/// 1/(BASE_Y_DEGREE · 2^3) = 1/32 (up to the ~2^-56 Hasse–Weil dust) — the
+/// number behind the fused-nonce grinding credit
+/// (`zerocheck::ag_skip::AG_SAMPLING_CREDIT_BITS`). 200k attempts give
+/// σ ≈ 4·10⁻⁴; the asserted window is ±8σ around 1/32.
+#[test]
+fn acceptance_rate_is_one_in_32() {
+    let mut rng = super::Sha256Rng::new([0xACu8; 32]);
+    let n: u32 = 200_000;
+    let mut ok: u32 = 0;
+    for _ in 0..n {
+        if super::try_evaluation_point(&mut rng).is_some() {
+            ok += 1;
+        }
+    }
+    let p = f64::from(ok) / f64::from(n);
+    assert!(
+        (p - 1.0 / 32.0).abs() < 0.0032,
+        "acceptance rate {p:.5} strayed from the pinned 1/32"
+    );
+}

--- a/crates/flock-core/src/genus95_curve_code/tests.rs
+++ b/crates/flock-core/src/genus95_curve_code/tests.rs
@@ -383,3 +383,60 @@ fn acceptance_rate_is_one_in_32() {
         "acceptance rate {p:.5} strayed from the pinned 1/32"
     );
 }
+
+/// Census of the BASE functional's in-circuit cost surfaces (phase D's
+/// `emit_ag_lows` sizing): the pushed-monomial count, the total XOR terms
+/// across the 64 coordinate masks, and the x-power ladder length.
+#[test]
+fn base_functional_circuit_census() {
+    use super::constants::{BASE_X_POWER_COUNT, FOUR_RUSSIANS_BLOCK_BITS};
+    use super::tables::TABLES;
+    let l = &TABLES.base_layout;
+    let mut xor_terms = 0usize;
+    for (blk, masks) in l.block_masks.iter().enumerate() {
+        let (s, e) = (
+            l.block_coordinate_offsets[blk],
+            l.block_coordinate_offsets[blk + 1],
+        );
+        for &coord in &l.block_coordinates[s..e] {
+            xor_terms += masks[coord as usize].count_ones() as usize;
+        }
+    }
+    println!(
+        "base layout: input_count {} | xor terms {} | x powers {} | blocks {} (block bits {})",
+        l.input_count,
+        xor_terms,
+        BASE_X_POWER_COUNT,
+        l.block_masks.len(),
+        FOUR_RUSSIANS_BLOCK_BITS,
+    );
+    // The in-circuit sharing estimate: per block, each DISTINCT nonzero
+    // sub-mask sum is built once (popcount-1 adds), then one add folds it
+    // into each affected coordinate.
+    let (mut pairs, mut distinct_builds, mut distinct_total) = (0usize, 0usize, 0usize);
+    for (blk, masks) in l.block_masks.iter().enumerate() {
+        let (s, e) = (
+            l.block_coordinate_offsets[blk],
+            l.block_coordinate_offsets[blk + 1],
+        );
+        let mut seen = std::collections::HashSet::new();
+        for &coord in &l.block_coordinates[s..e] {
+            let m = masks[coord as usize];
+            pairs += 1;
+            if seen.insert(m) {
+                distinct_total += 1;
+                distinct_builds += (m.count_ones() as usize).saturating_sub(1);
+            }
+        }
+    }
+    println!(
+        "sharing: (block,coord) pairs {} | distinct masks {} (build adds {}) | est rows = pushes {} + builds {} + pairs {} = {}",
+        pairs,
+        distinct_total,
+        distinct_builds,
+        l.input_count,
+        distinct_builds,
+        pairs,
+        l.input_count + distinct_builds + pairs,
+    );
+}

--- a/crates/flock-core/src/lincheck.rs
+++ b/crates/flock-core/src/lincheck.rs
@@ -613,6 +613,18 @@ impl LincheckGrinding {
             .filter(|&bits| bits != 0)
     }
 
+    /// Explicit PoW bits for the AG-basis final skip point's FUSED nonce. The
+    /// bad set is a nonzero BASE-code word's zeros — at most `deg D = 158`
+    /// (the genus tax: `dim 64 + g 95 − 1`), against the φ₈ basis's `2^6 − 1
+    /// = 63` — so `bits_for(158) = 8` total bits, of which the rejection
+    /// sampler provably contributes
+    /// [`crate::zerocheck::ag_skip::AG_SAMPLING_CREDIT_BITS`] = 5, leaving 3
+    /// explicit. Gated on the same flag as [`Self::skip_bits`], so
+    /// [`Self::nonce_count`] holds for either basis (one skip nonce each).
+    pub fn ag_skip_bits(self, k_skip: usize) -> Option<u32> {
+        self.skip_bits(k_skip).map(|_| AG_LINCHECK_SKIP_POW_BITS)
+    }
+
     /// Number of nonces the proof must carry for this concrete lincheck.
     pub fn nonce_count(
         self,
@@ -626,6 +638,11 @@ impl LincheckGrinding {
             + usize::from(self.skip_bits(k_skip).is_some())
     }
 }
+
+/// Explicit PoW bits on the AG-basis final-skip fused nonce:
+/// `bits_for(158) − AG_SAMPLING_CREDIT_BITS = 8 − 5 = 3`. See
+/// [`LincheckGrinding::ag_skip_bits`]; guarded by the ag_skip constants test.
+pub const AG_LINCHECK_SKIP_POW_BITS: u32 = 3;
 
 /// Lincheck output: one MLE evaluation claim on `z`, at the quirky inner
 /// point `(r_inner_skip, r_inner_rest)` combined with `x_ab.x_outer`
@@ -1223,14 +1240,7 @@ impl SkipPoint {
         match self {
             SkipPoint::Phi8(_) => SkipPoint::Phi8(ch.sample_f128()),
             SkipPoint::Ag(_) => {
-                ch.observe_label(b"flock-lincheck-ag-skip-point");
-                let s0 = ch.sample_f128();
-                let s1 = ch.sample_f128();
-                let mut seed = [0u8; 32];
-                seed[0..8].copy_from_slice(&s0.lo.to_le_bytes());
-                seed[8..16].copy_from_slice(&s0.hi.to_le_bytes());
-                seed[16..24].copy_from_slice(&s1.lo.to_le_bytes());
-                seed[24..32].copy_from_slice(&s1.hi.to_le_bytes());
+                let seed = Self::ag_fresh_seed(ch);
                 let p = crate::genus95_curve_code::sample_random_evaluation_point(
                     &mut crate::genus95_curve_code::FsRng::new(ch.hash_kind(), seed),
                 )
@@ -1238,6 +1248,84 @@ impl SkipPoint {
                 SkipPoint::Ag(p)
             }
         }
+    }
+
+    /// The 32-byte transcript seed for a fresh AG skip point: label + two
+    /// squeezes. Shared by [`Self::sample_fresh`] (deterministic replay on
+    /// both sides) and the fused-nonce pair below.
+    fn ag_fresh_seed<Ch: crate::challenger::Challenger>(ch: &mut Ch) -> [u8; 32] {
+        ch.observe_label(b"flock-lincheck-ag-skip-point");
+        let s0 = ch.sample_f128();
+        let s1 = ch.sample_f128();
+        let mut seed = [0u8; 32];
+        seed[0..8].copy_from_slice(&s0.lo.to_le_bytes());
+        seed[8..16].copy_from_slice(&s0.hi.to_le_bytes());
+        seed[16..24].copy_from_slice(&s1.lo.to_le_bytes());
+        seed[24..32].copy_from_slice(&s1.hi.to_le_bytes());
+        seed
+    }
+
+    /// Bind the chosen fused nonce into the transcript — later challenges
+    /// (nothing today, but the claim value flows onward) depend on the point
+    /// through it. Mirrored exactly by the verifier.
+    fn observe_ag_fresh_nonce<Ch: crate::challenger::Challenger>(ch: &mut Ch, nonce: u32) {
+        ch.observe_label(b"flock-lincheck-ag-skip-nonce");
+        ch.observe_bytes(&nonce.to_le_bytes());
+    }
+
+    /// [`Self::sample_fresh`] under a strict grinding schedule, AG basis only
+    /// — the FUSED nonce: `H(seed ‖ nonce)` must clear `pow_bits` of PoW AND
+    /// decode to a valid cover point (both criteria on one hash, so no free
+    /// choice among valid nonces). With the sampler's provable
+    /// [`crate::zerocheck::ag_skip::AG_SAMPLING_CREDIT_BITS`] = 5 bits on
+    /// top, the point carries `pow_bits + 5` grinding bits total, and the
+    /// verifier mirror is ONE-SHOT (no rejection replay).
+    pub fn sample_fresh_pow_prover<Ch: crate::challenger::Challenger>(
+        &self,
+        ch: &mut Ch,
+        pow_bits: u32,
+    ) -> (SkipPoint, u64) {
+        let SkipPoint::Ag(_) = self else {
+            unreachable!("the fused fresh-point nonce is AG-basis only");
+        };
+        let seed = Self::ag_fresh_seed(ch);
+        let kind = ch.hash_kind();
+        for nonce in 0..crate::zerocheck::ag_skip::R1_FUSED_ATTEMPT_BUDGET {
+            if let Some(p) = crate::genus95_curve_code::evaluation_point_from_nonce_pow(
+                &seed, nonce, kind, pow_bits,
+            ) {
+                Self::observe_ag_fresh_nonce(ch, nonce);
+                return (SkipPoint::Ag(p), u64::from(nonce));
+            }
+        }
+        unreachable!("fused fresh-point grind exhausted its budget (probability ~2^-2954)")
+    }
+
+    /// Verifier mirror of [`Self::sample_fresh_pow_prover`]: one hash + one
+    /// point attempt; `None` rejects (bad PoW, bad point, or a nonce outside
+    /// the prover's scan budget).
+    pub fn sample_fresh_pow_verifier<Ch: crate::challenger::Challenger>(
+        &self,
+        ch: &mut Ch,
+        nonce: u64,
+        pow_bits: u32,
+    ) -> Option<SkipPoint> {
+        let SkipPoint::Ag(_) = self else {
+            unreachable!("the fused fresh-point nonce is AG-basis only");
+        };
+        let seed = Self::ag_fresh_seed(ch);
+        let nonce = u32::try_from(nonce).ok()?;
+        if nonce >= crate::zerocheck::ag_skip::R1_FUSED_ATTEMPT_BUDGET {
+            return None;
+        }
+        Self::observe_ag_fresh_nonce(ch, nonce);
+        crate::genus95_curve_code::evaluation_point_from_nonce_pow(
+            &seed,
+            nonce,
+            ch.hash_kind(),
+            pow_bits,
+        )
+        .map(SkipPoint::Ag)
     }
 
     /// Extract the φ₈ field point. Panics on an AG point — used at RS PCS-verify
@@ -1909,24 +1997,27 @@ fn column_sumcheck_prove<Ch: Challenger>(
 
     // 7. Sample fresh z_skip AFTER observing z_partial — gives Schwartz-Zippel
     //    soundness on the φ8 (univariate-skip) dim.
-    let r_inner_skip = if let Some(bits) = grinding.skip_bits(k_skip) {
-        match z_skip {
-            // Grinding profiles run the φ₈ basis; keep the FUSED PoW+squeeze
-            // transcript (byte-pinned on the chained-BLAKE3 challenger).
-            SkipPoint::Phi8(_) => {
+    let r_inner_skip = match z_skip {
+        // Grinding profiles on the φ₈ basis keep the FUSED PoW+squeeze
+        // transcript (byte-pinned on the chained-BLAKE3 challenger).
+        SkipPoint::Phi8(_) => match grinding.skip_bits(k_skip) {
+            Some(bits) => {
                 let (nonce, r) = challenger.grind_pow_and_sample_f128(bits);
                 grinding_nonces.push(nonce);
                 SkipPoint::Phi8(r)
             }
-            // No grinding profile uses the AG basis today; compose the two
-            // operations sequentially if one ever does.
-            SkipPoint::Ag(_) => {
-                grinding_nonces.push(challenger.grind_pow(bits));
-                z_skip.sample_fresh(challenger)
+            None => z_skip.sample_fresh(challenger),
+        },
+        // AG basis: the FUSED nonce (PoW + point validity on one hash) —
+        // 3 explicit bits + the sampler's 5 provable bits = bits_for(158).
+        SkipPoint::Ag(_) => match grinding.ag_skip_bits(k_skip) {
+            Some(bits) => {
+                let (p, nonce) = z_skip.sample_fresh_pow_prover(challenger, bits);
+                grinding_nonces.push(nonce);
+                p
             }
-        }
-    } else {
-        z_skip.sample_fresh(challenger)
+            None => z_skip.sample_fresh(challenger),
+        },
     };
 
     // 8. Output claim's value: φ8 Lagrange combination of z_partial at z_skip.
@@ -2171,9 +2262,9 @@ pub fn verify_with_grinding<Ch: Challenger>(
     }
 
     // 6. Sample fresh z_skip AFTER z_partial — gives SZ on the φ8 dim.
-    let r_inner_skip = if let Some(bits) = grinding.skip_bits(k_skip) {
-        match &x_ab.z_skip {
-            SkipPoint::Phi8(_) => {
+    let r_inner_skip = match &x_ab.z_skip {
+        SkipPoint::Phi8(_) => match grinding.skip_bits(k_skip) {
+            Some(bits) => {
                 let r = challenger
                     .verify_pow_and_sample_f128(proof.grinding_nonces[nonce_idx], bits)
                     .ok_or(VerifyError::InvalidGrindingNonce {
@@ -2182,18 +2273,20 @@ pub fn verify_with_grinding<Ch: Challenger>(
                 nonce_idx += 1;
                 SkipPoint::Phi8(r)
             }
-            SkipPoint::Ag(_) => {
-                if !challenger.verify_pow(proof.grinding_nonces[nonce_idx], bits) {
-                    return Err(VerifyError::InvalidGrindingNonce {
-                        which: "inner-skip",
-                    });
-                }
+            None => x_ab.z_skip.sample_fresh(challenger),
+        },
+        SkipPoint::Ag(_) => match grinding.ag_skip_bits(k_skip) {
+            Some(bits) => {
+                let nonce = proof.grinding_nonces[nonce_idx];
                 nonce_idx += 1;
-                x_ab.z_skip.sample_fresh(challenger)
+                x_ab.z_skip
+                    .sample_fresh_pow_verifier(challenger, nonce, bits)
+                    .ok_or(VerifyError::InvalidGrindingNonce {
+                        which: "inner-skip",
+                    })?
             }
-        }
-    } else {
-        x_ab.z_skip.sample_fresh(challenger)
+            None => x_ab.z_skip.sample_fresh(challenger),
+        },
     };
     debug_assert_eq!(nonce_idx, proof.grinding_nonces.len());
 

--- a/crates/flock-core/src/lincheck.rs
+++ b/crates/flock-core/src/lincheck.rs
@@ -1298,7 +1298,9 @@ impl SkipPoint {
                 return (SkipPoint::Ag(p), u64::from(nonce));
             }
         }
-        unreachable!("fused fresh-point grind exhausted its budget (probability ~2^-2954)")
+        unreachable!(
+            "fused fresh-point grind exhausted its budget (see R1_FUSED_ATTEMPT_BUDGET)"
+        )
     }
 
     /// Verifier mirror of [`Self::sample_fresh_pow_prover`]: one hash + one

--- a/crates/flock-core/src/lincheck.rs
+++ b/crates/flock-core/src/lincheck.rs
@@ -1298,9 +1298,7 @@ impl SkipPoint {
                 return (SkipPoint::Ag(p), u64::from(nonce));
             }
         }
-        unreachable!(
-            "fused fresh-point grind exhausted its budget (see R1_FUSED_ATTEMPT_BUDGET)"
-        )
+        unreachable!("fused fresh-point grind exhausted its budget (see R1_FUSED_ATTEMPT_BUDGET)")
     }
 
     /// Verifier mirror of [`Self::sample_fresh_pow_prover`]: one hash + one

--- a/crates/flock-core/src/lincheck/union.rs
+++ b/crates/flock-core/src/lincheck/union.rs
@@ -65,11 +65,11 @@ use crate::matrix_fold::{MatrixClaim, Weight};
 use crate::schedule::Registry;
 use crate::union::UnionInstance;
 use crate::zerocheck::K_SKIP;
-use crate::zerocheck::multilinear::lagrange_weights_naive;
 
 use super::{
     LincheckCircuit, LincheckClaim, LincheckGrinding, LincheckProof, QuirkyPoint, SkipPoint,
-    VerifyError, build_eq_table, build_quirky_eq_table, column_sumcheck_prove, inner_product,
+    VerifyError, build_eq_table, build_quirky_eq_table_from_weights,
+    column_sumcheck_prove, inner_product,
     partial_fold_packed_z_rows_best,
 };
 
@@ -293,8 +293,10 @@ pub fn prove_union_capture_z_vec_with_grinding<Ch: Challenger>(
         .zip(slots)
     {
         let inner = ty.k_log - k_skip;
-        let eq_inner =
-            build_quirky_eq_table(x_ab.z_skip.phi8(), &x_ab.x_inner_rest[..inner], k_skip);
+        let eq_inner = build_quirky_eq_table_from_weights(
+            &x_ab.z_skip.weights(k_skip),
+            &x_ab.x_inner_rest[..inner],
+        );
         // Split, so the per-matrix bilinear values can be reported below.
         // Same nonzeros as the α-batched fold; only the accumulation differs.
         let (comb_a, comb_b) = slot_in.circuit.fold_split(&eq_inner);
@@ -466,8 +468,10 @@ fn col_weight(z_partial: &[F128], rr: &[F128], k_skip: usize) -> Vec<F128> {
 pub struct MatrixAssertion {
     /// The challenge batching the A- and B-matrices.
     pub alpha: F128,
-    /// Row-side weight: `λ(z_skip) ⊗ eq(x_inner_rest)`.
-    pub z_skip: F128,
+    /// Row-side weight: `λ(z_skip) ⊗ eq(x_inner_rest)` — `λ` is the skip
+    /// basis's evaluation functional ([`SkipPoint::weights`]), φ₈ Lagrange
+    /// on the RS route, the AG base-code functional on the AG route.
+    pub z_skip: SkipPoint,
     pub x_inner_rest: Vec<F128>,
     /// Column-side weight: `z_partial ⊗ eq(rr)`.
     pub rr: Vec<F128>,
@@ -509,7 +513,7 @@ impl MatrixAssertion {
             .map(|(ty, &(v_a, v_b))| {
                 let inner = ty.k_log - k_skip;
                 let row = Weight::low_eq(
-                    lagrange_weights_naive(k_skip, self.z_skip),
+                    self.z_skip.weights(k_skip),
                     self.x_inner_rest[..inner].to_vec(),
                 );
                 let col = Weight::low_eq(self.z_partial.clone(), self.rr[..inner].to_vec());
@@ -593,7 +597,10 @@ impl MatrixAssertion {
             .map(|((ty, slot), circuit)| {
                 let inner = ty.k_log - k_skip;
                 let eq_inner =
-                    build_quirky_eq_table(self.z_skip, &self.x_inner_rest[..inner], k_skip);
+                    build_quirky_eq_table_from_weights(
+                        &self.z_skip.weights(k_skip),
+                        &self.x_inner_rest[..inner],
+                    );
                 let mut comb = circuit.fold_alpha_batched(self.alpha, &eq_inner);
                 if slot.prefix_bits > 0 {
                     let w_t = eq_prefix_weight(&self.x_inner_rest[inner..], slot.prefix);
@@ -879,7 +886,7 @@ pub fn verify_union_deferred_with_grinding<Ch: Challenger>(
     rr.reverse();
     let assertion = MatrixAssertion {
         alpha,
-        z_skip: x_ab.z_skip.phi8(),
+        z_skip: x_ab.z_skip,
         x_inner_rest: x_ab.x_inner_rest.clone(),
         rr: rr.clone(),
         z_partial: proof.z_partial.clone(),
@@ -890,26 +897,43 @@ pub fn verify_union_deferred_with_grinding<Ch: Challenger>(
         evals: proof.matrix_evals.clone(),
     };
 
-    // 6.–7. Fresh skip challenge after z_partial; claim value via φ8
-    //       Lagrange (identical to the single-table verifier).
+    // 6.–7. Fresh skip challenge after z_partial, in the SAME basis as the
+    //       input point (identical to the single-table verifier); claim
+    //       value via the basis's evaluation functional. Mirrors
+    //       `column_sumcheck_prove`'s grinding composition exactly: the φ₈
+    //       basis keeps the FUSED PoW+squeeze (byte-pinned), the AG basis
+    //       composes the standalone PoW with `sample_fresh`.
     let r_inner_skip = if let Some(bits) = grinding.skip_bits(k_skip) {
-        let r = challenger
-            .verify_pow_and_sample_f128(proof.grinding_nonces[nonce_idx], bits)
-            .ok_or(VerifyError::InvalidGrindingNonce {
-                which: "inner-skip",
-            })?;
+        let nonce = proof.grinding_nonces[nonce_idx];
         nonce_idx += 1;
-        r
+        match x_ab.z_skip {
+            SkipPoint::Phi8(_) => {
+                let r = challenger.verify_pow_and_sample_f128(nonce, bits).ok_or(
+                    VerifyError::InvalidGrindingNonce {
+                        which: "inner-skip",
+                    },
+                )?;
+                SkipPoint::Phi8(r)
+            }
+            SkipPoint::Ag(_) => {
+                if !challenger.verify_pow(nonce, bits) {
+                    return Err(VerifyError::InvalidGrindingNonce {
+                        which: "inner-skip",
+                    });
+                }
+                x_ab.z_skip.sample_fresh(challenger)
+            }
+        }
     } else {
-        challenger.sample_f128()
+        x_ab.z_skip.sample_fresh(challenger)
     };
     debug_assert_eq!(nonce_idx, proof.grinding_nonces.len());
-    let lambda = lagrange_weights_naive(k_skip, r_inner_skip);
+    let lambda = r_inner_skip.weights(k_skip);
     let w = inner_product(&lambda, &proof.z_partial);
 
     Ok((
         LincheckClaim {
-            r_inner_skip: SkipPoint::Phi8(r_inner_skip),
+            r_inner_skip,
             r_inner_rest: rr,
             w,
         },

--- a/crates/flock-core/src/lincheck/union.rs
+++ b/crates/flock-core/src/lincheck/union.rs
@@ -901,11 +901,11 @@ pub fn verify_union_deferred_with_grinding<Ch: Challenger>(
     //       `column_sumcheck_prove`'s grinding composition exactly: the φ₈
     //       basis keeps the FUSED PoW+squeeze (byte-pinned), the AG basis
     //       composes the standalone PoW with `sample_fresh`.
-    let r_inner_skip = if let Some(bits) = grinding.skip_bits(k_skip) {
-        let nonce = proof.grinding_nonces[nonce_idx];
-        nonce_idx += 1;
-        match x_ab.z_skip {
-            SkipPoint::Phi8(_) => {
+    let r_inner_skip = match x_ab.z_skip {
+        SkipPoint::Phi8(_) => match grinding.skip_bits(k_skip) {
+            Some(bits) => {
+                let nonce = proof.grinding_nonces[nonce_idx];
+                nonce_idx += 1;
                 let r = challenger.verify_pow_and_sample_f128(nonce, bits).ok_or(
                     VerifyError::InvalidGrindingNonce {
                         which: "inner-skip",
@@ -913,17 +913,22 @@ pub fn verify_union_deferred_with_grinding<Ch: Challenger>(
                 )?;
                 SkipPoint::Phi8(r)
             }
-            SkipPoint::Ag(_) => {
-                if !challenger.verify_pow(nonce, bits) {
-                    return Err(VerifyError::InvalidGrindingNonce {
+            None => x_ab.z_skip.sample_fresh(challenger),
+        },
+        // AG basis: ONE-SHOT fused-nonce check — 3 explicit bits + the
+        // sampler's 5 provable bits = bits_for(158) for the base-code bad set.
+        SkipPoint::Ag(_) => match grinding.ag_skip_bits(k_skip) {
+            Some(bits) => {
+                let nonce = proof.grinding_nonces[nonce_idx];
+                nonce_idx += 1;
+                x_ab.z_skip
+                    .sample_fresh_pow_verifier(challenger, nonce, bits)
+                    .ok_or(VerifyError::InvalidGrindingNonce {
                         which: "inner-skip",
-                    });
-                }
-                x_ab.z_skip.sample_fresh(challenger)
+                    })?
             }
-        }
-    } else {
-        x_ab.z_skip.sample_fresh(challenger)
+            None => x_ab.z_skip.sample_fresh(challenger),
+        },
     };
     debug_assert_eq!(nonce_idx, proof.grinding_nonces.len());
     let lambda = r_inner_skip.weights(k_skip);

--- a/crates/flock-core/src/lincheck/union.rs
+++ b/crates/flock-core/src/lincheck/union.rs
@@ -900,7 +900,7 @@ pub fn verify_union_deferred_with_grinding<Ch: Challenger>(
     //       value via the basis's evaluation functional. Mirrors
     //       `column_sumcheck_prove`'s grinding composition exactly: the φ₈
     //       basis keeps the FUSED PoW+squeeze (byte-pinned), the AG basis
-    //       composes the standalone PoW with `sample_fresh`.
+    //       verifies the fused nonce one-shot (`sample_fresh_pow_verifier`).
     let r_inner_skip = match x_ab.z_skip {
         SkipPoint::Phi8(_) => match grinding.skip_bits(k_skip) {
             Some(bits) => {

--- a/crates/flock-core/src/lincheck/union.rs
+++ b/crates/flock-core/src/lincheck/union.rs
@@ -68,9 +68,8 @@ use crate::zerocheck::K_SKIP;
 
 use super::{
     LincheckCircuit, LincheckClaim, LincheckGrinding, LincheckProof, QuirkyPoint, SkipPoint,
-    VerifyError, build_eq_table, build_quirky_eq_table_from_weights,
-    column_sumcheck_prove, inner_product,
-    partial_fold_packed_z_rows_best,
+    VerifyError, build_eq_table, build_quirky_eq_table_from_weights, column_sumcheck_prove,
+    inner_product, partial_fold_packed_z_rows_best,
 };
 
 /// One slot's lincheck inputs, in slot order — the union counterpart of the
@@ -596,11 +595,10 @@ impl MatrixAssertion {
             .zip(circuits)
             .map(|((ty, slot), circuit)| {
                 let inner = ty.k_log - k_skip;
-                let eq_inner =
-                    build_quirky_eq_table_from_weights(
-                        &self.z_skip.weights(k_skip),
-                        &self.x_inner_rest[..inner],
-                    );
+                let eq_inner = build_quirky_eq_table_from_weights(
+                    &self.z_skip.weights(k_skip),
+                    &self.x_inner_rest[..inner],
+                );
                 let mut comb = circuit.fold_alpha_batched(self.alpha, &eq_inner);
                 if slot.prefix_bits > 0 {
                     let w_t = eq_prefix_weight(&self.x_inner_rest[inner..], slot.prefix);

--- a/crates/flock-core/src/pcs.rs
+++ b/crates/flock-core/src/pcs.rs
@@ -1925,7 +1925,7 @@ fn assemble_jagged_assertion(
 pub fn verify_batch_merged<Ch: Challenger>(
     commitment: &Commitment,
     claims: &[F128],
-    z_skips: &[F128],
+    z_skips: &[crate::lincheck::SkipPoint],
     x_outers: &[&[F128]],
     packed_direct: &[PackedDirectClaimRef<'_>],
     heights: &[u64],
@@ -1961,7 +1961,7 @@ pub fn verify_batch_merged<Ch: Challenger>(
 pub fn verify_batch_merged_deferred<Ch: Challenger>(
     commitment: &Commitment,
     claims: &[F128],
-    z_skips: &[F128],
+    z_skips: &[crate::lincheck::SkipPoint],
     x_outers: &[&[F128]],
     packed_direct: &[PackedDirectClaimRef<'_>],
     heights: &[u64],
@@ -1993,7 +1993,7 @@ pub fn verify_batch_merged_deferred<Ch: Challenger>(
 fn verify_batch_merged_core<Ch: Challenger>(
     commitment: &Commitment,
     claims: &[F128],
-    z_skips: &[F128],
+    z_skips: &[crate::lincheck::SkipPoint],
     x_outers: &[&[F128]],
     packed_direct: &[PackedDirectClaimRef<'_>],
     heights: &[u64],
@@ -2032,7 +2032,7 @@ fn verify_batch_merged_core<Ch: Challenger>(
     let t = std::time::Instant::now();
     let mut rs_outputs = Vec::with_capacity(n_rs);
     for i in 0..n_rs {
-        let skip_w = crate::lincheck::SkipPoint::Phi8(z_skips[i]).weights(LOG_PACKING - 1);
+        let skip_w = z_skips[i].weights(LOG_PACKING - 1);
         let out = ring_switch::verify_succinct_with_grinding(
             claims[i],
             &skip_w,

--- a/crates/flock-core/src/proof.rs
+++ b/crates/flock-core/src/proof.rs
@@ -92,10 +92,14 @@ pub struct BooleanPiopProof {
 /// [`BooleanPiopProof`] with the **AG-skip** zerocheck: the genus-95 AG
 /// multiplication code replaces the RS additive-NTT round 1; the lincheck and
 /// every claim downstream are unchanged (the skip point rides as
-/// [`lincheck::SkipPoint::Ag`]). PADDING CONTRACT: the AG round-1 sum reads
-/// the full `2^m_bool` boolean region, so the witness must be built in
-/// honest-zero padding mode — the run-list-gated dirty-padding mode the RS
-/// kernels tolerate is UNSOUND here.
+/// [`lincheck::SkipPoint::Ag`]). PADDING CONTRACT (the owning statement —
+/// other sites point here): the AG union entries are run-list READ-EXACT,
+/// exactly like the RS kernels — Dead code blocks are skipped, Partial
+/// blocks are cleansed into zeroed scratch (`zerocheck::cleanse_block`),
+/// and no declared-dead bit is ever read — so dirty pooled padding
+/// (`PooledDirty`) is legal for both flavors. Only the DENSE direct-route
+/// entries (`ag_skip::prove`, `prove_capture_s_hat_v_c`) still sum the
+/// full region and need honestly zero padding.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BooleanPiopProofAg {
     pub ag: zerocheck::ag_skip::AgProof,

--- a/crates/flock-core/src/proof.rs
+++ b/crates/flock-core/src/proof.rs
@@ -89,6 +89,29 @@ pub struct BooleanPiopProof {
     pub lincheck: lincheck::LincheckProof,
 }
 
+/// [`BooleanPiopProof`] with the **AG-skip** zerocheck: the genus-95 AG
+/// multiplication code replaces the RS additive-NTT round 1; the lincheck and
+/// every claim downstream are unchanged (the skip point rides as
+/// [`lincheck::SkipPoint::Ag`]). PADDING CONTRACT: the AG round-1 sum reads
+/// the full `2^m_bool` boolean region, so the witness must be built in
+/// honest-zero padding mode — the run-list-gated dirty-padding mode the RS
+/// kernels tolerate is UNSOUND here.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BooleanPiopProofAg {
+    pub ag: zerocheck::ag_skip::AgProof,
+    pub lincheck: lincheck::LincheckProof,
+}
+
+/// [`R1csProofMergedLigerito`] with the **AG-skip** boolean zerocheck — the
+/// boolean-only union proof over the MERGED transport, AG flavor. Same
+/// transport, same lincheck, same merged opening; only the zerocheck's round
+/// 1 differs.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct R1csProofMergedLigeritoAg {
+    pub boolean: BooleanPiopProofAg,
+    pub pcs_open: pcs::MergedOpenProof,
+}
+
 /// The claims a verified mixed-class union proof leaves behind, per class.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnionClassClaims {

--- a/crates/flock-core/src/proof.rs
+++ b/crates/flock-core/src/proof.rs
@@ -112,6 +112,20 @@ pub struct R1csProofMergedLigeritoAg {
     pub pcs_open: pcs::MergedOpenProof,
 }
 
+/// [`R1csProofCircuitMerged`] with the **AG-skip** boolean zerocheck — the
+/// circuit proof, AG flavor. The element class and the wiring argument are
+/// flavor-independent; only the boolean zerocheck's round 1 differs (and the
+/// boolean claim points ride [`lincheck::SkipPoint::Ag`]). MIGRATION shape:
+/// when the RS skip is removed this struct is renamed to primary and
+/// [`R1csProofCircuitMerged`] is deleted (docs/ag-recursion-plan.md).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct R1csProofCircuitMergedAg {
+    pub boolean: Option<BooleanPiopProofAg>,
+    pub element: Option<crate::element_r1cs::union::Proof>,
+    pub wiring: crate::circuit::WiringProof,
+    pub pcs_open: pcs::MergedOpenProof,
+}
+
 /// The claims a verified mixed-class union proof leaves behind, per class.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnionClassClaims {

--- a/crates/flock-core/src/transcript_record.rs
+++ b/crates/flock-core/src/transcript_record.rs
@@ -763,6 +763,13 @@ impl<Ch: Challenger> Challenger for RecordingChallenger<Ch> {
         self.inner.supports_fused_pow_squeeze()
     }
 
+    fn hash_kind(&self) -> crate::hash::HashKind {
+        // Forward — the trait default (SHA-256) would silently diverge any
+        // out-of-sponge derivation (the AG-skip nonce decode) from the
+        // inner transcript's hash during recording.
+        self.inner.hash_kind()
+    }
+
     fn fork_from_seed(&self, _seed: [F128; 2], _label: &'static [u8]) -> Self {
         // `fork` (below) is the recorded entry: it samples the seed THROUGH
         // the recorder so the two seed squeezes land on the tape, then

--- a/crates/flock-core/src/verifier.rs
+++ b/crates/flock-core/src/verifier.rs
@@ -278,6 +278,55 @@ pub fn verify_ligerito_union<Ch: Challenger>(
     Ok(claims.boolean.expect("asserted boolean-only above"))
 }
 
+/// [`verify_ligerito_union`] with the **AG-skip** boolean zerocheck — the
+/// mirror of `flock_prover::prover::prove_fast_ligerito_union_ag`. Same
+/// statement binding, lincheck, and merged opening; only the zerocheck's
+/// round-1 replay differs (and the claim points ride [`SkipPoint::Ag`]).
+pub fn verify_ligerito_union_ag<Ch: Challenger>(
+    union: &crate::union::UnionInstance<'_>,
+    circuits: &[&dyn lincheck::LincheckCircuit],
+    commitment: &Commitment,
+    proof: &crate::proof::R1csProofMergedLigeritoAg,
+    pcs_params: &crate::pcs::PcsParams,
+    challenger: &mut Ch,
+) -> Result<R1csClaim, VerifyError> {
+    assert!(
+        !union.has_element(),
+        "the AG union route is boolean-only (the element region's PIOP is \
+         independent of the zerocheck flavor, but no mixed AG proof shape \
+         exists yet)"
+    );
+    if union.num_boolean() == 0 {
+        return Err(VerifyError::ClassMismatch);
+    }
+    let (claims, packed_direct_points, matrix, _el_matrix, _sigma) = verify_union_piops(
+        union,
+        UnionVerifyBinding::Mixed,
+        circuits,
+        commitment,
+        Some(BooleanPiopRef::Ag(&proof.boolean)),
+        None,
+        None,
+        false,
+        pcs_params,
+        challenger,
+    )?;
+    if let Some(a) = matrix {
+        a.check(union, circuits).map_err(VerifyError::Lincheck)?;
+    }
+    let claims = verify_merged_opening(
+        union,
+        commitment,
+        &claims,
+        &packed_direct_points,
+        &proof.pcs_open,
+        pcs_params,
+        challenger,
+        None,
+    )?;
+    Ok(claims.boolean.expect("boolean-only registry checked above"))
+}
+
 /// The **circuit** verify entry over the MERGED transport — the production
 /// shape, and the mirror of
 /// `flock_prover::prover::prove_fast_ligerito_union_circuit`.
@@ -311,7 +360,7 @@ pub fn verify_ligerito_union_circuit<Ch: Challenger>(
         UnionVerifyBinding::Circuit { circuit, public },
         circuits,
         commitment,
-        proof.boolean.as_ref(),
+        proof.boolean.as_ref().map(BooleanPiopRef::Rs),
         proof.element.as_ref(),
         Some(&proof.wiring),
         false,
@@ -387,7 +436,7 @@ pub fn verify_ligerito_union_circuit_deferred<Ch: Challenger>(
         UnionVerifyBinding::Circuit { circuit, public },
         circuits,
         commitment,
-        proof.boolean.as_ref(),
+        proof.boolean.as_ref().map(BooleanPiopRef::Rs),
         proof.element.as_ref(),
         Some(&proof.wiring),
         true,
@@ -433,7 +482,7 @@ fn verify_merged_opening<Ch: Challenger>(
         None => Vec::new(),
     };
     let values: Vec<F128> = cl.iter().map(|z| z.value).collect();
-    let z_skips: Vec<F128> = cl.iter().map(|z| z.point.z_skip.phi8()).collect();
+    let z_skips: Vec<SkipPoint> = cl.iter().map(|z| z.point.z_skip).collect();
     let x_fulls: Vec<Vec<F128>> = cl
         .iter()
         .map(|z| {
@@ -512,7 +561,7 @@ pub fn verify_ligerito_union_mixed_class<Ch: Challenger>(
         UnionVerifyBinding::Mixed,
         circuits,
         commitment,
-        proof.boolean.as_ref(),
+        proof.boolean.as_ref().map(BooleanPiopRef::Rs),
         proof.element.as_ref(),
         None,
         false,
@@ -539,7 +588,7 @@ pub fn verify_ligerito_union_mixed_class<Ch: Challenger>(
         None => Vec::new(),
     };
     let values: Vec<F128> = cl.iter().map(|z| z.value).collect();
-    let z_skips: Vec<F128> = cl.iter().map(|z| z.point.z_skip.phi8()).collect();
+    let z_skips: Vec<SkipPoint> = cl.iter().map(|z| z.point.z_skip).collect();
     let x_fulls: Vec<Vec<F128>> = cl
         .iter()
         .map(|z| {
@@ -607,7 +656,7 @@ pub fn verify_ligerito_union_mixed_class_deferred<Ch: Challenger>(
         UnionVerifyBinding::Mixed,
         circuits,
         commitment,
-        proof.boolean.as_ref(),
+        proof.boolean.as_ref().map(BooleanPiopRef::Rs),
         proof.element.as_ref(),
         None,
         false,
@@ -622,7 +671,7 @@ pub fn verify_ligerito_union_mixed_class_deferred<Ch: Challenger>(
         None => Vec::new(),
     };
     let values: Vec<F128> = cl.iter().map(|z| z.value).collect();
-    let z_skips: Vec<F128> = cl.iter().map(|z| z.point.z_skip.phi8()).collect();
+    let z_skips: Vec<SkipPoint> = cl.iter().map(|z| z.point.z_skip).collect();
     let x_fulls: Vec<Vec<F128>> = cl
         .iter()
         .map(|z| {
@@ -673,6 +722,15 @@ pub fn verify_ligerito_union_mixed_class_deferred<Ch: Challenger>(
     ))
 }
 
+/// The boolean sub-proof as [`verify_union_piops`] consumes it — either
+/// zerocheck flavor. Downstream of the zerocheck the two are identical (the
+/// lincheck and both claim points are generic over [`SkipPoint`]).
+#[derive(Clone, Copy)]
+enum BooleanPiopRef<'a> {
+    Rs(&'a crate::proof::BooleanPiopProof),
+    Ag(&'a crate::proof::BooleanPiopProofAg),
+}
+
 /// Shared PIOP replay for both union verify shapes: statement binding, the
 /// boolean class's zerocheck + lincheck over the `M_bool` prefix subcube, then
 /// the element region's PIOP. Returns the per-class claims and the element
@@ -685,7 +743,7 @@ fn verify_union_piops<Ch: Challenger>(
     binding: UnionVerifyBinding<'_>,
     circuits: &[&dyn lincheck::LincheckCircuit],
     commitment: &Commitment,
-    boolean: Option<&crate::proof::BooleanPiopProof>,
+    boolean: Option<BooleanPiopRef<'_>>,
     element: Option<&crate::element_r1cs::union::Proof>,
     wiring: Option<&crate::circuit::WiringProof>,
     defer_sigma: bool,
@@ -737,16 +795,49 @@ fn verify_union_piops<Ch: Challenger>(
                 // The boolean PIOP runs over the BOOLEAN REGION only — the
                 // prefix subcube `[0, 2^M_bool)`, `M_bool = M` for a
                 // boolean-only registry. (The element region cannot join this
-                // sum: `c = z` there.)
-                let zc_claim = zerocheck::verify_with_grinding(
-                    union.m_bool(),
-                    &piop.zerocheck,
-                    pcs_params.zerocheck_grinding(),
-                    challenger,
-                )
-                .map_err(VerifyError::Zerocheck)?;
-                let x_ab =
-                    union.x_ab_from_mlv(SkipPoint::Phi8(zc_claim.z), &zc_claim.mlv_challenges);
+                // sum: `c = z` there.) The zerocheck flavor dispatches here;
+                // everything downstream is shared, generic over the flavor's
+                // skip point.
+                let (z_skip, mlv_challenges, a_eval, b_eval, c_eval, r_rest, lincheck_proof) =
+                    match piop {
+                        BooleanPiopRef::Rs(p) => {
+                            let zc = zerocheck::verify_with_grinding(
+                                union.m_bool(),
+                                &p.zerocheck,
+                                pcs_params.zerocheck_grinding(),
+                                challenger,
+                            )
+                            .map_err(VerifyError::Zerocheck)?;
+                            (
+                                SkipPoint::Phi8(zc.z),
+                                zc.mlv_challenges,
+                                zc.a_eval,
+                                zc.b_eval,
+                                zc.c_eval,
+                                zc.r_rest,
+                                &p.lincheck,
+                            )
+                        }
+                        BooleanPiopRef::Ag(p) => {
+                            let ag = zerocheck::ag_skip::verify_with_grinding(
+                                union.m_bool(),
+                                &p.ag,
+                                pcs_params.zerocheck_grinding(),
+                                challenger,
+                            )
+                            .map_err(VerifyError::Ag)?;
+                            (
+                                SkipPoint::Ag(ag.r1),
+                                ag.mlv_challenges,
+                                ag.a_eval,
+                                ag.b_eval,
+                                ag.c_eval,
+                                ag.r_rest,
+                                &p.lincheck,
+                            )
+                        }
+                    };
+                let x_ab = union.x_ab_from_mlv(z_skip, &mlv_challenges);
                 // The union-column lincheck (one circuit per BOOLEAN slot, in
                 // slot order); the declared counts additionally bind through
                 // the per-type const-pin target terms.
@@ -757,9 +848,9 @@ fn verify_union_piops<Ch: Challenger>(
                     union,
                     circuits,
                     &x_ab,
-                    zc_claim.a_eval,
-                    zc_claim.b_eval,
-                    &piop.lincheck,
+                    a_eval,
+                    b_eval,
+                    lincheck_proof,
                     pcs_params.lincheck_grinding(),
                     challenger,
                 )
@@ -775,8 +866,8 @@ fn verify_union_piops<Ch: Challenger>(
                         value: lc_claim.w,
                     },
                     c: ZClaim {
-                        point: union.c_claim_point(SkipPoint::Phi8(zc_claim.z), &zc_claim.r_rest),
-                        value: zc_claim.c_eval,
+                        point: union.c_claim_point(z_skip, &r_rest),
+                        value: c_eval,
                     },
                 })
             }

--- a/crates/flock-core/src/verifier.rs
+++ b/crates/flock-core/src/verifier.rs
@@ -465,6 +465,121 @@ pub fn verify_ligerito_union_circuit_deferred<Ch: Challenger>(
     ))
 }
 
+/// [`verify_ligerito_union_circuit`] with the **AG-skip** boolean zerocheck —
+/// the mirror of `flock_prover::prover::prove_fast_ligerito_union_circuit_ag`.
+/// Same replay; only the boolean zerocheck's round 1 differs.
+#[allow(clippy::too_many_arguments)]
+pub fn verify_ligerito_union_circuit_ag<Ch: Challenger>(
+    union: &crate::union::UnionInstance<'_>,
+    circuit: &crate::circuit::Circuit,
+    public: &[F128],
+    circuits: &[&dyn lincheck::LincheckCircuit],
+    commitment: &Commitment,
+    proof: &crate::proof::R1csProofCircuitMergedAg,
+    pcs_params: &crate::pcs::PcsParams,
+    challenger: &mut Ch,
+) -> Result<crate::proof::UnionClassClaims, VerifyError> {
+    if !circuit.check_instance(union) || !circuit.check_public(public) {
+        return Err(VerifyError::CircuitMismatch);
+    }
+    if proof.boolean.is_some() != (union.num_boolean() > 0)
+        || proof.element.is_some() != union.has_element()
+    {
+        return Err(VerifyError::ClassMismatch);
+    }
+    let (claims, packed_direct_points, matrix, el_matrix, _sigma) = verify_union_piops(
+        union,
+        UnionVerifyBinding::Circuit { circuit, public },
+        circuits,
+        commitment,
+        proof.boolean.as_ref().map(BooleanPiopRef::Ag),
+        proof.element.as_ref(),
+        Some(&proof.wiring),
+        false,
+        pcs_params,
+        challenger,
+    )?;
+    if let Some(a) = matrix {
+        a.check(union, circuits).map_err(VerifyError::Lincheck)?;
+    }
+    if let Some(a) = el_matrix {
+        a.check_reported(union).map_err(VerifyError::Element)?;
+    }
+    verify_merged_opening(
+        union,
+        commitment,
+        &claims,
+        &packed_direct_points,
+        &proof.pcs_open,
+        pcs_params,
+        challenger,
+        None,
+    )
+}
+
+/// [`verify_ligerito_union_circuit_deferred`] with the **AG-skip** boolean
+/// zerocheck — the succinct entry the recursion tower records and replays for
+/// AG-flavored children. Same conditional-claims contract as the RS twin.
+#[allow(clippy::too_many_arguments)]
+pub fn verify_ligerito_union_circuit_ag_deferred<Ch: Challenger>(
+    union: &crate::union::UnionInstance<'_>,
+    circuit: &crate::circuit::Circuit,
+    public: &[F128],
+    circuits: &[&dyn lincheck::LincheckCircuit],
+    commitment: &Commitment,
+    proof: &crate::proof::R1csProofCircuitMergedAg,
+    pcs_params: &crate::pcs::PcsParams,
+    challenger: &mut Ch,
+) -> Result<
+    (
+        crate::proof::UnionClassClaims,
+        DeferredMatrixWork,
+        crate::circuit::SigmaAssertion,
+    ),
+    VerifyError,
+> {
+    if !circuit.check_instance(union) || !circuit.check_public(public) {
+        return Err(VerifyError::CircuitMismatch);
+    }
+    if proof.boolean.is_some() != (union.num_boolean() > 0)
+        || proof.element.is_some() != union.has_element()
+    {
+        return Err(VerifyError::ClassMismatch);
+    }
+    let (claims, packed_direct_points, matrix, el_matrix, sigma) = verify_union_piops(
+        union,
+        UnionVerifyBinding::Circuit { circuit, public },
+        circuits,
+        commitment,
+        proof.boolean.as_ref().map(BooleanPiopRef::Ag),
+        proof.element.as_ref(),
+        Some(&proof.wiring),
+        true,
+        pcs_params,
+        challenger,
+    )?;
+    let mut jagged = None;
+    let claims = verify_merged_opening(
+        union,
+        commitment,
+        &claims,
+        &packed_direct_points,
+        &proof.pcs_open,
+        pcs_params,
+        challenger,
+        Some(&mut jagged),
+    )?;
+    Ok((
+        claims,
+        DeferredMatrixWork {
+            boolean: matrix,
+            element: el_matrix,
+            jagged: jagged.expect("the deferred opening fills the export"),
+        },
+        sigma.expect("a circuit binding always verifies wiring"),
+    ))
+}
+
 /// The merged transport's verification, shared by the mixed-class and circuit
 /// entries: the boolean pair ring-switched, everything else packed-direct.
 fn verify_merged_opening<Ch: Challenger>(

--- a/crates/flock-core/src/zerocheck.rs
+++ b/crates/flock-core/src/zerocheck.rs
@@ -121,11 +121,13 @@ impl ZerocheckGrinding {
     }
 
     /// Explicit PoW bits on the AG-skip zerocheck's FUSED `r₁` nonce
-    /// ([`ag_skip::sample_r1_prover_pow`]): `bits_for(474) = 9` total bits
-    /// required ([`ag_skip::R1_ZERO_BOUND`]), of which the rejection sampler
-    /// provably contributes [`ag_skip::AG_SAMPLING_CREDIT_BITS`] = 5, leaving
-    /// 4 explicit. `None` under a disabled schedule (the direct route's plain
-    /// single-attempt nonce, which makes no 128-bit claim).
+    /// ([`ag_skip::sample_r1_prover_pow`]): ALL `bits_for(474) = 9` bits
+    /// required ([`ag_skip::R1_ZERO_BOUND`]) are explicit — the recursion
+    /// circuit binds the decode with RELAXED canonicity (any fiber point
+    /// over the XOF-derived `x`), which returns the sampler's 5 flattening
+    /// bits to the prover, so they are repaid in the PoW target. `None`
+    /// under a disabled schedule (the direct route's plain single-attempt
+    /// nonce, which makes no 128-bit claim).
     pub const fn ag_r1_bits(self) -> Option<u32> {
         if self.enabled {
             Some(ag_skip::R1_POW_BITS)

--- a/crates/flock-core/src/zerocheck.rs
+++ b/crates/flock-core/src/zerocheck.rs
@@ -120,6 +120,20 @@ impl ZerocheckGrinding {
         }
     }
 
+    /// Explicit PoW bits on the AG-skip zerocheck's FUSED `r₁` nonce
+    /// ([`ag_skip::sample_r1_prover_pow`]): `bits_for(474) = 9` total bits
+    /// required ([`ag_skip::R1_ZERO_BOUND`]), of which the rejection sampler
+    /// provably contributes [`ag_skip::AG_SAMPLING_CREDIT_BITS`] = 5, leaving
+    /// 4 explicit. `None` under a disabled schedule (the direct route's plain
+    /// single-attempt nonce, which makes no 128-bit claim).
+    pub const fn ag_r1_bits(self) -> Option<u32> {
+        if self.enabled {
+            Some(ag_skip::R1_POW_BITS)
+        } else {
+            None
+        }
+    }
+
     /// PoW before a standard degree-two tail-round challenge.
     pub const fn multilinear_round_bits(self) -> Option<u32> {
         if self.enabled {

--- a/crates/flock-core/src/zerocheck.rs
+++ b/crates/flock-core/src/zerocheck.rs
@@ -297,6 +297,41 @@ impl PaddingSpec {
         out
     }
 
+    /// Per-block coverage over `n_blocks` blocks of `2^log2_block` bits —
+    /// the gating map for block-grained kernels (the AG round 1 and fold,
+    /// whose natural tile is the 8192-bit code block). `Dead` blocks may be
+    /// skipped outright (their honest contribution is zero), `Full` blocks
+    /// read in place, and `Partial` blocks carry their block-local useful
+    /// bit ranges so a kernel can cleanse them into a zeroed scratch block
+    /// ([`cleanse_block`]) and never read a declared-dead bit — the
+    /// exactness `PooledDirty` requires.
+    pub fn block_coverage(&self, log2_block: usize, n_blocks: usize) -> Vec<BlockCoverage> {
+        let block_bits = 1usize << log2_block;
+        let mut out = vec![BlockCoverage::Dead; n_blocks];
+        for (s, e) in self.useful_intervals() {
+            let mut blk = s >> log2_block;
+            while blk < n_blocks && (blk << log2_block) < e {
+                let b0 = blk << log2_block;
+                let (cs, ce) = (s.max(b0), e.min(b0 + block_bits));
+                let piece = (cs - b0, ce - b0);
+                out[blk] = match std::mem::replace(&mut out[blk], BlockCoverage::Dead) {
+                    _ if piece == (0, block_bits) => BlockCoverage::Full,
+                    BlockCoverage::Dead => BlockCoverage::Partial(vec![piece]),
+                    BlockCoverage::Partial(mut v) => {
+                        // Intervals are sorted and merged, so pieces arrive
+                        // in order and never touch (a touching pair would
+                        // have merged upstream).
+                        v.push(piece);
+                        BlockCoverage::Partial(v)
+                    }
+                    BlockCoverage::Full => unreachable!("a full block admits no second piece"),
+                };
+                blk += 1;
+            }
+        }
+        out
+    }
+
     /// Sorted, merged list of useful bit intervals `[start, end)` — the
     /// semantic content of the spec (everything outside is declared zero).
     /// Consumed by the general (multi-run) kernel paths and by tests; cost is
@@ -319,6 +354,40 @@ impl PaddingSpec {
             offset += run.extent_bits();
         }
         intervals
+    }
+}
+
+/// One block's standing in a [`PaddingSpec::block_coverage`] map.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BlockCoverage {
+    /// No useful bit — skippable outright (honest contribution zero).
+    Dead,
+    /// Every bit useful — read in place.
+    Full,
+    /// The block-local useful bit ranges `[start, end)`, sorted and
+    /// non-touching — cleanse into zeroed scratch before reading.
+    Partial(Vec<(usize, usize)>),
+}
+
+/// Copy one block's useful bits — block-local bit `ranges` — from `src` at
+/// byte offset `base_byte` into `dst` (zeroed here first). Edge bits of a
+/// non-byte-aligned range are masked, so a declared-dead neighbor bit never
+/// leaks through: after this, `dst` is the block a fully honest prover
+/// would have had, whatever garbage the pooled source carries.
+pub fn cleanse_block(src: &[u8], base_byte: usize, ranges: &[(usize, usize)], dst: &mut [u8]) {
+    dst.fill(0);
+    for &(s, e) in ranges {
+        let (sb, eb) = (s / 8, e.div_ceil(8));
+        for i in sb..eb {
+            let mut mask = 0xFFu8;
+            if i == s / 8 {
+                mask &= 0xFFu8 << (s % 8);
+            }
+            if e % 8 != 0 && i == e / 8 {
+                mask &= !(0xFFu8 << (e % 8));
+            }
+            dst[i] |= src[base_byte + i] & mask;
+        }
     }
 }
 
@@ -1680,6 +1749,91 @@ mod tests {
     // -----------------------------------------------------------------------
     // Run-list PaddingSpec.
     // -----------------------------------------------------------------------
+
+    /// The block-coverage map (the AG kernels' gating grid) classifies
+    /// every 8192-bit block correctly — full runs, bit-granular partial
+    /// tails, dead gaps, runs straddling the grid, mid-block starts, and
+    /// multiple pieces per block — and [`cleanse_block`] reproduces exactly
+    /// the honest block (dead bits zero, edge bits masked) from a dirty
+    /// source.
+    #[test]
+    fn block_coverage_and_cleanse() {
+        let spec = PaddingSpec::from_runs(vec![
+            PaddingRun {
+                k_log: 13,
+                useful_bits_per_block: 1 << 13,
+                n_blocks: 2,
+            },
+            PaddingRun {
+                k_log: 13,
+                useful_bits_per_block: 3001,
+                n_blocks: 1,
+            },
+            PaddingRun {
+                k_log: 13,
+                useful_bits_per_block: 0,
+                n_blocks: 2,
+            },
+            PaddingRun {
+                k_log: 14,
+                useful_bits_per_block: 9000,
+                n_blocks: 1,
+            },
+        ]);
+        let cov = spec.block_coverage(13, 8);
+        assert_eq!(
+            cov,
+            vec![
+                BlockCoverage::Full,
+                BlockCoverage::Full,
+                BlockCoverage::Partial(vec![(0, 3001)]),
+                BlockCoverage::Dead,
+                BlockCoverage::Dead,
+                BlockCoverage::Full,
+                BlockCoverage::Partial(vec![(0, 9000 - 8192)]),
+                BlockCoverage::Dead,
+            ]
+        );
+        // Sub-grid runs: a dead prefix pushes an interval to a mid-block
+        // start, and two disjoint intervals land in ONE grid block.
+        let sub = PaddingSpec::from_runs(vec![
+            PaddingRun {
+                k_log: 12,
+                useful_bits_per_block: 1000,
+                n_blocks: 1,
+            },
+            PaddingRun {
+                k_log: 12,
+                useful_bits_per_block: 2000,
+                n_blocks: 1,
+            },
+        ]);
+        assert_eq!(
+            sub.block_coverage(13, 2),
+            vec![
+                BlockCoverage::Partial(vec![(0, 1000), (4096, 6096)]),
+                BlockCoverage::Dead,
+            ]
+        );
+
+        // Cleanse: a garbage source, block-local ranges — the output holds
+        // the source's bits exactly on the ranges and zero elsewhere.
+        let src: Vec<u8> = (0..2048u32).map(|i| (i * 37 + 11) as u8).collect();
+        let base = 1024usize;
+        let ranges = [(0usize, 1001usize), (4099usize, 6096usize), (8003, 8190)];
+        let mut dst = [0xEEu8; 1024]; // pre-dirty: cleanse must fully own it
+        cleanse_block(&src, base, &ranges, &mut dst);
+        for bit in 0..8192usize {
+            let useful = ranges.iter().any(|&(s, e)| bit >= s && bit < e);
+            let got = (dst[bit / 8] >> (bit % 8)) & 1;
+            let want = if useful {
+                (src[base + bit / 8] >> (bit % 8)) & 1
+            } else {
+                0
+            };
+            assert_eq!(got, want, "bit {bit} (useful: {useful})");
+        }
+    }
 
     /// Run-list construction/accessor sanity: canonical forms, extents,
     /// single-run detection, and useful-interval merging.

--- a/crates/flock-core/src/zerocheck/ag_skip.rs
+++ b/crates/flock-core/src/zerocheck/ag_skip.rs
@@ -808,6 +808,12 @@ pub struct AgProof {
     pub final_a_eval: F128,
     pub final_b_eval: F128,
     pub final_c_eval: F128,
+    /// PoW nonces in transcript order: the initial outer-eq point, then one
+    /// per multilinear round. Empty under [`ZerocheckGrinding::disabled`]
+    /// (the direct-route entries and every pre-grinding proof). `r₁` keeps
+    /// its own rejection-sampling nonce (`r1_nonce`) regardless.
+    #[serde(default)]
+    pub grinding_nonces: Vec<u64>,
 }
 
 /// Evaluation claims the AG-skip zerocheck reduces to (no PCS). `a_eval`, `b_eval`
@@ -844,6 +850,67 @@ pub enum AgVerifyError {
     },
     CEvalMismatch,
     SumcheckFinalFailed,
+    /// The nonce vector does not match the configured grinding schedule.
+    BadGrindingNonceCount { expected: usize, got: usize },
+    /// A nonce fails the PoW at the FS position sampling its challenge.
+    InvalidGrindingNonce,
+}
+
+/// Challenger adapter for the multilinear tail under per-round grinding:
+/// every `sample_f128` in the tail IS a round challenge, so the adapter
+/// grinds `bits` before each and records the nonce — the tail's kernels stay
+/// untouched. Framing-sensitive ops delegate verbatim.
+struct RoundGrindProver<'a, C: Challenger> {
+    inner: &'a mut C,
+    bits: u32,
+    nonces: &'a mut Vec<u64>,
+}
+
+impl<C: Challenger> Challenger for RoundGrindProver<'_, C> {
+    fn supports_fused_pow_squeeze(&self) -> bool {
+        self.inner.supports_fused_pow_squeeze()
+    }
+    fn hash_kind(&self) -> crate::merkle::HashKind {
+        self.inner.hash_kind()
+    }
+    fn observe_label(&mut self, label: &[u8]) {
+        self.inner.observe_label(label)
+    }
+    fn observe_f128(&mut self, value: F128) {
+        self.inner.observe_f128(value)
+    }
+    fn observe_f128_slice(&mut self, values: &[F128]) {
+        self.inner.observe_f128_slice(values)
+    }
+    fn observe_bytes(&mut self, bytes: &[u8]) {
+        self.inner.observe_bytes(bytes)
+    }
+    fn sample_f128(&mut self) -> F128 {
+        let (nonce, r) = self.inner.grind_pow_and_sample_f128(self.bits);
+        self.nonces.push(nonce);
+        r
+    }
+    fn sample_f128_vec(&mut self, n: usize) -> Vec<F128> {
+        // The tail never vector-squeezes; keep the inner framing if it ever does.
+        self.inner.sample_f128_vec(n)
+    }
+    fn grind_pow(&mut self, bits: u32) -> u64 {
+        self.inner.grind_pow(bits)
+    }
+    fn verify_pow(&mut self, nonce: u64, bits: u32) -> bool {
+        self.inner.verify_pow(nonce, bits)
+    }
+    fn fork_from_seed(&self, _seed: [F128; 2], _label: &'static [u8]) -> Self {
+        unreachable!("the grinding tail adapter is never forked")
+    }
+}
+
+/// Nonce count [`AgProof::grinding_nonces`] must carry for `m` under a
+/// schedule: the initial outer-eq point + one per multilinear round. (`r₁`'s
+/// rejection nonce is a separate proof field.)
+pub fn grinding_nonce_count(grinding: super::ZerocheckGrinding, m: usize) -> usize {
+    usize::from(grinding.initial_bits(m).is_some())
+        + usize::from(grinding.multilinear_round_bits().is_some()) * (m - K_SKIP)
 }
 
 /// Prove `a(y)·b(y) = c(y)` for all `y ∈ {0,1}^m` via the AG-skip zerocheck.
@@ -867,7 +934,15 @@ pub fn prove<C: Challenger>(
     let eq = crate::zerocheck::univariate_skip::build_eq(&r_outer);
 
     let msg = prove_round1(a_packed, b_packed, c_packed, &eq);
-    prove_from_round1(a_packed, b_packed, msg, &r_outer, challenger)
+    prove_from_round1(
+        a_packed,
+        b_packed,
+        msg,
+        &r_outer,
+        super::ZerocheckGrinding::disabled(),
+        Vec::new(),
+        challenger,
+    )
 }
 
 /// [`prove`] that ALSO returns the c-claim's `s_hat_v_c` — the length-128
@@ -901,7 +976,67 @@ pub fn prove_capture_s_hat_v_c<C: Challenger>(
     let eq = crate::zerocheck::univariate_skip::build_eq(&r_outer);
 
     let (msg, s_hat_v_c) = prove_round1_banks(a_packed, b_packed, c_packed, &eq);
-    let (proof, claim) = prove_from_round1(a_packed, b_packed, msg, &r_outer, challenger);
+    let (proof, claim) = prove_from_round1(
+        a_packed,
+        b_packed,
+        msg,
+        &r_outer,
+        super::ZerocheckGrinding::disabled(),
+        Vec::new(),
+        challenger,
+    );
+    (proof, claim, s_hat_v_c)
+}
+
+/// [`prove_capture_s_hat_v_c`] under a Fiat--Shamir grinding schedule — the
+/// UNION route's strict-profile entry. Grinds the initial outer-eq point
+/// (`initial_bits(m)`) and every multilinear round
+/// (`multilinear_round_bits`), mirroring the RS zerocheck's schedule; `r₁`
+/// keeps its inherent rejection-sampling nonce (the AG challenge family's
+/// strict-bits accounting is an audit TODO — this variant is opt-in).
+///
+/// PADDING CONTRACT: round 1 sums the FULL `2^m` region — every padding
+/// word of `a`/`b`/`c` must be an HONEST ZERO (the union's fresh-zeroed
+/// witness mode), unlike the run-list-gated RS kernels which never read
+/// them.
+#[cfg(target_arch = "aarch64")]
+pub fn prove_capture_s_hat_v_c_with_grinding<C: Challenger>(
+    a_packed: &[u8],
+    b_packed: &[u8],
+    c_packed: &[u8],
+    m: usize,
+    grinding: super::ZerocheckGrinding,
+    challenger: &mut C,
+) -> (AgProof, AgClaim, Vec<F128>) {
+    assert!(m >= K_SKIP + N_INNER, "m >= 13 required");
+    let expected = (1usize << m) / 8;
+    assert_eq!(a_packed.len(), expected);
+    assert_eq!(b_packed.len(), expected);
+    assert_eq!(c_packed.len(), expected);
+
+    challenger.observe_label(b"flock-ag-skip-v1");
+    let mut grinding_nonces = Vec::with_capacity(grinding_nonce_count(grinding, m));
+    let r_outer = match grinding.initial_bits(m) {
+        Some(bits) => {
+            let (nonce, v) =
+                challenger.grind_pow_and_sample_f128_vec(bits, m - K_SKIP - N_INNER);
+            grinding_nonces.push(nonce);
+            v
+        }
+        None => challenger.sample_f128_vec(m - K_SKIP - N_INNER),
+    };
+    let eq = crate::zerocheck::univariate_skip::build_eq(&r_outer);
+
+    let (msg, s_hat_v_c) = prove_round1_banks(a_packed, b_packed, c_packed, &eq);
+    let (proof, claim) = prove_from_round1(
+        a_packed,
+        b_packed,
+        msg,
+        &r_outer,
+        grinding,
+        grinding_nonces,
+        challenger,
+    );
     (proof, claim, s_hat_v_c)
 }
 
@@ -950,6 +1085,8 @@ fn prove_from_round1<C: Challenger>(
     b_packed: &[u8],
     msg: Round1Message,
     r_outer: &[F128],
+    grinding: super::ZerocheckGrinding,
+    mut grinding_nonces: Vec<u64>,
     challenger: &mut C,
 ) -> (AgProof, AgClaim) {
     challenger.observe_f128_slice(&msg.ab_fresh);
@@ -965,8 +1102,17 @@ fn prove_from_round1<C: Challenger>(
 
     // Round 0: fused fold of a,b at r1 + the first (full-size) multilinear message.
     let (a_mlv, b_mlv, g1_0, ginf_0) = fold_and_first_round(a_packed, b_packed, &w, &r_rest);
-    let (rounds, rhos, a_eval, b_eval) =
-        mlv_tail_fs(a_mlv, b_mlv, g1_0, ginf_0, &r_rest, challenger);
+    let (rounds, rhos, a_eval, b_eval) = match grinding.multilinear_round_bits() {
+        Some(bits) => {
+            let mut gch = RoundGrindProver {
+                inner: challenger,
+                bits,
+                nonces: &mut grinding_nonces,
+            };
+            mlv_tail_fs(a_mlv, b_mlv, g1_0, ginf_0, &r_rest, &mut gch)
+        }
+        None => mlv_tail_fs(a_mlv, b_mlv, g1_0, ginf_0, &r_rest, challenger),
+    };
 
     let proof = AgProof {
         round1_ab: msg.ab_fresh,
@@ -976,6 +1122,7 @@ fn prove_from_round1<C: Challenger>(
         final_a_eval: a_eval,
         final_b_eval: b_eval,
         final_c_eval: c_eval,
+        grinding_nonces,
     };
     let claim = AgClaim {
         r1,
@@ -1253,6 +1400,18 @@ pub fn verify<C: Challenger>(
     proof: &AgProof,
     challenger: &mut C,
 ) -> Result<AgClaim, AgVerifyError> {
+    verify_with_grinding(m, proof, super::ZerocheckGrinding::disabled(), challenger)
+}
+
+/// [`verify`] under a grinding schedule — the mirror of
+/// [`prove_capture_s_hat_v_c_with_grinding`]. With a disabled schedule this
+/// accepts exactly the old proofs (an empty nonce vector is required).
+pub fn verify_with_grinding<C: Challenger>(
+    m: usize,
+    proof: &AgProof,
+    grinding: super::ZerocheckGrinding,
+    challenger: &mut C,
+) -> Result<AgClaim, AgVerifyError> {
     if m < K_SKIP + N_INNER {
         return Err(AgVerifyError::LogNTooSmall { log_n: m });
     }
@@ -1277,9 +1436,25 @@ pub fn verify<C: Challenger>(
             got: proof.multilinear_rounds.len(),
         });
     }
+    let expected_nonces = grinding_nonce_count(grinding, m);
+    if proof.grinding_nonces.len() != expected_nonces {
+        return Err(AgVerifyError::BadGrindingNonceCount {
+            expected: expected_nonces,
+            got: proof.grinding_nonces.len(),
+        });
+    }
+    let mut nonces = proof.grinding_nonces.iter().copied();
 
     challenger.observe_label(b"flock-ag-skip-v1");
-    let r_outer = challenger.sample_f128_vec(m - K_SKIP - N_INNER);
+    let r_outer = match grinding.initial_bits(m) {
+        Some(bits) => {
+            let nonce = nonces.next().ok_or(AgVerifyError::InvalidGrindingNonce)?;
+            challenger
+                .verify_pow_and_sample_f128_vec(nonce, bits, m - K_SKIP - N_INNER)
+                .ok_or(AgVerifyError::InvalidGrindingNonce)?
+        }
+        None => challenger.sample_f128_vec(m - K_SKIP - N_INNER),
+    };
     challenger.observe_f128_slice(&proof.round1_ab);
     challenger.observe_f128_slice(&proof.round1_c);
 
@@ -1296,6 +1471,7 @@ pub fn verify<C: Challenger>(
     let mut r_rest = friendly_challenges().to_vec();
     r_rest.extend_from_slice(&r_outer);
 
+    let mlv_bits = grinding.multilinear_round_bits();
     let mut rhos = Vec::with_capacity(n_mlv);
     for i in 0..n_mlv {
         let (g1, g_inf) = proof.multilinear_rounds[i];
@@ -1303,7 +1479,15 @@ pub fn verify<C: Challenger>(
         let g0 = (c_running + r_eq * g1) * (F128::ONE + r_eq).inv();
         challenger.observe_f128(g1);
         challenger.observe_f128(g_inf);
-        let rho = challenger.sample_f128();
+        let rho = match mlv_bits {
+            Some(bits) => {
+                let nonce = nonces.next().ok_or(AgVerifyError::InvalidGrindingNonce)?;
+                challenger
+                    .verify_pow_and_sample_f128(nonce, bits)
+                    .ok_or(AgVerifyError::InvalidGrindingNonce)?
+            }
+            None => challenger.sample_f128(),
+        };
         rhos.push(rho);
         c_running = g0 * (F128::ONE + rho) + g1 * rho + g_inf * rho * (rho + F128::ONE);
     }

--- a/crates/flock-core/src/zerocheck/ag_skip.rs
+++ b/crates/flock-core/src/zerocheck/ag_skip.rs
@@ -393,7 +393,11 @@ pub fn fold_and_first_round_padded(
     let eq_outer = super::univariate_skip::build_eq(&r_rest[N_INNER..]);
     let n_outer = eq_outer.len();
     assert_eq!(n, n_outer * 128, "each outer block is 128 (2^7) messages");
-    assert_eq!(coverage.len(), n_outer, "one coverage entry per outer block");
+    assert_eq!(
+        coverage.len(),
+        n_outer,
+        "one coverage entry per outer block"
+    );
     let mut d1 = F128::ONE;
     for j in 1..N_INNER {
         d1 *= F128::ONE + gamma_pow(1usize << j);
@@ -459,7 +463,11 @@ pub fn fold_and_first_round_sparse(
     let eq_outer = super::univariate_skip::build_eq(&r_rest[N_INNER..]);
     let n_outer = eq_outer.len();
     assert_eq!(a_packed.len() / 8, n_outer * 128, "128 messages per block");
-    assert_eq!(coverage.len(), n_outer, "one coverage entry per outer block");
+    assert_eq!(
+        coverage.len(),
+        n_outer,
+        "one coverage entry per outer block"
+    );
     let mut d1 = F128::ONE;
     for j in 1..N_INNER {
         d1 *= F128::ONE + gamma_pow(1usize << j);

--- a/crates/flock-core/src/zerocheck/ag_skip.rs
+++ b/crates/flock-core/src/zerocheck/ag_skip.rs
@@ -869,14 +869,24 @@ pub const R1_ZERO_BOUND: usize = 474;
 /// empirical acceptance estimate; guarded by `credit_constants_are_pinned`.
 pub const AG_SAMPLING_CREDIT_BITS: u32 = 5;
 
-/// Explicit PoW bits on the FUSED r₁ nonce under a strict grinding schedule:
-/// `bits_for(R1_ZERO_BOUND) − AG_SAMPLING_CREDIT_BITS = 9 − 5 = 4`.
-pub const R1_POW_BITS: u32 = 4;
+/// Explicit PoW bits on the FUSED r₁ nonce under a strict grinding
+/// schedule: ALL of `bits_for(R1_ZERO_BOUND) = 9` — the sampler's
+/// [`AG_SAMPLING_CREDIT_BITS`] = 5 no longer discount r₁'s explicit bits.
+/// WHY (phase D, docs/ag-recursion-plan.md): the recursion circuit binds
+/// the r₁ decode with RELAXED canonicity — it enforces `x` from the
+/// nonce-seed's XOF and fiber membership for `(y, z₁..z₃)`, but not WHICH
+/// fiber point (the ≤ 32-point fiber = exactly the sampler's 5 flattening
+/// bits). A circuit-side prover may therefore choose among the fiber
+/// points, so those 5 bits are repaid explicitly; the total stays
+/// `bits_for(474)`, the split moves. The sampler's credit still stands
+/// where the decode is canonical end-to-end (the lincheck fresh skip).
+pub const R1_POW_BITS: u32 = 9;
 
 /// Prover-side scan budget for the fused r₁ nonce: success per nonce is
-/// `2^-R1_POW_BITS / 32 = 2^-9`, so exhausting `2^20` nonces has probability
-/// `(1 − 2^-9)^(2^20) ≈ 2^-2954` — a completeness error we accept (panic).
-pub const R1_FUSED_ATTEMPT_BUDGET: u32 = 1 << 20;
+/// `2^-R1_POW_BITS / 32 = 2^-14`, so exhausting `2^24` nonces has
+/// probability `(1 − 2^-14)^(2^24) ≈ 2^-1477` — a completeness error we
+/// accept (panic). Fits the 4-byte nonce encoding with room.
+pub const R1_FUSED_ATTEMPT_BUDGET: u32 = 1 << 24;
 
 /// rejection sampling exhausts its attempt budget. Baked from one offline sample.
 ///
@@ -973,9 +983,12 @@ pub(super) fn sample_r1_prover<C: Challenger>(challenger: &mut C) -> (Evaluation
 /// (or an attacker) evaluates re-enters the PoW, so there is no free choice
 /// among valid nonces; with the sampler's provable
 /// [`AG_SAMPLING_CREDIT_BITS`] = 5 bits on top, `r₁` carries
-/// `pow_bits + 5` grinding bits total. Expected prover cost is
-/// `2^pow_bits · 32` hash calls plus `2^pow_bits` point attempts (~50 µs at
-/// the strict [`R1_POW_BITS`] = 4); the verifier stays ONE-SHOT.
+/// `pow_bits + 5` grinding bits total against a CANONICAL decode — the
+/// strict schedule sets `pow_bits =` [`R1_POW_BITS`] = 9 so the budget
+/// holds even against the recursion circuit's relaxed-canonicity decode,
+/// which returns the fiber's 5 bits to the prover. Expected prover cost is
+/// `2^pow_bits · 32` hash calls plus `2^pow_bits` point attempts (~1 ms at
+/// 9 bits); the verifier stays ONE-SHOT.
 pub(super) fn sample_r1_prover_pow<C: Challenger>(
     challenger: &mut C,
     pow_bits: u32,
@@ -1241,9 +1254,10 @@ pub fn prove_capture_s_hat_v_c<C: Challenger>(
 /// (`initial_bits(m)`) and every multilinear round
 /// (`multilinear_round_bits`), mirroring the RS zerocheck's schedule; `r₁`
 /// switches to the FUSED nonce ([`sample_r1_prover_pow`]):
-/// [`R1_POW_BITS`] = 4 explicit PoW bits + the sampler's
-/// [`AG_SAMPLING_CREDIT_BITS`] = 5 provable bits = `bits_for(474)` for the
-/// product+base code bad set ([`R1_ZERO_BOUND`]), with a ONE-SHOT verifier.
+/// [`R1_POW_BITS`] = 9 explicit PoW bits = `bits_for(474)` for the
+/// product+base code bad set ([`R1_ZERO_BOUND`]) — all explicit, so the
+/// budget survives the recursion circuit's relaxed-canonicity decode —
+/// with a ONE-SHOT verifier.
 ///
 /// PADDING CONTRACT: round 1 sums the FULL `2^m` region — every padding
 /// word of `a`/`b`/`c` must be an HONEST ZERO (the union's fresh-zeroed
@@ -2689,11 +2703,10 @@ mod tests {
         let sampler_denom = crate::genus95_curve_code::BASE_Y_DEGREE * 8;
         assert_eq!(sampler_denom, 32);
         assert_eq!(AG_SAMPLING_CREDIT_BITS, sampler_denom.trailing_zeros());
-        // Explicit + credit = the strict per-challenge requirement.
-        assert_eq!(
-            R1_POW_BITS + AG_SAMPLING_CREDIT_BITS,
-            bits_for(R1_ZERO_BOUND)
-        );
+        // r₁: ALL bits explicit — the recursion circuit's relaxed-canonicity
+        // decode (phase D) hands the fiber's 5 flattening bits back to the
+        // prover, so the sampler credit no longer discounts this site.
+        assert_eq!(R1_POW_BITS, bits_for(R1_ZERO_BOUND));
         assert_eq!(
             crate::lincheck::AG_LINCHECK_SKIP_POW_BITS + AG_SAMPLING_CREDIT_BITS,
             bits_for(base_deg)

--- a/crates/flock-core/src/zerocheck/ag_skip.rs
+++ b/crates/flock-core/src/zerocheck/ag_skip.rs
@@ -113,6 +113,7 @@ pub fn d_inv() -> F128 {
 // ---------------------------------------------------------------------------
 
 /// The round-1 wire message in canonical (`D⁻¹`-scaled) form, evaluator basis.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Round1Message {
     /// `P^{ab}` fresh coords (158): kernel fresh slot `s` ↦ evaluator product
     /// coord `64 + s`. (Garbage kernel slots 158/159 dropped.)
@@ -320,31 +321,111 @@ pub fn fold_and_first_round(
         .zip(eq_outer.par_iter())
         .enumerate()
         .map(|(outer, ((am, bm), &eo))| {
-            // One fused pass over the 64 pairs (reverse, for the γ²-Horner): fold
-            // the four rows at r₁, write them to a_mlv/b_mlv, AND accumulate the
-            // first message from those just-folded values — no read-back of the
-            // folded array (the two-pass version re-read 2 KB/block). γ² = x², so
-            // each Σ weight is a pure 2-bit shift: a *wide* Horner on a 256-bit
-            // accumulator (no per-step reduction — max degree 2·63+127 = 253 <
-            // 256), reduced once per block.
-            let base = outer * 128;
-            let mut s1 = F256Unreduced::ZERO;
-            let mut s_inf = F256Unreduced::ZERO;
-            for inner in (0..64).rev() {
-                let (i0, i1) = (2 * inner, 2 * inner + 1);
-                let a0 = byte_dot(a_packed, base + i0, &table);
-                let a1 = byte_dot(a_packed, base + i1, &table);
-                let b0 = byte_dot(b_packed, base + i0, &table);
-                let b1 = byte_dot(b_packed, base + i1, &table);
-                am[i0] = a0;
-                am[i1] = a1;
-                bm[i0] = b0;
-                bm[i1] = b1;
-                s1 = shl2_xor(s1, a1 * b1);
-                s_inf = shl2_xor(s_inf, (a0 + a1) * (b0 + b1));
-            }
+            let (s1, s_inf) = fold_block_at(a_packed, b_packed, outer * 128, &table, am, bm);
             let e = eo * d1_inv;
             (e * s1.reduce(), e * s_inf.reduce())
+        })
+        .reduce(|| (F128::ZERO, F128::ZERO), |(p, q), (r, s)| (p + r, q + s));
+    (a_mlv, b_mlv, g1, g_inf)
+}
+
+/// One outer block of the fused fold + first-round accumulation — one fused
+/// pass over the 64 pairs (reverse, for the γ²-Horner): fold the four rows
+/// at `r₁` via the byte-dot `table`, write them to `am`/`bm`, AND
+/// accumulate the first message from those just-folded values — no
+/// read-back of the folded array (the two-pass version re-read 2 KB/block).
+/// γ² = x², so each Σ weight is a pure 2-bit shift: a *wide* Horner on a
+/// 256-bit accumulator (no per-step reduction — max degree 2·63+127 = 253 <
+/// 256), reduced once per block by the caller. `msg_base` is the block's
+/// first 64-bit-message index in `a_src`/`b_src` — a cleansed single-block
+/// scratch buffer passes 0.
+#[inline]
+fn fold_block_at(
+    a_src: &[u8],
+    b_src: &[u8],
+    msg_base: usize,
+    table: &[[F128; 256]],
+    am: &mut [F128],
+    bm: &mut [F128],
+) -> (F256Unreduced, F256Unreduced) {
+    let mut s1 = F256Unreduced::ZERO;
+    let mut s_inf = F256Unreduced::ZERO;
+    for inner in (0..64).rev() {
+        let (i0, i1) = (2 * inner, 2 * inner + 1);
+        let a0 = byte_dot(a_src, msg_base + i0, table);
+        let a1 = byte_dot(a_src, msg_base + i1, table);
+        let b0 = byte_dot(b_src, msg_base + i0, table);
+        let b1 = byte_dot(b_src, msg_base + i1, table);
+        am[i0] = a0;
+        am[i1] = a1;
+        bm[i0] = b0;
+        bm[i1] = b1;
+        s1 = shl2_xor(s1, a1 * b1);
+        s_inf = shl2_xor(s_inf, (a0 + a1) * (b0 + b1));
+    }
+    (s1, s_inf)
+}
+
+/// [`fold_and_first_round`] under a witness run-list ([`BlockCoverage`] at
+/// the 8192-bit code-block grid, one entry per outer block): DEAD blocks
+/// write zero folds and contribute nothing (their honest bits are all
+/// zero), FULL blocks run the in-place fused pass, and PARTIAL blocks are
+/// cleansed into zeroed scratch first — no declared-dead bit is ever read,
+/// so `PooledDirty` witnesses are legal. Value-identical to the dense fold
+/// on an honestly zero-padded witness.
+pub fn fold_and_first_round_padded(
+    a_packed: &[u8],
+    b_packed: &[u8],
+    w: &[F128],
+    r_rest: &[F128],
+    coverage: &[super::BlockCoverage],
+) -> (Vec<F128>, Vec<F128>, F128, F128) {
+    use rayon::prelude::*;
+    assert_eq!(a_packed.len(), b_packed.len());
+    debug_assert_eq!(
+        &r_rest[1..N_INNER],
+        &friendly_challenges()[1..N_INNER],
+        "fold_and_first_round assumes γ-geometric friendly dims"
+    );
+    let n = a_packed.len() / 8;
+    let table = build_w_tables(w);
+    let eq_outer = super::univariate_skip::build_eq(&r_rest[N_INNER..]);
+    let n_outer = eq_outer.len();
+    assert_eq!(n, n_outer * 128, "each outer block is 128 (2^7) messages");
+    assert_eq!(coverage.len(), n_outer, "one coverage entry per outer block");
+    let mut d1 = F128::ONE;
+    for j in 1..N_INNER {
+        d1 *= F128::ONE + gamma_pow(1usize << j);
+    }
+    let d1_inv = d1.inv();
+
+    let mut a_mlv = crate::scratch::take_f128(n);
+    let mut b_mlv = crate::scratch::take_f128(n);
+    let (g1, g_inf) = a_mlv
+        .par_chunks_mut(128)
+        .zip(b_mlv.par_chunks_mut(128))
+        .zip(eq_outer.par_iter())
+        .enumerate()
+        .map(|(outer, ((am, bm), &eo))| match &coverage[outer] {
+            super::BlockCoverage::Dead => {
+                am.fill(F128::ZERO);
+                bm.fill(F128::ZERO);
+                (F128::ZERO, F128::ZERO)
+            }
+            super::BlockCoverage::Full => {
+                let (s1, s_inf) = fold_block_at(a_packed, b_packed, outer * 128, &table, am, bm);
+                let e = eo * d1_inv;
+                (e * s1.reduce(), e * s_inf.reduce())
+            }
+            super::BlockCoverage::Partial(ranges) => {
+                let mut a_buf = [0u8; 1024];
+                let mut b_buf = [0u8; 1024];
+                super::cleanse_block(a_packed, outer * 1024, ranges, &mut a_buf);
+                super::cleanse_block(b_packed, outer * 1024, ranges, &mut b_buf);
+                let (s1, s_inf) = fold_block_at(&a_buf, &b_buf, 0, &table, am, bm);
+                let e = eo * d1_inv;
+                (e * s1.reduce(), e * s_inf.reduce())
+            }
         })
         .reduce(|| (F128::ZERO, F128::ZERO), |(p, q), (r, s)| (p + r, q + s));
     (a_mlv, b_mlv, g1, g_inf)
@@ -1028,6 +1109,7 @@ pub fn prove<C: Challenger>(
         &r_outer,
         super::ZerocheckGrinding::disabled(),
         Vec::new(),
+        None,
         challenger,
     )
 }
@@ -1070,6 +1152,7 @@ pub fn prove_capture_s_hat_v_c<C: Challenger>(
         &r_outer,
         super::ZerocheckGrinding::disabled(),
         Vec::new(),
+        None,
         challenger,
     );
     (proof, claim, s_hat_v_c)
@@ -1094,6 +1177,7 @@ pub fn prove_capture_s_hat_v_c_with_grinding<C: Challenger>(
     b_packed: &[u8],
     c_packed: &[u8],
     m: usize,
+    padding: &super::PaddingSpec,
     grinding: super::ZerocheckGrinding,
     challenger: &mut C,
 ) -> (AgProof, AgClaim, Vec<F128>) {
@@ -1102,6 +1186,11 @@ pub fn prove_capture_s_hat_v_c_with_grinding<C: Challenger>(
     assert_eq!(a_packed.len(), expected);
     assert_eq!(b_packed.len(), expected);
     assert_eq!(c_packed.len(), expected);
+    // The run-list at the kernels' 8192-bit code-block grid — round 1 and
+    // the fold share it. Read-exact (Dead skipped, Partial cleansed), so
+    // the honest-zero witness-mode forcing this entry used to need is gone:
+    // declared-dead bits are never read, whatever they hold.
+    let coverage = padding.block_coverage(K_SKIP + N_INNER, 1usize << (m - K_SKIP - N_INNER));
 
     challenger.observe_label(b"flock-ag-skip-v1");
     let mut grinding_nonces = Vec::with_capacity(grinding_nonce_count(grinding, m));
@@ -1115,7 +1204,7 @@ pub fn prove_capture_s_hat_v_c_with_grinding<C: Challenger>(
     };
     let eq = crate::zerocheck::univariate_skip::build_eq(&r_outer);
 
-    let (msg, s_hat_v_c) = prove_round1_banks(a_packed, b_packed, c_packed, &eq);
+    let (msg, s_hat_v_c) = prove_round1_banks_padded(a_packed, b_packed, c_packed, &eq, &coverage);
     let (proof, claim) = prove_from_round1(
         a_packed,
         b_packed,
@@ -1123,6 +1212,7 @@ pub fn prove_capture_s_hat_v_c_with_grinding<C: Challenger>(
         &r_outer,
         grinding,
         grinding_nonces,
+        Some(&coverage),
         challenger,
     );
     (proof, claim, s_hat_v_c)
@@ -1138,21 +1228,99 @@ fn prove_round1_banks(
     c_packed: &[u8],
     eq: &[F128],
 ) -> (Round1Message, Vec<F128>) {
-    let (res_ab, bank0, bank1) = if ROUND1_UNFUSED.load(Ordering::Relaxed) {
+    let raw = if ROUND1_UNFUSED.load(Ordering::Relaxed) {
         crate::genus95_curve_code::round1::round1_slp_packed_banks(a_packed, b_packed, c_packed, eq)
     } else {
         crate::genus95_curve_code::round1::round1_slp_packed_banks_fused(
             a_packed, b_packed, c_packed, eq,
         )
     };
+    banks_to_message(raw)
+}
+
+/// [`prove_round1_banks`] under a witness run-list. The round-1 kernels are
+/// position-independent additive sums over 8192-bit blocks (one eq weight
+/// each), so the run-list needs NO kernel changes: maximal runs of FULL
+/// blocks go to the untouched kernel as (slice, eq-subrange) segments,
+/// PARTIAL blocks are cleansed into zeroed scratch and run as one-block
+/// segments, DEAD blocks are skipped, and the segment outputs sum. Reads no
+/// declared-dead bit (`PooledDirty`-legal); a fully-Full coverage is the
+/// one-segment identity call.
+#[cfg(target_arch = "aarch64")]
+fn prove_round1_banks_padded(
+    a_packed: &[u8],
+    b_packed: &[u8],
+    c_packed: &[u8],
+    eq: &[F128],
+    coverage: &[super::BlockCoverage],
+) -> (Round1Message, Vec<F128>) {
+    use super::BlockCoverage;
+    let kernel = if ROUND1_UNFUSED.load(Ordering::Relaxed) {
+        crate::genus95_curve_code::round1::round1_slp_packed_banks
+    } else {
+        crate::genus95_curve_code::round1::round1_slp_packed_banks_fused
+    };
+    let n = a_packed.len() / 1024;
+    assert_eq!(eq.len(), n, "one eq weight per block");
+    assert_eq!(coverage.len(), n, "one coverage entry per block");
+    let mut res_ab = [F128::ZERO; 160];
+    let mut bank0 = [F128::ZERO; 64];
+    let mut bank1 = [F128::ZERO; 64];
+    let mut acc = |seg: ([F128; 160], [F128; 64], [F128; 64])| {
+        for j in 0..160 {
+            res_ab[j] += seg.0[j];
+        }
+        for k in 0..64 {
+            bank0[k] += seg.1[k];
+            bank1[k] += seg.2[k];
+        }
+    };
+    let mut i = 0usize;
+    while i < n {
+        match &coverage[i] {
+            BlockCoverage::Dead => i += 1,
+            BlockCoverage::Full => {
+                let mut j = i + 1;
+                while j < n && coverage[j] == BlockCoverage::Full {
+                    j += 1;
+                }
+                acc(kernel(
+                    &a_packed[i * 1024..j * 1024],
+                    &b_packed[i * 1024..j * 1024],
+                    &c_packed[i * 1024..j * 1024],
+                    &eq[i..j],
+                ));
+                i = j;
+            }
+            BlockCoverage::Partial(ranges) => {
+                let mut a_buf = [0u8; 1024];
+                let mut b_buf = [0u8; 1024];
+                let mut c_buf = [0u8; 1024];
+                super::cleanse_block(a_packed, i * 1024, ranges, &mut a_buf);
+                super::cleanse_block(b_packed, i * 1024, ranges, &mut b_buf);
+                super::cleanse_block(c_packed, i * 1024, ranges, &mut c_buf);
+                acc(kernel(&a_buf, &b_buf, &c_buf, &eq[i..i + 1]));
+                i += 1;
+            }
+        }
+    }
+    banks_to_message((res_ab, bank0, bank1))
+}
+
+/// The shared banks → wire-message post-processing: `D⁻¹` scaling of the
+/// fresh coords and the recombined `w̄`, plus the canonical `s_hat_v_c`
+/// capture — `s_hat_v_c[skip + b·64] = bank_b[skip] / D₁`, with `γ⁻¹` for
+/// bank 1 (the kernel's odd-i bank carries an extra `γ` from friendly bit
+/// 0 = 1). `1/D₁ = (1+γ)·κ` since `D = (1+γ)·D₁` and `κ = D⁻¹ = d_inv()`.
+#[cfg(target_arch = "aarch64")]
+fn banks_to_message(
+    (res_ab, bank0, bank1): ([F128; 160], [F128; 64], [F128; 64]),
+) -> (Round1Message, Vec<F128>) {
     let di = d_inv();
     let msg = Round1Message {
         ab_fresh: (0..158).map(|s| di * res_ab[s]).collect(),
         c_msg: (0..64).map(|i| di * (bank0[i] + bank1[i])).collect(),
     };
-    // Canonical s_hat_v_c[skip + b·64] = bank_b[skip] / D₁, with γ⁻¹ for bank 1
-    // (the kernel's odd-i bank carries an extra γ from friendly bit 0 = 1).
-    // 1/D₁ = (1+γ)·κ since D = (1+γ)·D₁ and κ = D⁻¹ = d_inv().
     let inv_d1 = (F128::ONE + gamma_pow(1)) * di;
     let gamma_inv = gamma_pow(1).inv();
     let n_skip = 1usize << K_SKIP;
@@ -1175,6 +1343,7 @@ fn prove_from_round1<C: Challenger>(
     r_outer: &[F128],
     grinding: super::ZerocheckGrinding,
     mut grinding_nonces: Vec<u64>,
+    coverage: Option<&[super::BlockCoverage]>,
     challenger: &mut C,
 ) -> (AgProof, AgClaim) {
     challenger.observe_f128_slice(&msg.ab_fresh);
@@ -1191,8 +1360,12 @@ fn prove_from_round1<C: Challenger>(
     let mut r_rest = friendly_challenges().to_vec();
     r_rest.extend_from_slice(r_outer);
 
-    // Round 0: fused fold of a,b at r1 + the first (full-size) multilinear message.
-    let (a_mlv, b_mlv, g1_0, ginf_0) = fold_and_first_round(a_packed, b_packed, &w, &r_rest);
+    // Round 0: fused fold of a,b at r1 + the first (full-size) multilinear
+    // message — run-list-gated when the caller supplies a coverage map.
+    let (a_mlv, b_mlv, g1_0, ginf_0) = match coverage {
+        Some(cov) => fold_and_first_round_padded(a_packed, b_packed, &w, &r_rest, cov),
+        None => fold_and_first_round(a_packed, b_packed, &w, &r_rest),
+    };
     let (rounds, rhos, a_eval, b_eval) = match grinding.multilinear_round_bits() {
         Some(bits) => {
             let mut gch = RoundGrindProver {
@@ -2338,6 +2511,120 @@ mod tests {
         assert!(evaluation_point_from_nonce(&seed, n4, HashKind::Sha256).is_some());
     }
 
+    /// The run-list arms are value-identical to the dense kernels on an
+    /// honestly zero-padded witness AND read no declared-dead bit: proving
+    /// over a witness whose dead regions hold garbage (deliberately
+    /// inconsistent garbage — dead `c` bits set where `a·b` is zero) yields
+    /// byte-identical round-1 message, fold, `s_hat_v_c`, and full proof —
+    /// the exactness `PooledDirty` requires.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn padded_arms_match_dense_and_ignore_dirty_padding() {
+        use crate::challenger::FsChallenger;
+        use crate::zerocheck::{PaddingRun, PaddingSpec};
+        let m = 16usize;
+        let spec = PaddingSpec::from_runs(vec![
+            PaddingRun {
+                k_log: 13,
+                useful_bits_per_block: 1 << 13,
+                n_blocks: 2,
+            },
+            PaddingRun {
+                k_log: 13,
+                useful_bits_per_block: 3001,
+                n_blocks: 1,
+            },
+            PaddingRun {
+                k_log: 13,
+                useful_bits_per_block: 0,
+                n_blocks: 2,
+            },
+            PaddingRun {
+                k_log: 14,
+                useful_bits_per_block: 9000,
+                n_blocks: 1,
+            },
+        ]);
+        // LSB-first byte mask of the useful bits.
+        let mut mask = vec![0u8; (1usize << m) / 8];
+        for (s, e) in spec.useful_intervals() {
+            for i in s..e {
+                mask[i / 8] |= 1 << (i % 8);
+            }
+        }
+        let (a0, b0, c0) = random_witness(m, 91);
+        let honest = |v: &[u8]| -> Vec<u8> { v.iter().zip(&mask).map(|(x, k)| x & k).collect() };
+        let dirty = |v: &[u8], g: u8| -> Vec<u8> {
+            v.iter()
+                .zip(&mask)
+                .map(|(x, k)| (x & k) | (g & !k))
+                .collect()
+        };
+        let (ah, bh, ch) = (honest(&a0), honest(&b0), honest(&c0));
+        let (ad, bd, cd) = (dirty(&a0, 0xA5), dirty(&b0, 0x5A), dirty(&c0, 0xFF));
+
+        // Kernel level, round 1: dense-honest vs padded-dirty.
+        let cov = spec.block_coverage(K_SKIP + N_INNER, 1usize << (m - K_SKIP - N_INNER));
+        let mut rng = Sha256Rng::new([7u8; 32]);
+        let r_outer: Vec<F128> = (0..m - K_SKIP - N_INNER)
+            .map(|_| F128::new(rng.next_u64(), rng.next_u64()))
+            .collect();
+        let eq = crate::zerocheck::univariate_skip::build_eq(&r_outer);
+        let dense = prove_round1_banks(&ah, &bh, &ch, &eq);
+        let padded = prove_round1_banks_padded(&ad, &bd, &cd, &eq, &cov);
+        assert_eq!(dense.0, padded.0, "round-1 message");
+        assert_eq!(dense.1, padded.1, "s_hat_v_c capture");
+
+        // Kernel level, the fold + first message, at a decoded point.
+        let seed = [3u8; 32];
+        let pt = (0..u32::MAX)
+            .find_map(|n| {
+                crate::genus95_curve_code::evaluation_point_from_nonce(
+                    &seed,
+                    n,
+                    crate::hash::HashKind::Sha256,
+                )
+            })
+            .expect("a decodable nonce exists");
+        let w: Vec<F128> = base_evaluation_functional(&pt)
+            .expect("functional at a sampled point")
+            .iter()
+            .copied()
+            .collect();
+        let mut r_rest = friendly_challenges().to_vec();
+        r_rest.extend_from_slice(&r_outer);
+        let (af, bf, g1, gi) = fold_and_first_round(&ah, &bh, &w, &r_rest);
+        let (afp, bfp, g1p, gip) = fold_and_first_round_padded(&ad, &bd, &w, &r_rest, &cov);
+        assert_eq!((g1, gi), (g1p, gip), "first multilinear message");
+        assert_eq!(af, afp, "folded a");
+        assert_eq!(bf, bfp, "folded b");
+
+        // End to end under the strict schedule: the padded-dirty proof is
+        // byte-identical to the dense-honest one, and to the padded-honest
+        // one, and verifies.
+        let g = crate::zerocheck::ZerocheckGrinding::per_challenge_128();
+        let mk = || FsChallenger::new(b"flock-ag-padded-test");
+        let (p0, cl0, sv0) = prove_capture_s_hat_v_c_with_grinding(
+            &ah,
+            &bh,
+            &ch,
+            m,
+            &PaddingSpec::dense(m),
+            g,
+            &mut mk(),
+        );
+        let (p1, cl1, sv1) =
+            prove_capture_s_hat_v_c_with_grinding(&ad, &bd, &cd, m, &spec, g, &mut mk());
+        assert_eq!(p0, p1, "proof bytes");
+        assert_eq!(cl0, cl1, "claims");
+        assert_eq!(sv0, sv1, "s_hat_v_c");
+        let (p2, _, sv2) =
+            prove_capture_s_hat_v_c_with_grinding(&ah, &bh, &ch, m, &spec, g, &mut mk());
+        assert_eq!(p0, p2, "padded-honest proof bytes");
+        assert_eq!(sv0, sv2, "padded-honest s_hat_v_c");
+        verify_with_grinding(m, &p1, g, &mut mk()).expect("the padded-dirty proof verifies");
+    }
+
     /// Full grinding roundtrip on the fused transcript + fused-nonce tamper
     /// rejection: any change to `r1_nonce` must reject (bad PoW, bad point,
     /// or — if both criteria fluke — a different r₁ failing the c-eval bind).
@@ -2349,7 +2636,15 @@ mod tests {
         let (a, b, c) = random_witness(m, 77);
         let g = crate::zerocheck::ZerocheckGrinding::per_challenge_128();
         let mk = || FsChallenger::new(b"flock-ag-grind-test");
-        let (proof, claim, _) = prove_capture_s_hat_v_c_with_grinding(&a, &b, &c, m, g, &mut mk());
+        let (proof, claim, _) = prove_capture_s_hat_v_c_with_grinding(
+            &a,
+            &b,
+            &c,
+            m,
+            &crate::zerocheck::PaddingSpec::dense(m),
+            g,
+            &mut mk(),
+        );
         let vclaim =
             verify_with_grinding(m, &proof, g, &mut mk()).expect("honest fused proof verifies");
         assert_eq!(vclaim, claim);

--- a/crates/flock-core/src/zerocheck/ag_skip.rs
+++ b/crates/flock-core/src/zerocheck/ag_skip.rs
@@ -17,8 +17,9 @@
 //!     cryptographic primitive enters the soundness argument.
 
 use super::multilinear::{
-    fold_and_compute_round_pair_into, fold_in_place_pair, fold1_lookahead_into,
-    fold2_lookahead_into, lookahead_msg_first, lookahead_msg_second, round_pair_naive,
+    LiveLayout, expand_to_dense, fold_and_compute_round_pair_into, fold_and_round_pair_sparse_into,
+    fold_in_place_pair, fold1_lookahead_into, fold2_lookahead_into, lookahead_msg_first,
+    lookahead_msg_second, round_pair_naive,
 };
 use crate::challenger::Challenger;
 use crate::field::{F128, F256Unreduced, mul_by_x};
@@ -429,6 +430,83 @@ pub fn fold_and_first_round_padded(
         })
         .reduce(|| (F128::ZERO, F128::ZERO), |(p, q), (r, s)| (p + r, q + s));
     (a_mlv, b_mlv, g1, g_inf)
+}
+
+/// [`fold_and_first_round_padded`] with LIVE-SPAN output — the AG analog of
+/// RS's `uni_skip_fold_and_round_pair_runs_sparse`: dead blocks get no
+/// storage at all, so the fold's cost AND footprint are count-derived. The
+/// returned [`LiveLayout`] maps the compacted buffers back to the padded
+/// `2^(m−6)` domain: the k-th live block's 128 slots sit at offset `128·k`.
+/// Intervals are 128-aligned by construction — pair-aligned for every tail
+/// round. Message and live values are byte-identical to the dense fold on
+/// an honestly zero-padded witness; a Partial block stores its full 128
+/// slots (the cleansed fold writes honest zeros past its ranges).
+pub fn fold_and_first_round_sparse(
+    a_packed: &[u8],
+    b_packed: &[u8],
+    w: &[F128],
+    r_rest: &[F128],
+    coverage: &[super::BlockCoverage],
+) -> (Vec<F128>, Vec<F128>, F128, F128, LiveLayout) {
+    use rayon::prelude::*;
+    assert_eq!(a_packed.len(), b_packed.len());
+    debug_assert_eq!(
+        &r_rest[1..N_INNER],
+        &friendly_challenges()[1..N_INNER],
+        "fold_and_first_round assumes γ-geometric friendly dims"
+    );
+    let table = build_w_tables(w);
+    let eq_outer = super::univariate_skip::build_eq(&r_rest[N_INNER..]);
+    let n_outer = eq_outer.len();
+    assert_eq!(a_packed.len() / 8, n_outer * 128, "128 messages per block");
+    assert_eq!(coverage.len(), n_outer, "one coverage entry per outer block");
+    let mut d1 = F128::ONE;
+    for j in 1..N_INNER {
+        d1 *= F128::ONE + gamma_pow(1usize << j);
+    }
+    let d1_inv = d1.inv();
+
+    // The live block list + its 128-aligned mlv-slot intervals.
+    let live: Vec<usize> = (0..n_outer)
+        .filter(|&o| !matches!(coverage[o], super::BlockCoverage::Dead))
+        .collect();
+    debug_assert!(!live.is_empty(), "a witness with no live block");
+    let mut intervals: Vec<(usize, usize)> = Vec::new();
+    for &o in &live {
+        match intervals.last_mut() {
+            Some((_, e)) if *e == 128 * o => *e = 128 * (o + 1),
+            _ => intervals.push((128 * o, 128 * (o + 1))),
+        }
+    }
+    let store = LiveLayout::new(intervals);
+    let n_live = 128 * live.len();
+    let mut a_mlv = crate::scratch::take_f128(n_live);
+    let mut b_mlv = crate::scratch::take_f128(n_live);
+    let (g1, g_inf) = a_mlv
+        .par_chunks_mut(128)
+        .zip(b_mlv.par_chunks_mut(128))
+        .zip(live.par_iter())
+        .map(|((am, bm), &outer)| {
+            let (s1, s_inf) = match &coverage[outer] {
+                super::BlockCoverage::Dead => unreachable!("the live list has no dead entry"),
+                super::BlockCoverage::Full => {
+                    fold_block_at(a_packed, b_packed, outer * 128, &table, am, bm)
+                }
+                super::BlockCoverage::Partial(ranges) => {
+                    let mut a_buf = [0u8; 1024];
+                    let mut b_buf = [0u8; 1024];
+                    super::cleanse_block(a_packed, outer * 1024, ranges, &mut a_buf);
+                    super::cleanse_block(b_packed, outer * 1024, ranges, &mut b_buf);
+                    fold_block_at(&a_buf, &b_buf, 0, &table, am, bm)
+                }
+            };
+            let e = eq_outer[outer] * d1_inv;
+            (e * s1.reduce(), e * s_inf.reduce())
+        })
+        .reduce(|| (F128::ZERO, F128::ZERO), |(p, q), (r, s)| (p + r, q + s));
+    a_mlv.truncate(n_live);
+    b_mlv.truncate(n_live);
+    (a_mlv, b_mlv, g1, g_inf, store)
 }
 
 /// One wide-Horner step with a compile-time shift `S` (the friendly base
@@ -1360,11 +1438,32 @@ fn prove_from_round1<C: Challenger>(
     let mut r_rest = friendly_challenges().to_vec();
     r_rest.extend_from_slice(r_outer);
 
-    // Round 0: fused fold of a,b at r1 + the first (full-size) multilinear
-    // message — run-list-gated when the caller supplies a coverage map.
-    let (a_mlv, b_mlv, g1_0, ginf_0) = match coverage {
-        Some(cov) => fold_and_first_round_padded(a_packed, b_packed, &w, &r_rest, cov),
-        None => fold_and_first_round(a_packed, b_packed, &w, &r_rest),
+    // Round 0 + the tail. The sparse-support decision mirrors the RS
+    // zerocheck's `sparse_from_round2`: when the run-list has dead blocks
+    // and the live fraction clears the gate, the fold emits LIVE-SPAN
+    // buffers and the tail runs support-proportional rounds; otherwise the
+    // padded (or dense) fold feeds the lookahead tail. Byte-identical wire
+    // output on every path.
+    let sparse = coverage.is_some_and(|cov| {
+        let live_blocks = cov
+            .iter()
+            .filter(|c| !matches!(c, super::BlockCoverage::Dead))
+            .count();
+        let n_out = cov.len() * 128;
+        live_blocks < cov.len()
+            && n_out >= 8
+            && live_blocks * 128 * super::sparse_tail_gate() <= n_out
+    });
+    let (a_mlv, b_mlv, g1_0, ginf_0, store) = if sparse {
+        let cov = coverage.expect("sparse implies coverage");
+        let (a, b, g1, gi, st) = fold_and_first_round_sparse(a_packed, b_packed, &w, &r_rest, cov);
+        (a, b, g1, gi, Some(st))
+    } else {
+        let (a, b, g1, gi) = match coverage {
+            Some(cov) => fold_and_first_round_padded(a_packed, b_packed, &w, &r_rest, cov),
+            None => fold_and_first_round(a_packed, b_packed, &w, &r_rest),
+        };
+        (a, b, g1, gi, None)
     };
     let (rounds, rhos, a_eval, b_eval) = match grinding.multilinear_round_bits() {
         Some(bits) => {
@@ -1373,9 +1472,9 @@ fn prove_from_round1<C: Challenger>(
                 bits,
                 nonces: &mut grinding_nonces,
             };
-            mlv_tail_fs(a_mlv, b_mlv, g1_0, ginf_0, &r_rest, &mut gch)
+            mlv_tail_dispatch(a_mlv, b_mlv, g1_0, ginf_0, store, &r_rest, &mut gch)
         }
-        None => mlv_tail_fs(a_mlv, b_mlv, g1_0, ginf_0, &r_rest, challenger),
+        None => mlv_tail_dispatch(a_mlv, b_mlv, g1_0, ginf_0, store, &r_rest, challenger),
     };
 
     let proof = AgProof {
@@ -1421,6 +1520,109 @@ pub(super) fn mlv_tail_fs<C: Challenger>(
     rhos.push(rho0);
     let (tail_rounds, tail_rhos, a_eval, b_eval) =
         mlv_tail_fs_resume(a_mlv, b_mlv, 1, rho0, None, r_rest, challenger);
+    rounds.extend(tail_rounds);
+    rhos.extend(tail_rhos);
+    (rounds, rhos, a_eval, b_eval)
+}
+
+/// One tail, two storages: dispatch on whether the fold handed over
+/// live-span buffers (+ their [`LiveLayout`]) or a full dense pair.
+fn mlv_tail_dispatch<C: Challenger>(
+    a_mlv: Vec<F128>,
+    b_mlv: Vec<F128>,
+    g1_0: F128,
+    ginf_0: F128,
+    store: Option<LiveLayout>,
+    r_rest: &[F128],
+    challenger: &mut C,
+) -> (Vec<(F128, F128)>, Vec<F128>, F128, F128) {
+    match store {
+        Some(st) => mlv_tail_fs_sparse(a_mlv, b_mlv, g1_0, ginf_0, st, r_rest, challenger),
+        None => mlv_tail_fs(a_mlv, b_mlv, g1_0, ginf_0, r_rest, challenger),
+    }
+}
+
+/// [`mlv_tail_fs`] over LIVE-SPAN buffers (the sparse fold's output): the
+/// tail runs the support-proportional rounds — RS's
+/// [`fold_and_round_pair_sparse_into`], with the friendly constants riding
+/// as ordinary `r_next` weights — while the live set clears the gate and
+/// the domain keeps the fused threshold, then expands to dense ONCE and
+/// resumes the lookahead tail mid-stream. Wire output is bit-identical to
+/// the dense tail: every skipped term carries an `a·b` factor of zero.
+pub(super) fn mlv_tail_fs_sparse<C: Challenger>(
+    mut a_mlv: Vec<F128>,
+    mut b_mlv: Vec<F128>,
+    g1_0: F128,
+    ginf_0: F128,
+    mut store: LiveLayout,
+    r_rest: &[F128],
+    challenger: &mut C,
+) -> (Vec<(F128, F128)>, Vec<F128>, F128, F128) {
+    let n_mlv = r_rest.len();
+    let mut rounds = Vec::with_capacity(n_mlv);
+    let mut rhos = Vec::with_capacity(n_mlv);
+    rounds.push((g1_0, ginf_0));
+    challenger.observe_f128(g1_0);
+    challenger.observe_f128(ginf_0);
+    let mut rho_prev = challenger.sample_f128();
+    rhos.push(rho_prev);
+
+    // The sparse rounds — the RS tail's loop shape: the logical `domain`
+    // halves every round regardless of the compacted buffer length, and
+    // the gate re-checks per round (interval ends round outward, so the
+    // live fraction can cross it mid-tail).
+    let mut domain = 1usize << n_mlv;
+    let (mut a_nxt, mut b_nxt) = (Vec::new(), Vec::new());
+    let mut i = 1usize;
+    while i < n_mlv && domain >= 1024 && store.len() * super::sparse_tail_gate() <= domain {
+        let log_before = domain.trailing_zeros() as usize;
+        let mut r_next = vec![F128::ONE; log_before - 1];
+        r_next[1..].copy_from_slice(&r_rest[i + 1..]);
+        // Output storage is bounded by the input's: shrinking pairs can
+        // only round outward by one slot per interval end.
+        let cap = store.len() + 2 * store.intervals().len() + 2;
+        if a_nxt.len() < cap {
+            crate::scratch::give_f128(a_nxt);
+            crate::scratch::give_f128(b_nxt);
+            a_nxt = crate::scratch::take_f128(cap);
+            b_nxt = crate::scratch::take_f128(cap);
+        }
+        let (m1, mi, store_out) = fold_and_round_pair_sparse_into(
+            &a_mlv,
+            &b_mlv,
+            &mut a_nxt[..cap],
+            &mut b_nxt[..cap],
+            rho_prev,
+            &r_next,
+            &store,
+            domain,
+        );
+        std::mem::swap(&mut a_mlv, &mut a_nxt);
+        std::mem::swap(&mut b_mlv, &mut b_nxt);
+        a_mlv.truncate(store_out.len());
+        b_mlv.truncate(store_out.len());
+        store = store_out;
+        domain /= 2;
+        rounds.push((m1, mi));
+        challenger.observe_f128(m1);
+        challenger.observe_f128(mi);
+        rho_prev = challenger.sample_f128();
+        rhos.push(rho_prev);
+        i += 1;
+    }
+
+    // Back to global indexing: scatter the live span into a full padded
+    // buffer once and resume the lookahead tail mid-stream (the arrays are
+    // folded through every sampled challenge except `rho_prev` — resume's
+    // own invariant).
+    let a_full = expand_to_dense(&a_mlv, &store, domain);
+    let b_full = expand_to_dense(&b_mlv, &store, domain);
+    crate::scratch::give_f128(a_mlv);
+    crate::scratch::give_f128(b_mlv);
+    crate::scratch::give_f128(a_nxt);
+    crate::scratch::give_f128(b_nxt);
+    let (tail_rounds, tail_rhos, a_eval, b_eval) =
+        mlv_tail_fs_resume(a_full, b_full, i, rho_prev, None, r_rest, challenger);
     rounds.extend(tail_rounds);
     rhos.extend(tail_rhos);
     (rounds, rhos, a_eval, b_eval)
@@ -2623,6 +2825,73 @@ mod tests {
         assert_eq!(p0, p2, "padded-honest proof bytes");
         assert_eq!(sv0, sv2, "padded-honest s_hat_v_c");
         verify_with_grinding(m, &p1, g, &mut mk()).expect("the padded-dirty proof verifies");
+    }
+
+    /// The SPARSE tail at deep low utilization (3 of 64 code blocks live):
+    /// the live-span fold + four support-proportional rounds + the
+    /// expand-and-resume handoff produce a proof byte-identical to the
+    /// dense-honest one, under both grinding schedules, over a witness
+    /// whose dead regions hold garbage.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn sparse_tail_matches_dense_at_low_utilization() {
+        use crate::challenger::FsChallenger;
+        use crate::zerocheck::{PaddingRun, PaddingSpec};
+        let m = 19usize; // 64 blocks; n_mlv = 13, so the gate holds 4 rounds
+        let spec = PaddingSpec::from_runs(vec![
+            PaddingRun {
+                k_log: 13,
+                useful_bits_per_block: 1 << 13,
+                n_blocks: 2,
+            },
+            PaddingRun {
+                k_log: 13,
+                useful_bits_per_block: 0,
+                n_blocks: 30,
+            },
+            PaddingRun {
+                k_log: 13,
+                useful_bits_per_block: 5000,
+                n_blocks: 1,
+            },
+        ]); // + an implicit 31-block trailing gap
+        let mut mask = vec![0u8; (1usize << m) / 8];
+        for (s, e) in spec.useful_intervals() {
+            for i in s..e {
+                mask[i / 8] |= 1 << (i % 8);
+            }
+        }
+        let (a0, b0, c0) = random_witness(m, 55);
+        let honest = |v: &[u8]| -> Vec<u8> { v.iter().zip(&mask).map(|(x, k)| x & k).collect() };
+        let dirty = |v: &[u8], g: u8| -> Vec<u8> {
+            v.iter()
+                .zip(&mask)
+                .map(|(x, k)| (x & k) | (g & !k))
+                .collect()
+        };
+        let (ah, bh, ch) = (honest(&a0), honest(&b0), honest(&c0));
+        let (ad, bd, cd) = (dirty(&a0, 0xC3), dirty(&b0, 0x3C), dirty(&c0, 0xFF));
+        for g in [
+            crate::zerocheck::ZerocheckGrinding::disabled(),
+            crate::zerocheck::ZerocheckGrinding::per_challenge_128(),
+        ] {
+            let mk = || FsChallenger::new(b"flock-ag-sparse-test");
+            let (p0, cl0, sv0) = prove_capture_s_hat_v_c_with_grinding(
+                &ah,
+                &bh,
+                &ch,
+                m,
+                &PaddingSpec::dense(m),
+                g,
+                &mut mk(),
+            );
+            let (p1, cl1, sv1) =
+                prove_capture_s_hat_v_c_with_grinding(&ad, &bd, &cd, m, &spec, g, &mut mk());
+            assert_eq!(p0, p1, "proof bytes (grinding: {})", g.enabled);
+            assert_eq!(cl0, cl1, "claims");
+            assert_eq!(sv0, sv1, "s_hat_v_c");
+            verify_with_grinding(m, &p1, g, &mut mk()).expect("the sparse-path proof verifies");
+        }
     }
 
     /// Full grinding roundtrip on the fused transcript + fused-nonce tamper

--- a/crates/flock-core/src/zerocheck/ag_skip.rs
+++ b/crates/flock-core/src/zerocheck/ag_skip.rs
@@ -692,6 +692,33 @@ pub fn verify_multilinear(
 // ---------------------------------------------------------------------------
 
 /// A fixed, valid point of `Y`, the fallback for the (≈`2^-289`) chance that
+/// Zero-count bound behind the r₁ grinding budget: a false round-1 message
+/// pair survives at r₁ only if a nonzero PRODUCT-code word (a function in
+/// `L(2D)`, at most `deg 2D = 316` zeros — the ab check) or a nonzero
+/// BASE-code word (`L(D)`, at most `deg D = 158` zeros — the c check)
+/// vanishes there. `316 + 158 = 474` bad points over the ~`2^128` valid
+/// cover points; `bits_for(474) = 9` total bits required.
+pub const R1_ZERO_BOUND: usize = 474;
+
+/// Provable grinding contribution of the rejection sampler itself:
+/// `log2(BASE_Y_DEGREE · 2^3) = log2(32) = 5` bits. The sampler weights
+/// every reachable cover point at exactly `1/(2^128 · 32)` (slot flattening
+/// over the degree-4 base fiber, three all-or-nothing Artin–Schreier levels
+/// with uniform choice bits), and Hasse–Weil pins the genus-95 cover's point
+/// count to `2^128 · (1 ± 2^-56)` — so each valid draw provably costs
+/// ≥ ~32 attempts. A protocol constant (the sampler's shape), NOT an
+/// empirical acceptance estimate; guarded by `credit_constants_are_pinned`.
+pub const AG_SAMPLING_CREDIT_BITS: u32 = 5;
+
+/// Explicit PoW bits on the FUSED r₁ nonce under a strict grinding schedule:
+/// `bits_for(R1_ZERO_BOUND) − AG_SAMPLING_CREDIT_BITS = 9 − 5 = 4`.
+pub const R1_POW_BITS: u32 = 4;
+
+/// Prover-side scan budget for the fused r₁ nonce: success per nonce is
+/// `2^-R1_POW_BITS / 32 = 2^-9`, so exhausting `2^20` nonces has probability
+/// `(1 − 2^-9)^(2^20) ≈ 2^-2954` — a completeness error we accept (panic).
+pub const R1_FUSED_ATTEMPT_BUDGET: u32 = 1 << 20;
+
 /// rejection sampling exhausts its attempt budget. Baked from one offline sample.
 ///
 /// No longer used by the AG-skip `r₁` derivation (the nonce-grind path panics
@@ -699,8 +726,9 @@ pub fn verify_multilinear(
 /// prover pin `r₁` to this public constant). Still backs
 /// [`crate::lincheck::SkipPoint::sample_fresh`], where BOTH sides replay the
 /// same deterministic loop, so a prover cannot claim failure unilaterally:
-/// forcing it costs `~1/P_fail ≈ 2^289`, far above the `2^128` target. (Keep
-/// linked to the sampler's attempt cap; lowering the cap raises `P_fail`.)
+/// forcing it costs `~1/P_fail ≈ 2^916` (acceptance is 1/32 per attempt, so
+/// `P_fail = (1 − 1/32)^20000`), far above the `2^128` target. (Keep linked
+/// to the sampler's attempt cap; lowering the cap raises `P_fail`.)
 pub(crate) fn fallback_point() -> EvaluationPoint {
     EvaluationPoint {
         x: F128 {
@@ -753,13 +781,19 @@ fn observe_r1_nonce<C: Challenger>(challenger: &mut C, nonce: u32) {
 /// ([`crate::genus95_curve_code::evaluation_point_from_nonce`]); the first
 /// nonce whose attempt lands a valid point is observed into the transcript and
 /// shipped in the proof, so the verifier re-derives `r₁` with a SINGLE attempt
-/// rather than the expected ~100 (worst-case 20 000) replayed ones.
+/// rather than the expected ~32 (worst-case 20 000) replayed ones.
 ///
-/// Per-attempt acceptance is ~1%, so exhausting all
+/// Per-attempt acceptance is 1/32 (measured 3.141% over 10⁶ attempts;
+/// structurally `1/(BASE_Y_DEGREE · 2^3)`), so exhausting all
 /// [`SAMPLE_ATTEMPT_BUDGET`](crate::genus95_curve_code::SAMPLE_ATTEMPT_BUDGET)
-/// nonces has probability ~2⁻²⁸⁹ — a completeness error we accept (panic)
+/// nonces has probability ~2⁻⁹²¹ — a completeness error we accept (panic)
 /// instead of a verifier-side fallback point: an unconditionally accepted
 /// fallback claim would let a cheating prover fix `r₁` to a public constant.
+///
+/// UNGRINDED path only (the direct route / disabled schedules, which make no
+/// 128-bit claim): the verifier's single attempt lets a cheating prover pick
+/// among the ~630 expected valid nonces in the budget — ≤ log₂(20 000) ≈ 14.3
+/// bits of freedom. Strict schedules use [`sample_r1_prover_pow`] instead.
 pub(super) fn sample_r1_prover<C: Challenger>(challenger: &mut C) -> (EvaluationPoint, u32) {
     let seed = r1_seed(challenger);
     let kind = challenger.hash_kind();
@@ -771,15 +805,42 @@ pub(super) fn sample_r1_prover<C: Challenger>(challenger: &mut C) -> (Evaluation
             return (point, nonce);
         }
     }
-    unreachable!("r1 nonce grind exhausted its budget (probability ~2^-289)")
+    unreachable!("r1 nonce grind exhausted its budget (probability ~2^-921)")
+}
+
+/// [`sample_r1_prover`] under a strict grinding schedule: the FUSED nonce —
+/// `H(seed ‖ nonce)` must clear `pow_bits` of PoW AND decode to a valid
+/// cover point, both criteria on the same hash. Every candidate the prover
+/// (or an attacker) evaluates re-enters the PoW, so there is no free choice
+/// among valid nonces; with the sampler's provable
+/// [`AG_SAMPLING_CREDIT_BITS`] = 5 bits on top, `r₁` carries
+/// `pow_bits + 5` grinding bits total. Expected prover cost is
+/// `2^pow_bits · 32` hash calls plus `2^pow_bits` point attempts (~50 µs at
+/// the strict [`R1_POW_BITS`] = 4); the verifier stays ONE-SHOT.
+pub(super) fn sample_r1_prover_pow<C: Challenger>(
+    challenger: &mut C,
+    pow_bits: u32,
+) -> (EvaluationPoint, u32) {
+    let seed = r1_seed(challenger);
+    let kind = challenger.hash_kind();
+    for nonce in 0..R1_FUSED_ATTEMPT_BUDGET {
+        if let Some(point) =
+            crate::genus95_curve_code::evaluation_point_from_nonce_pow(&seed, nonce, kind, pow_bits)
+        {
+            observe_r1_nonce(challenger, nonce);
+            return (point, nonce);
+        }
+    }
+    unreachable!("fused r1 nonce grind exhausted its budget (probability ~2^-2954)")
 }
 
 /// Verifier: re-derive `r₁` from the proof's nonce — range-check it, run the
 /// single attempt, and reject unless it lands a valid point. The verifier does
 /// NOT check the nonce is the prover's minimal one, so a cheating prover may
-/// pick any of the ~200 expected valid nonces in the budget: ≤ log₂(20 000) ≈
-/// 14.3 bits of grinding over `r₁`, charged to the soundness budget exactly
-/// like a PoW grind.
+/// pick any of the ~630 expected valid nonces in the budget: ≤ log₂(20 000) ≈
+/// 14.3 bits of freedom over `r₁`. UNGRINDED path only — strict schedules
+/// verify the fused nonce via [`replay_r1_verifier_pow`], which has no such
+/// freedom (every candidate carries its own PoW).
 pub(super) fn replay_r1_verifier<C: Challenger>(
     challenger: &mut C,
     nonce: u32,
@@ -791,6 +852,28 @@ pub(super) fn replay_r1_verifier<C: Challenger>(
     observe_r1_nonce(challenger, nonce);
     crate::genus95_curve_code::evaluation_point_from_nonce(&seed, nonce, challenger.hash_kind())
         .ok_or(AgVerifyError::BadR1Nonce { nonce })
+}
+
+/// Verifier mirror of [`sample_r1_prover_pow`]: ONE hash + ONE point attempt,
+/// rejecting unless the fused nonce clears the PoW target AND lands a valid
+/// point. Constant-shape — no rejection replay, no data-dependent loop.
+pub(super) fn replay_r1_verifier_pow<C: Challenger>(
+    challenger: &mut C,
+    nonce: u32,
+    pow_bits: u32,
+) -> Result<EvaluationPoint, AgVerifyError> {
+    let seed = r1_seed(challenger);
+    if nonce >= R1_FUSED_ATTEMPT_BUDGET {
+        return Err(AgVerifyError::BadR1Nonce { nonce });
+    }
+    observe_r1_nonce(challenger, nonce);
+    crate::genus95_curve_code::evaluation_point_from_nonce_pow(
+        &seed,
+        nonce,
+        challenger.hash_kind(),
+        pow_bits,
+    )
+    .ok_or(AgVerifyError::BadR1Nonce { nonce })
 }
 
 /// All round messages the AG-skip prover sends, in order.
@@ -910,7 +993,8 @@ impl<C: Challenger> Challenger for RoundGrindProver<'_, C> {
 
 /// Nonce count [`AgProof::grinding_nonces`] must carry for `m` under a
 /// schedule: the initial outer-eq point + one per multilinear round. (`r₁`'s
-/// rejection nonce is a separate proof field.)
+/// nonce — fused PoW+sampling under a strict schedule, plain sampling
+/// otherwise — is the separate [`AgProof::r1_nonce`] field.)
 pub fn grinding_nonce_count(grinding: super::ZerocheckGrinding, m: usize) -> usize {
     usize::from(grinding.initial_bits(m).is_some())
         + usize::from(grinding.multilinear_round_bits().is_some()) * (m - K_SKIP)
@@ -995,8 +1079,10 @@ pub fn prove_capture_s_hat_v_c<C: Challenger>(
 /// UNION route's strict-profile entry. Grinds the initial outer-eq point
 /// (`initial_bits(m)`) and every multilinear round
 /// (`multilinear_round_bits`), mirroring the RS zerocheck's schedule; `r₁`
-/// keeps its inherent rejection-sampling nonce (the AG challenge family's
-/// strict-bits accounting is an audit TODO — this variant is opt-in).
+/// switches to the FUSED nonce ([`sample_r1_prover_pow`]):
+/// [`R1_POW_BITS`] = 4 explicit PoW bits + the sampler's
+/// [`AG_SAMPLING_CREDIT_BITS`] = 5 provable bits = `bits_for(474)` for the
+/// product+base code bad set ([`R1_ZERO_BOUND`]), with a ONE-SHOT verifier.
 ///
 /// PADDING CONTRACT: round 1 sums the FULL `2^m` region — every padding
 /// word of `a`/`b`/`c` must be an HONEST ZERO (the union's fresh-zeroed
@@ -1094,7 +1180,10 @@ fn prove_from_round1<C: Challenger>(
     challenger.observe_f128_slice(&msg.ab_fresh);
     challenger.observe_f128_slice(&msg.c_msg);
 
-    let (r1, r1_nonce) = sample_r1_prover(challenger);
+    let (r1, r1_nonce) = match grinding.ag_r1_bits() {
+        Some(bits) => sample_r1_prover_pow(challenger, bits),
+        None => sample_r1_prover(challenger),
+    };
     let c_eval = eval_c_at(&msg, &r1);
 
     let bf = base_evaluation_functional(&r1).expect("denominator nonzero at r1");
@@ -1460,7 +1549,10 @@ pub fn verify_with_grinding<C: Challenger>(
     challenger.observe_f128_slice(&proof.round1_ab);
     challenger.observe_f128_slice(&proof.round1_c);
 
-    let r1 = replay_r1_verifier(challenger, proof.r1_nonce)?;
+    let r1 = match grinding.ag_r1_bits() {
+        Some(bits) => replay_r1_verifier_pow(challenger, proof.r1_nonce, bits)?,
+        None => replay_r1_verifier(challenger, proof.r1_nonce)?,
+    };
     let msg = Round1Message {
         ab_fresh: proof.round1_ab.clone(),
         c_msg: proof.round1_c.clone(),
@@ -2174,5 +2266,108 @@ mod tests {
             verify(m, &proof, &mut FsChallenger::new(b"flock-ag-skip-test")).is_err(),
             "must reject a witness violating a*b=c"
         );
+    }
+
+    /// The fused-nonce grinding credit rests on pinned protocol constants —
+    /// this test ties every number in the derivation together so a change to
+    /// the sampler's shape or the code parameters cannot silently invalidate
+    /// the 5-bit credit or the explicit-bit splits.
+    #[test]
+    fn credit_constants_are_pinned() {
+        const GENUS: usize = 95;
+        let bits_for = |n: usize| usize::BITS - n.leading_zeros();
+        // Code degrees from the Riemann–Roch dimensions: deg = dim + g − 1.
+        let base_deg = crate::genus95_curve_code::BASE_MESSAGE_BITS + GENUS - 1;
+        let product_deg = crate::genus95_curve_code::PRODUCT_MESSAGE_BITS + GENUS - 1;
+        assert_eq!(base_deg, 158);
+        assert_eq!(product_deg, 316);
+        assert_eq!(R1_ZERO_BOUND, product_deg + base_deg);
+        // The sampler's per-point weight is 1/(2^128 · BASE_Y_DEGREE · 2^3):
+        // the slot flattening over the base fiber and the three
+        // Artin–Schreier choice bits. log2 of that constant is the credit.
+        let sampler_denom = crate::genus95_curve_code::BASE_Y_DEGREE * 8;
+        assert_eq!(sampler_denom, 32);
+        assert_eq!(AG_SAMPLING_CREDIT_BITS, sampler_denom.trailing_zeros());
+        // Explicit + credit = the strict per-challenge requirement.
+        assert_eq!(
+            R1_POW_BITS + AG_SAMPLING_CREDIT_BITS,
+            bits_for(R1_ZERO_BOUND)
+        );
+        assert_eq!(
+            crate::lincheck::AG_LINCHECK_SKIP_POW_BITS + AG_SAMPLING_CREDIT_BITS,
+            bits_for(base_deg)
+        );
+        // The schedule methods expose exactly these constants.
+        let g = crate::zerocheck::ZerocheckGrinding::per_challenge_128();
+        assert_eq!(g.ag_r1_bits(), Some(R1_POW_BITS));
+        assert_eq!(
+            crate::zerocheck::ZerocheckGrinding::disabled().ag_r1_bits(),
+            None
+        );
+    }
+
+    /// The fused predicate really gates on BOTH criteria: a nonce whose
+    /// attempt lands a valid point still rejects under a PoW target its hash
+    /// does not clear, and pow_bits = 0 degenerates to the plain attempt.
+    #[test]
+    fn fused_nonce_gates_on_pow_and_point() {
+        use crate::genus95_curve_code::{
+            evaluation_point_from_nonce, evaluation_point_from_nonce_pow,
+        };
+        use crate::hash::HashKind;
+        let seed = [5u8; 32];
+        let n = (0..20_000u32)
+            .find(|&n| evaluation_point_from_nonce(&seed, n, HashKind::Sha256).is_some())
+            .expect("a valid nonce exists in the budget");
+        // pow_bits = 0: identical to the plain attempt.
+        assert_eq!(
+            evaluation_point_from_nonce_pow(&seed, n, HashKind::Sha256, 0),
+            evaluation_point_from_nonce(&seed, n, HashKind::Sha256)
+        );
+        // A 40-bit target rejects this specific point-valid nonce (its hash
+        // clears 40 zero bits with probability 2^-40 — deterministic here).
+        assert_eq!(
+            evaluation_point_from_nonce_pow(&seed, n, HashKind::Sha256, 40),
+            None,
+            "the PoW gate must reject a point-valid nonce whose hash misses the target"
+        );
+        // And a nonce found UNDER the 4-bit target also passes the plain attempt.
+        let n4 = (0..(1u32 << 20))
+            .find(|&n| evaluation_point_from_nonce_pow(&seed, n, HashKind::Sha256, 4).is_some())
+            .expect("a fused nonce exists in the budget");
+        assert!(evaluation_point_from_nonce(&seed, n4, HashKind::Sha256).is_some());
+    }
+
+    /// Full grinding roundtrip on the fused transcript + fused-nonce tamper
+    /// rejection: any change to `r1_nonce` must reject (bad PoW, bad point,
+    /// or — if both criteria fluke — a different r₁ failing the c-eval bind).
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn grinding_roundtrip_rejects_fused_nonce_tampers() {
+        use crate::challenger::FsChallenger;
+        let m = 14usize;
+        let (a, b, c) = random_witness(m, 77);
+        let g = crate::zerocheck::ZerocheckGrinding::per_challenge_128();
+        let mk = || FsChallenger::new(b"flock-ag-grind-test");
+        let (proof, claim, _) = prove_capture_s_hat_v_c_with_grinding(&a, &b, &c, m, g, &mut mk());
+        let vclaim =
+            verify_with_grinding(m, &proof, g, &mut mk()).expect("honest fused proof verifies");
+        assert_eq!(vclaim, claim);
+
+        for delta in [1u32, 2, 3, 17] {
+            let mut bad = proof.clone();
+            bad.r1_nonce = proof.r1_nonce.wrapping_add(delta);
+            assert!(
+                verify_with_grinding(m, &bad, g, &mut mk()).is_err(),
+                "tampered fused r1 nonce (+{delta}) accepted"
+            );
+        }
+        // The grinding-nonce vector still binds: wrong count rejects.
+        let mut bad = proof.clone();
+        bad.grinding_nonces.push(0);
+        assert!(matches!(
+            verify_with_grinding(m, &bad, g, &mut mk()),
+            Err(AgVerifyError::BadGrindingNonceCount { .. })
+        ));
     }
 }

--- a/crates/flock-core/src/zerocheck/ag_skip.rs
+++ b/crates/flock-core/src/zerocheck/ag_skip.rs
@@ -1003,7 +1003,7 @@ pub(super) fn sample_r1_prover_pow<C: Challenger>(
             return (point, nonce);
         }
     }
-    unreachable!("fused r1 nonce grind exhausted its budget (probability ~2^-2954)")
+    unreachable!("fused r1 nonce grind exhausted its budget (see R1_FUSED_ATTEMPT_BUDGET)")
 }
 
 /// Verifier: re-derive `r₁` from the proof's nonce — range-check it, run the
@@ -1148,9 +1148,10 @@ impl<C: Challenger> Challenger for RoundGrindProver<'_, C> {
         self.nonces.push(nonce);
         r
     }
-    fn sample_f128_vec(&mut self, n: usize) -> Vec<F128> {
-        // The tail never vector-squeezes; keep the inner framing if it ever does.
-        self.inner.sample_f128_vec(n)
+    fn sample_f128_vec(&mut self, _n: usize) -> Vec<F128> {
+        // Fail loudly rather than silently skip the per-round grind: a tail
+        // change that vector-squeezes must extend the adapter first.
+        unreachable!("the grinding tail adapter never vector-squeezes")
     }
     fn grind_pow(&mut self, bits: u32) -> u64 {
         self.inner.grind_pow(bits)
@@ -1259,10 +1260,10 @@ pub fn prove_capture_s_hat_v_c<C: Challenger>(
 /// budget survives the recursion circuit's relaxed-canonicity decode —
 /// with a ONE-SHOT verifier.
 ///
-/// PADDING CONTRACT: round 1 sums the FULL `2^m` region — every padding
-/// word of `a`/`b`/`c` must be an HONEST ZERO (the union's fresh-zeroed
-/// witness mode), unlike the run-list-gated RS kernels which never read
-/// them.
+/// PADDING CONTRACT: this entry is run-list READ-EXACT — see the owning
+/// statement on [`crate::proof::BooleanPiopProofAg`]. Round 1 and the fold
+/// consult the `padding` spec's block coverage; declared-dead bits are
+/// never read, whatever the pooled buffers hold.
 #[cfg(target_arch = "aarch64")]
 pub fn prove_capture_s_hat_v_c_with_grinding<C: Challenger>(
     a_packed: &[u8],

--- a/crates/flock-core/src/zerocheck/ag_skip.rs
+++ b/crates/flock-core/src/zerocheck/ag_skip.rs
@@ -1268,6 +1268,8 @@ pub fn prove_capture_s_hat_v_c_with_grinding<C: Challenger>(
     // the fold share it. Read-exact (Dead skipped, Partial cleansed), so
     // the honest-zero witness-mode forcing this entry used to need is gone:
     // declared-dead bits are never read, whatever they hold.
+    let zc_timing = std::env::var_os("FLOCK_ZC_TIMING").is_some();
+    let t0 = std::time::Instant::now();
     let coverage = padding.block_coverage(K_SKIP + N_INNER, 1usize << (m - K_SKIP - N_INNER));
 
     challenger.observe_label(b"flock-ag-skip-v1");
@@ -1281,8 +1283,24 @@ pub fn prove_capture_s_hat_v_c_with_grinding<C: Challenger>(
         None => challenger.sample_f128_vec(m - K_SKIP - N_INNER),
     };
     let eq = crate::zerocheck::univariate_skip::build_eq(&r_outer);
-
+    let t_r1 = std::time::Instant::now();
     let (msg, s_hat_v_c) = prove_round1_banks_padded(a_packed, b_packed, c_packed, &eq, &coverage);
+    if zc_timing {
+        let (mut full, mut part, mut dead) = (0usize, 0usize, 0usize);
+        for c in &coverage {
+            match c {
+                super::BlockCoverage::Full => full += 1,
+                super::BlockCoverage::Partial(_) => part += 1,
+                super::BlockCoverage::Dead => dead += 1,
+            }
+        }
+        eprintln!(
+            "[ag-zc-timing] m={m} setup+eq {:.2} ms | round1 {:.2} ms (blocks: {full} full / {part} partial / {dead} dead)",
+            (t_r1 - t0).as_secs_f64() * 1e3,
+            t_r1.elapsed().as_secs_f64() * 1e3,
+        );
+    }
+    let t_tail = std::time::Instant::now();
     let (proof, claim) = prove_from_round1(
         a_packed,
         b_packed,
@@ -1293,6 +1311,12 @@ pub fn prove_capture_s_hat_v_c_with_grinding<C: Challenger>(
         Some(&coverage),
         challenger,
     );
+    if zc_timing {
+        eprintln!(
+            "[ag-zc-timing] m={m} fold+tail {:.2} ms",
+            t_tail.elapsed().as_secs_f64() * 1e3
+        );
+    }
     (proof, claim, s_hat_v_c)
 }
 
@@ -1316,14 +1340,13 @@ fn prove_round1_banks(
     banks_to_message(raw)
 }
 
-/// [`prove_round1_banks`] under a witness run-list. The round-1 kernels are
-/// position-independent additive sums over 8192-bit blocks (one eq weight
-/// each), so the run-list needs NO kernel changes: maximal runs of FULL
-/// blocks go to the untouched kernel as (slice, eq-subrange) segments,
-/// PARTIAL blocks are cleansed into zeroed scratch and run as one-block
-/// segments, DEAD blocks are skipped, and the segment outputs sum. Reads no
-/// declared-dead bit (`PooledDirty`-legal); a fully-Full coverage is the
-/// one-segment identity call.
+/// [`prove_round1_banks`] under a witness run-list. The hot (fused) path
+/// is [`round1_slp_packed_banks_fused_padded`] — ONE parallel pass over
+/// the live-block list, Partial blocks cleansed inline, per-element parity
+/// with the dense kernel. The bench-only unfused arm keeps the
+/// segment-call driver below (correct, but it pays a rayon bridge per
+/// full-run segment — the envelope's per-column run structure has ~450 of
+/// them, which is exactly why the fused arm got its own kernel).
 #[cfg(target_arch = "aarch64")]
 fn prove_round1_banks_padded(
     a_packed: &[u8],
@@ -1333,11 +1356,14 @@ fn prove_round1_banks_padded(
     coverage: &[super::BlockCoverage],
 ) -> (Round1Message, Vec<F128>) {
     use super::BlockCoverage;
-    let kernel = if ROUND1_UNFUSED.load(Ordering::Relaxed) {
-        crate::genus95_curve_code::round1::round1_slp_packed_banks
-    } else {
-        crate::genus95_curve_code::round1::round1_slp_packed_banks_fused
-    };
+    if !ROUND1_UNFUSED.load(Ordering::Relaxed) {
+        return banks_to_message(
+            crate::genus95_curve_code::round1::round1_slp_packed_banks_fused_padded(
+                a_packed, b_packed, c_packed, eq, coverage,
+            ),
+        );
+    }
+    let kernel = crate::genus95_curve_code::round1::round1_slp_packed_banks;
     let n = a_packed.len() / 1024;
     assert_eq!(eq.len(), n, "one eq weight per block");
     assert_eq!(coverage.len(), n, "one coverage entry per block");

--- a/crates/flock-core/src/zerocheck/ag_skip.rs
+++ b/crates/flock-core/src/zerocheck/ag_skip.rs
@@ -851,7 +851,10 @@ pub enum AgVerifyError {
     CEvalMismatch,
     SumcheckFinalFailed,
     /// The nonce vector does not match the configured grinding schedule.
-    BadGrindingNonceCount { expected: usize, got: usize },
+    BadGrindingNonceCount {
+        expected: usize,
+        got: usize,
+    },
     /// A nonce fails the PoW at the FS position sampling its challenge.
     InvalidGrindingNonce,
 }
@@ -1018,8 +1021,7 @@ pub fn prove_capture_s_hat_v_c_with_grinding<C: Challenger>(
     let mut grinding_nonces = Vec::with_capacity(grinding_nonce_count(grinding, m));
     let r_outer = match grinding.initial_bits(m) {
         Some(bits) => {
-            let (nonce, v) =
-                challenger.grind_pow_and_sample_f128_vec(bits, m - K_SKIP - N_INNER);
+            let (nonce, v) = challenger.grind_pow_and_sample_f128_vec(bits, m - K_SKIP - N_INNER);
             grinding_nonces.push(nonce);
             v
         }

--- a/crates/flock-core/tests/union_lincheck.rs
+++ b/crates/flock-core/tests/union_lincheck.rs
@@ -803,7 +803,7 @@ fn matrix_assertion_decomposes_into_foldable_claims() {
     // ---- Decompose into the two per-matrix claims.
     let inner = slot.k_log - K_SKIP;
     let row = Weight::low_eq(
-        lagrange_weights_naive(K_SKIP, assertion.z_skip),
+        assertion.z_skip.weights(K_SKIP),
         assertion.x_inner_rest[..inner].to_vec(),
     );
     let col = Weight::low_eq(assertion.z_partial.clone(), assertion.rr.clone());

--- a/crates/flock-prover/benches/blake3_rs_vs_ag.rs
+++ b/crates/flock-prover/benches/blake3_rs_vs_ag.rs
@@ -6,8 +6,7 @@
 //!               comparison mixes commit shape with zerocheck flavor.
 //!   AG-union  — `prove_fast_union_ag`: the SAME union transport as RS with
 //!               the AG zerocheck — the apples-to-apples pair. The only
-//!               difference vs RS is round 1 of the zerocheck (plus the
-//!               honest-zero witness mode AG requires).
+//!               difference vs RS is round 1 of the zerocheck.
 //!
 //! Run twice for ST and MT:
 //!   cargo bench --bench blake3_rs_vs_ag                       # MT (default)

--- a/crates/flock-prover/benches/blake3_rs_vs_ag.rs
+++ b/crates/flock-prover/benches/blake3_rs_vs_ag.rs
@@ -244,7 +244,9 @@ fn bench_block(n_blocks: usize, n_runs: usize, threads_label: &str) {
             .verify_union_ag(&commitment, &proof, &mut ch_v)
             .expect("union-AG verify");
         let verify_t = t0.elapsed().as_secs_f64();
-        let size = bincode::serialize(&proof).expect("ser union-AG proof").len();
+        let size = bincode::serialize(&proof)
+            .expect("ser union-AG proof")
+            .len();
         black_box(&proof);
 
         println!(

--- a/crates/flock-prover/benches/blake3_rs_vs_ag.rs
+++ b/crates/flock-prover/benches/blake3_rs_vs_ag.rs
@@ -1,8 +1,13 @@
-//! BLAKE3 `prove_fast` (RS additive-NTT zerocheck) vs `prove_fast_ag` (genus-95
-//! AG-code zerocheck) head-to-head — both on the standard pack + Ligerito PCS.
-//! The ONLY difference is round 1 of the zerocheck; everything else (witness gen,
-//! commit, lincheck, ring-switch open) is shared, so this isolates the AG-skip
-//! zerocheck win at the full-proof level.
+//! BLAKE3 zerocheck-flavor head-to-head, three arms:
+//!   RS        — `prove_fast`: the UNION route (dense-stack commit, integer
+//!               lanes) with the RS additive-NTT zerocheck.
+//!   AG-direct — `prove_fast_ag`: the standard-pack (dense pow2-lane) commit
+//!               with the AG zerocheck. Different transport than RS, so the
+//!               comparison mixes commit shape with zerocheck flavor.
+//!   AG-union  — `prove_fast_union_ag`: the SAME union transport as RS with
+//!               the AG zerocheck — the apples-to-apples pair. The only
+//!               difference vs RS is round 1 of the zerocheck (plus the
+//!               honest-zero witness mode AG requires).
 //!
 //! Run twice for ST and MT:
 //!   cargo bench --bench blake3_rs_vs_ag                       # MT (default)
@@ -210,6 +215,49 @@ fn bench_block(n_blocks: usize, n_runs: usize, threads_label: &str) {
             "  ──> AG prove speedup vs RS: {:.3}×  ({:+.2} ms)",
             rs_prove / ag_prove,
             (rs_prove - ag_prove) * 1000.0,
+        );
+    }
+
+    // ============ AG on the UNION transport (same commit as RS) ============
+    #[cfg(target_arch = "aarch64")]
+    {
+        let mut ch_p = FsChallenger::new(b"flock-bench-v0");
+        let (p, _, _) = setup.prove_fast_union_ag(&block_sets[0], &mut ch_p);
+        black_box(&p);
+
+        let mut agu_prove = f64::INFINITY;
+        for run in 0..n_runs {
+            let mut ch_p = FsChallenger::new(b"flock-bench-v0");
+            let t0 = Instant::now();
+            let (p, _, _) = setup.prove_fast_union_ag(&block_sets[run + 1], &mut ch_p);
+            agu_prove = agu_prove.min(t0.elapsed().as_secs_f64());
+            black_box(&p);
+        }
+
+        reset_peak();
+        let mut ch_p = FsChallenger::new(b"flock-bench-v0");
+        let (proof, commitment, _) = setup.prove_fast_union_ag(&block_sets[0], &mut ch_p);
+        let peak = peak_mb();
+        let mut ch_v = FsChallenger::new(b"flock-bench-v0");
+        let t0 = Instant::now();
+        setup
+            .verify_union_ag(&commitment, &proof, &mut ch_v)
+            .expect("union-AG verify");
+        let verify_t = t0.elapsed().as_secs_f64();
+        let size = bincode::serialize(&proof).expect("ser union-AG proof").len();
+        black_box(&proof);
+
+        println!(
+            "  AGu zerocheck: prove = {}   verify = {}   proof = {}   peak = {:.1} MB",
+            fmt_ms(agu_prove),
+            fmt_ms(verify_t),
+            fmt_kb(size),
+            peak,
+        );
+        println!(
+            "  ──> union-AG prove speedup vs union-RS: {:.3}×  ({:+.2} ms)",
+            rs_prove / agu_prove,
+            (rs_prove - agu_prove) * 1000.0,
         );
     }
 

--- a/crates/flock-prover/src/prover.rs
+++ b/crates/flock-prover/src/prover.rs
@@ -545,7 +545,7 @@ pub fn prove_fast_ligerito_union_circuit<Ch: Challenger>(
         pcs_open,
     } = out;
     let (bool_proof, bool_claim) = match boolean {
-        Some((p, c)) => (Some(p), Some(c)),
+        Some((p, c)) => (Some(p.expect_rs()), Some(c)),
         None => (None, None),
     };
     let (el_proof, el_claim) = match element {
@@ -611,6 +611,7 @@ pub fn prove_fast_ligerito_union<Ch: Challenger>(
         challenger,
     );
     let (piop, claim) = out.boolean.expect("asserted boolean-only above");
+    let piop = piop.expect_rs();
     (
         flock_core::proof::R1csProofMergedLigerito {
             zerocheck: piop.zerocheck,
@@ -622,11 +623,100 @@ pub fn prove_fast_ligerito_union<Ch: Challenger>(
     )
 }
 
+/// Which zerocheck the boolean class runs inside
+/// [`prove_union_with_binding_zc`]. The lincheck, claims, and opening are
+/// flavor-generic ([`SkipPoint`] carries the difference).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BooleanZcKind {
+    /// RS additive-NTT univariate skip (the default).
+    Rs,
+    /// Genus-95 AG multiplication-code skip. aarch64-only (NEON SLP kernel);
+    /// forces the honest-zero witness mode — see the padding note in the body.
+    #[cfg(target_arch = "aarch64")]
+    Ag,
+}
+
+/// The zerocheck transcript alone, before the lincheck joins it in the
+/// closure's assembly step.
+enum UnionZcProof {
+    Rs(zerocheck::ZerocheckProof),
+    #[cfg(target_arch = "aarch64")]
+    Ag(flock_core::zerocheck::ag_skip::AgProof),
+}
+
+/// The boolean sub-proof [`prove_union_with_binding_zc`] hands back — the
+/// prove-side counterpart of the verifier's `BooleanPiopRef`.
+enum UnionBooleanProof {
+    Rs(flock_core::proof::BooleanPiopProof),
+    #[cfg(target_arch = "aarch64")]
+    Ag(flock_core::proof::BooleanPiopProofAg),
+}
+
+impl UnionBooleanProof {
+    fn expect_rs(self) -> flock_core::proof::BooleanPiopProof {
+        match self {
+            UnionBooleanProof::Rs(p) => p,
+            #[cfg(target_arch = "aarch64")]
+            UnionBooleanProof::Ag(_) => {
+                unreachable!("an RS-flavor entry received an AG boolean proof")
+            }
+        }
+    }
+}
+
+/// [`prove_fast_ligerito_union`] with the **AG-skip** boolean zerocheck —
+/// verify with [`flock_core::verifier::verify_ligerito_union_ag`]. Same
+/// transport, lincheck, and merged opening; only the zerocheck's round 1
+/// differs (the genus-95 AG multiplication code replaces the RS
+/// additive-NTT skip, and the claim points ride [`SkipPoint::Ag`]).
+///
+/// aarch64-only (the AG round-1 kernel is NEON SLP). Forces the honest-zero
+/// witness mode: the AG round-1 sum reads the FULL boolean region, so the
+/// dirty pooled padding the run-list-gated RS kernels tolerate is unsound
+/// here (the flavor gate inside the shared body enforces this).
+#[cfg(target_arch = "aarch64")]
+pub fn prove_fast_ligerito_union_ag<Ch: Challenger>(
+    union: &flock_core::union::UnionInstance<'_>,
+    pcs_params: &PcsParams,
+    slots: Vec<UnionSlotProverInput<'_>>,
+    challenger: &mut Ch,
+) -> (
+    flock_core::proof::R1csProofMergedLigeritoAg,
+    Commitment,
+    R1csClaim,
+) {
+    assert!(
+        !union.has_element(),
+        "the AG union route is boolean-only; element registries go through          the RS mixed-class entry"
+    );
+    let (out, commitment) = prove_union_with_binding_zc(
+        union,
+        UnionProveBinding::Mixed,
+        BooleanZcKind::Ag,
+        pcs_params,
+        slots,
+        Vec::new(),
+        challenger,
+    );
+    let (piop, claim) = out.boolean.expect("asserted boolean-only above");
+    let UnionBooleanProof::Ag(boolean) = piop else {
+        unreachable!("the Ag flavor produces an Ag boolean proof")
+    };
+    (
+        flock_core::proof::R1csProofMergedLigeritoAg {
+            boolean,
+            pcs_open: out.pcs_open,
+        },
+        commitment,
+        claim,
+    )
+}
+
 /// What [`prove_union_with_binding`] produces: each class's PIOP sub-proof
 /// paired with its claims (`None` when the registry has no type of that class),
 /// plus the single opening covering all of them.
 struct UnionProveOutput {
-    boolean: Option<(flock_core::proof::BooleanPiopProof, R1csClaim)>,
+    boolean: Option<(UnionBooleanProof, R1csClaim)>,
     element: Option<(
         flock_core::element_r1cs::union::Proof,
         flock_core::element_r1cs::union::Claims,
@@ -646,6 +736,27 @@ struct UnionProveOutput {
 fn prove_union_with_binding<Ch: Challenger>(
     union: &flock_core::union::UnionInstance<'_>,
     binding: UnionProveBinding,
+    pcs_params: &PcsParams,
+    slots: Vec<UnionSlotProverInput<'_>>,
+    element_slots: Vec<UnionElementSlotInput<'_>>,
+    challenger: &mut Ch,
+) -> (UnionProveOutput, Commitment) {
+    prove_union_with_binding_zc(
+        union,
+        binding,
+        BooleanZcKind::Rs,
+        pcs_params,
+        slots,
+        element_slots,
+        challenger,
+    )
+}
+
+/// [`prove_union_with_binding`] with the boolean zerocheck flavor explicit.
+fn prove_union_with_binding_zc<Ch: Challenger>(
+    union: &flock_core::union::UnionInstance<'_>,
+    binding: UnionProveBinding,
+    bool_zc: BooleanZcKind,
     pcs_params: &PcsParams,
     slots: Vec<UnionSlotProverInput<'_>>,
     element_slots: Vec<UnionElementSlotInput<'_>>,
@@ -714,7 +825,11 @@ fn prove_union_with_binding<Ch: Challenger>(
     // its padding words are committed and must be honest zeros — dirty
     // pooling would put garbage into the committed stack (a latent hazard
     // of the pre-unification standalone body, never exercised there).
-    let padding_unread = !union.has_element()
+    // The AG flavor's round 1 sums the FULL boolean region densely (no
+    // run-list gating), so it READS the padding words — dirty pooled padding
+    // is unsound under it. Force the honest-zero witness mode.
+    let padding_unread = bool_zc == BooleanZcKind::Rs
+        && !union.has_element()
         && !union.compaction_is_identity()
         && union.m_total() - union.n_log() >= pcs::LOG_PACKING;
     let (z_packed, a_packed_f128, b_packed_f128, stripes, buf_mode) =
@@ -887,7 +1002,7 @@ fn prove_union_with_binding<Ch: Challenger>(
     let t_bool = std::time::Instant::now();
     let run_boolean = |challenger: &mut Ch| {
         (union.num_boolean() > 0).then(|| {
-            let (zc_proof, zc_claim, s_hat_v_c) = {
+            let (zc_proof, z_skip, mlv_challenges, zc_r_rest, zc_c_eval, s_hat_v_c) = {
                 // Zero-cost &[u8] views of the F128 buffers; c aliases z (C = I).
                 let view = |v: &[F128]| -> &[u8] {
                     unsafe {
@@ -900,18 +1015,54 @@ fn prove_union_with_binding<Ch: Challenger>(
                 let a_packed = view(&a_packed_f128);
                 let b_packed = view(&b_packed_f128);
                 let c_packed = view(&z_packed);
-                zerocheck::prove_packed_padded_capture_s_hat_v_c_with_grinding(
-                    a_packed,
-                    b_packed,
-                    c_packed,
-                    m_bool,
-                    &bool_padding,
-                    pcs_params.zerocheck_grinding(),
-                    challenger,
-                )
+                match bool_zc {
+                    BooleanZcKind::Rs => {
+                        let (p, cl, sv) =
+                            zerocheck::prove_packed_padded_capture_s_hat_v_c_with_grinding(
+                                a_packed,
+                                b_packed,
+                                c_packed,
+                                m_bool,
+                                &bool_padding,
+                                pcs_params.zerocheck_grinding(),
+                                challenger,
+                            );
+                        (
+                            UnionZcProof::Rs(p),
+                            SkipPoint::Phi8(cl.z),
+                            cl.mlv_challenges,
+                            cl.r_rest,
+                            cl.c_eval,
+                            sv,
+                        )
+                    }
+                    #[cfg(target_arch = "aarch64")]
+                    BooleanZcKind::Ag => {
+                        // Dense over the full boolean region — sound because
+                        // this flavor forced the honest-zero witness mode
+                        // above (padding rows contribute a·b − c = 0).
+                        let (p, cl, sv) =
+                            zerocheck::ag_skip::prove_capture_s_hat_v_c_with_grinding(
+                                a_packed,
+                                b_packed,
+                                c_packed,
+                                m_bool,
+                                pcs_params.zerocheck_grinding(),
+                                challenger,
+                            );
+                        (
+                            UnionZcProof::Ag(p),
+                            SkipPoint::Ag(cl.r1),
+                            cl.mlv_challenges,
+                            cl.r_rest,
+                            cl.c_eval,
+                            sv,
+                        )
+                    }
+                }
             };
 
-            let x_ab = union.x_ab_from_mlv(SkipPoint::Phi8(zc_claim.z), &zc_claim.mlv_challenges);
+            let x_ab = union.x_ab_from_mlv(z_skip, &mlv_challenges);
 
             // M2: the union-column lincheck — one sumcheck over the boolean
             // column domain against the per-slot stripes and circuits. On the M1
@@ -943,8 +1094,8 @@ fn prove_union_with_binding<Ch: Challenger>(
                 value: lc_claim.w,
             };
             let c = ZClaim {
-                point: union.c_claim_point(SkipPoint::Phi8(zc_claim.z), &zc_claim.r_rest),
-                value: zc_claim.c_eval,
+                point: union.c_claim_point(z_skip, &zc_r_rest),
+                value: zc_c_eval,
             };
 
             // `s_hat_v_from_z_vec` needs `z_vec.len() = 2^LOG_PACKING · 2^tail`;
@@ -976,15 +1127,22 @@ fn prove_union_with_binding<Ch: Challenger>(
             } else {
                 None
             };
-            (
-                flock_core::proof::BooleanPiopProof {
-                    zerocheck: zc_proof,
-                    lincheck: lc_proof,
-                },
-                R1csClaim { ab, c },
-                s_hat_v_ab,
-                s_hat_v_c,
-            )
+            let piop = match zc_proof {
+                UnionZcProof::Rs(zerocheck) => {
+                    UnionBooleanProof::Rs(flock_core::proof::BooleanPiopProof {
+                        zerocheck,
+                        lincheck: lc_proof,
+                    })
+                }
+                #[cfg(target_arch = "aarch64")]
+                UnionZcProof::Ag(ag) => {
+                    UnionBooleanProof::Ag(flock_core::proof::BooleanPiopProofAg {
+                        ag,
+                        lincheck: lc_proof,
+                    })
+                }
+            };
+            (piop, R1csClaim { ab, c }, s_hat_v_ab, s_hat_v_c)
         })
     };
     let (boolean, wiring_pre) = if par_transcript {
@@ -1993,7 +2151,7 @@ pub fn prove_fast_ligerito_union_mixed_class<Ch: Challenger>(
     } = out;
     debug_assert!(wiring.is_none(), "the Mixed binding runs no wiring");
     let (bool_proof, bool_claim) = match boolean {
-        Some((p, c)) => (Some(p), Some(c)),
+        Some((p, c)) => (Some(p.expect_rs()), Some(c)),
         None => (None, None),
     };
     let (el_proof, el_claim) = match element {

--- a/crates/flock-prover/src/prover.rs
+++ b/crates/flock-prover/src/prover.rs
@@ -636,6 +636,81 @@ enum BooleanZcKind {
     Ag,
 }
 
+/// [`prove_fast_ligerito_union_circuit`] with the **AG-skip** boolean
+/// zerocheck — verify with
+/// [`flock_core::verifier::verify_ligerito_union_circuit_ag`] (or the
+/// `_deferred` twin). Same class PIOP order, wiring argument, and merged
+/// opening; only the boolean zerocheck's round 1 differs. The element class
+/// may be present (its PIOP is flavor-independent); the AG flavor forces the
+/// honest-zero witness mode inside the shared body. aarch64-only (the AG
+/// round-1 kernel is NEON).
+#[cfg(target_arch = "aarch64")]
+#[allow(clippy::too_many_arguments)]
+pub fn prove_fast_ligerito_union_circuit_ag<Ch: Challenger>(
+    union: &flock_core::union::UnionInstance<'_>,
+    circuit: &flock_core::circuit::Circuit,
+    public: &[F128],
+    pcs_params: &PcsParams,
+    slots: Vec<UnionSlotProverInput<'_>>,
+    element_slots: Vec<UnionElementSlotInput<'_>>,
+    challenger: &mut Ch,
+) -> (
+    flock_core::proof::R1csProofCircuitMergedAg,
+    Commitment,
+    flock_core::proof::UnionClassClaims,
+) {
+    assert!(
+        circuit.check_instance(union),
+        "the circuit and the union instance must be the same statement \
+         (same registry, and the circuit's gate counts ARE the union's counts)"
+    );
+    assert!(
+        circuit.check_public(public),
+        "the public segment must have the circuit's declared length and fixed constants"
+    );
+    let (out, commitment) = prove_union_with_binding_zc(
+        union,
+        UnionProveBinding::Circuit(CircuitProverInput { circuit, public }),
+        BooleanZcKind::Ag,
+        pcs_params,
+        slots,
+        element_slots,
+        challenger,
+    );
+    let UnionProveOutput {
+        boolean,
+        element,
+        wiring,
+        pcs_open,
+    } = out;
+    let (bool_proof, bool_claim) = match boolean {
+        Some((p, c)) => {
+            let UnionBooleanProof::Ag(p) = p else {
+                unreachable!("the Ag flavor produces an Ag boolean proof")
+            };
+            (Some(p), Some(c))
+        }
+        None => (None, None),
+    };
+    let (el_proof, el_claim) = match element {
+        Some((p, c)) => (Some(p), Some(c)),
+        None => (None, None),
+    };
+    (
+        flock_core::proof::R1csProofCircuitMergedAg {
+            boolean: bool_proof,
+            element: el_proof,
+            wiring: wiring.expect("the circuit binding runs the wiring argument"),
+            pcs_open,
+        },
+        commitment,
+        flock_core::proof::UnionClassClaims {
+            boolean: bool_claim,
+            element: el_claim,
+        },
+    )
+}
+
 /// The zerocheck transcript alone, before the lincheck joins it in the
 /// closure's assembly step.
 enum UnionZcProof {

--- a/crates/flock-prover/src/prover.rs
+++ b/crates/flock-prover/src/prover.rs
@@ -630,8 +630,9 @@ pub fn prove_fast_ligerito_union<Ch: Challenger>(
 enum BooleanZcKind {
     /// RS additive-NTT univariate skip (the default).
     Rs,
-    /// Genus-95 AG multiplication-code skip. aarch64-only (NEON SLP kernel);
-    /// forces the honest-zero witness mode — see the padding note in the body.
+    /// Genus-95 AG multiplication-code skip. aarch64-only (NEON SLP
+    /// kernel); run-list read-exact like the RS flavor — see the padding
+    /// contract on `flock_core::proof::BooleanPiopProofAg`.
     #[cfg(target_arch = "aarch64")]
     Ag,
 }
@@ -641,9 +642,9 @@ enum BooleanZcKind {
 /// [`flock_core::verifier::verify_ligerito_union_circuit_ag`] (or the
 /// `_deferred` twin). Same class PIOP order, wiring argument, and merged
 /// opening; only the boolean zerocheck's round 1 differs. The element class
-/// may be present (its PIOP is flavor-independent); the AG flavor forces the
-/// honest-zero witness mode inside the shared body. aarch64-only (the AG
-/// round-1 kernel is NEON).
+/// may be present (its PIOP is flavor-independent). Run-list read-exact —
+/// the padding contract on [`flock_core::proof::BooleanPiopProofAg`] is
+/// the owning statement. aarch64-only (the AG round-1 kernel is NEON).
 #[cfg(target_arch = "aarch64")]
 #[allow(clippy::too_many_arguments)]
 pub fn prove_fast_ligerito_union_circuit_ag<Ch: Challenger>(
@@ -745,10 +746,9 @@ impl UnionBooleanProof {
 /// differs (the genus-95 AG multiplication code replaces the RS
 /// additive-NTT skip, and the claim points ride [`SkipPoint::Ag`]).
 ///
-/// aarch64-only (the AG round-1 kernel is NEON SLP). Forces the honest-zero
-/// witness mode: the AG round-1 sum reads the FULL boolean region, so the
-/// dirty pooled padding the run-list-gated RS kernels tolerate is unsound
-/// here (the flavor gate inside the shared body enforces this).
+/// aarch64-only (the AG round-1 kernel is NEON SLP). Run-list read-exact —
+/// the padding contract on [`flock_core::proof::BooleanPiopProofAg`] is
+/// the owning statement; dirty pooled padding is legal for both flavors.
 #[cfg(target_arch = "aarch64")]
 pub fn prove_fast_ligerito_union_ag<Ch: Challenger>(
     union: &flock_core::union::UnionInstance<'_>,

--- a/crates/flock-prover/src/prover.rs
+++ b/crates/flock-prover/src/prover.rs
@@ -900,11 +900,10 @@ fn prove_union_with_binding_zc<Ch: Challenger>(
     // its padding words are committed and must be honest zeros — dirty
     // pooling would put garbage into the committed stack (a latent hazard
     // of the pre-unification standalone body, never exercised there).
-    // The AG flavor's round 1 sums the FULL boolean region densely (no
-    // run-list gating), so it READS the padding words — dirty pooled padding
-    // is unsound under it. Force the honest-zero witness mode.
-    let padding_unread = bool_zc == BooleanZcKind::Rs
-        && !union.has_element()
+    // Flavor-independent since the AG round 1 + fold went run-list-gated
+    // (Dead blocks skipped, Partial blocks cleansed — no declared-dead bit
+    // is read on either flavor).
+    let padding_unread = !union.has_element()
         && !union.compaction_is_identity()
         && union.m_total() - union.n_log() >= pcs::LOG_PACKING;
     let (z_packed, a_packed_f128, b_packed_f128, stripes, buf_mode) =
@@ -1113,14 +1112,16 @@ fn prove_union_with_binding_zc<Ch: Challenger>(
                     }
                     #[cfg(target_arch = "aarch64")]
                     BooleanZcKind::Ag => {
-                        // Dense over the full boolean region — sound because
-                        // this flavor forced the honest-zero witness mode
-                        // above (padding rows contribute a·b − c = 0).
+                        // Run-list-gated like the RS twin: round 1 and the
+                        // fold skip Dead code blocks and cleanse Partial
+                        // ones, reading no declared-dead bit — PooledDirty
+                        // witnesses are legal here too.
                         let (p, cl, sv) = zerocheck::ag_skip::prove_capture_s_hat_v_c_with_grinding(
                             a_packed,
                             b_packed,
                             c_packed,
                             m_bool,
+                            &bool_padding,
                             pcs_params.zerocheck_grinding(),
                             challenger,
                         );

--- a/crates/flock-prover/src/prover.rs
+++ b/crates/flock-prover/src/prover.rs
@@ -1041,15 +1041,14 @@ fn prove_union_with_binding_zc<Ch: Challenger>(
                         // Dense over the full boolean region — sound because
                         // this flavor forced the honest-zero witness mode
                         // above (padding rows contribute a·b − c = 0).
-                        let (p, cl, sv) =
-                            zerocheck::ag_skip::prove_capture_s_hat_v_c_with_grinding(
-                                a_packed,
-                                b_packed,
-                                c_packed,
-                                m_bool,
-                                pcs_params.zerocheck_grinding(),
-                                challenger,
-                            );
+                        let (p, cl, sv) = zerocheck::ag_skip::prove_capture_s_hat_v_c_with_grinding(
+                            a_packed,
+                            b_packed,
+                            c_packed,
+                            m_bool,
+                            pcs_params.zerocheck_grinding(),
+                            challenger,
+                        );
                         (
                             UnionZcProof::Ag(p),
                             SkipPoint::Ag(cl.r1),

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -1705,6 +1705,50 @@ impl Blake3Setup {
         )
     }
 
+    /// [`Self::prove_fast`] with the **AG-skip** boolean zerocheck — the SAME
+    /// single-slot union commit, lincheck, and merged opening; only round 1
+    /// of the zerocheck differs. aarch64-only (NEON round-1 kernel). Verify
+    /// with [`Self::verify_union_ag`].
+    #[cfg(target_arch = "aarch64")]
+    pub fn prove_fast_union_ag<Ch: Challenger>(
+        &self,
+        blocks: &[Compression],
+        challenger: &mut Ch,
+    ) -> (
+        flock_core::proof::R1csProofMergedLigeritoAg,
+        Commitment,
+        R1csClaim,
+    ) {
+        assert_eq!(blocks.len(), self.n_blocks);
+        let union = flock_core::union::UnionInstance::new(&self.registry, vec![self.n_blocks]);
+        let slot = crate::prover::UnionSlotProverInput::new(
+            generate_witness_batch_major_partial(blocks, self.n_blocks_log()),
+            self.r1cs.csc_lincheck_circuit(),
+        );
+        crate::prover::prove_fast_ligerito_union_ag(&union, &self.pcs_params, vec![slot], challenger)
+    }
+
+    /// Verify a [`Self::prove_fast_union_ag`] proof. (Unlike the prove side,
+    /// this runs on every target.)
+    pub fn verify_union_ag<Ch: Challenger>(
+        &self,
+        commitment: &Commitment,
+        proof: &flock_core::proof::R1csProofMergedLigeritoAg,
+        challenger: &mut Ch,
+    ) -> Result<R1csClaim, verifier::VerifyError> {
+        let union = flock_core::union::UnionInstance::new(&self.registry, vec![self.n_blocks]);
+        let circuit = self.r1cs.csc_lincheck_circuit();
+        let circs: [&dyn flock_core::lincheck::LincheckCircuit; 1] = [circuit];
+        verifier::verify_ligerito_union_ag(
+            &union,
+            &circs,
+            commitment,
+            proof,
+            &self.pcs_params,
+            challenger,
+        )
+    }
+
     /// AG-skip mirror of [`Self::prove_fast`]: round 1 of the zerocheck runs
     /// on the genus-95 AG multiplication code instead of the RS additive-NTT
     /// skip; everything else (witness gen, commit, lincheck, ring-switch open)
@@ -2423,6 +2467,64 @@ mod tests {
             setup.verify_ag(&commitment, &bad, &mut ch).is_err(),
             "tampered batch-major AG proof accepted"
         );
+    }
+
+    /// UNION-AG e2e: prove_fast_union_ag → verify_union_ag roundtrip +
+    /// tamper rejection — the AG zerocheck inside the single-slot union
+    /// transport (dense stack + integer lanes, union lincheck, merged
+    /// opening on `SkipPoint::Ag` claim points), under the profile's full
+    /// grinding schedule.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    #[ignore] // Heavy — run with `cargo test prove_fast_union_ag_roundtrip -- --ignored`
+    fn prove_fast_union_ag_roundtrip() {
+        use flock_core::challenger::FsChallenger;
+        let setup = Blake3Setup::new(256);
+        let mut rng = Rng::new(0xA9_0110_4A6);
+        let blocks: Vec<Compression> = (0..256)
+            .map(|_| {
+                let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
+                let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                let counter = ((rng.next_u32() as u64) << 32) | (rng.next_u32() as u64);
+                (cv, m, counter, 64u32, 11u32)
+            })
+            .collect();
+        let mut ch_p = FsChallenger::new(b"flock-union-ag-v0");
+        let (proof, commitment, claim_p) = setup.prove_fast_union_ag(&blocks, &mut ch_p);
+        let mut ch_v = FsChallenger::new(b"flock-union-ag-v0");
+        let claim_v = setup
+            .verify_union_ag(&commitment, &proof, &mut ch_v)
+            .unwrap_or_else(|e| panic!("union-AG verify rejected honest proof: {e:?}"));
+        assert_eq!(claim_p, claim_v, "union-AG verifier claim != prover claim");
+
+        // Tampering an AG round-1 message must reject.
+        let mut bad = proof.clone();
+        bad.boolean.ag.round1_ab[0] += flock_core::field::F128::ONE;
+        let mut ch = FsChallenger::new(b"flock-union-ag-v0");
+        assert!(
+            setup.verify_union_ag(&commitment, &bad, &mut ch).is_err(),
+            "must reject a tampered union-AG round-1 message"
+        );
+
+        // A nonce vector off the grinding schedule must reject (count check).
+        let mut bad = proof.clone();
+        bad.boolean.ag.grinding_nonces.push(0);
+        let mut ch = FsChallenger::new(b"flock-union-ag-v0");
+        assert!(
+            setup.verify_union_ag(&commitment, &bad, &mut ch).is_err(),
+            "must reject a proof with an off-schedule nonce count"
+        );
+
+        // If the schedule grinds, a corrupted nonce must reject too.
+        if !proof.boolean.ag.grinding_nonces.is_empty() {
+            let mut bad = proof.clone();
+            bad.boolean.ag.grinding_nonces[0] ^= 1;
+            let mut ch = FsChallenger::new(b"flock-union-ag-v0");
+            assert!(
+                setup.verify_union_ag(&commitment, &bad, &mut ch).is_err(),
+                "must reject a corrupted grinding nonce"
+            );
+        }
     }
 
     #[test]

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -2555,6 +2555,43 @@ mod tests {
         );
     }
 
+    /// UNION-AG at PARTIAL UTILIZATION (200/256 declared rows): the
+    /// count-derived multi-run spec drives the AG run-list arms — round-1
+    /// full/partial/dead segments and the gated fold — through the real
+    /// transport, with the witness buffers eligible for the dirty pool
+    /// (the PooledDirty election no longer excludes the AG flavor). The
+    /// prove runs TWICE: the second draw takes the buffers the first
+    /// returned DIRTY, and byte-identical proofs pin the arms'
+    /// read-exactness in situ (the kernel-level legs live in
+    /// `ag_skip::padded_arms_match_dense_and_ignore_dirty_padding`).
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    #[ignore] // Heavy — run with `-- --ignored`.
+    fn prove_fast_union_ag_partial_utilization_roundtrip() {
+        use flock_core::challenger::FsChallenger;
+        let setup = Blake3Setup::new(200);
+        let mut rng = Rng::new(0xA9_0110_4A7);
+        let blocks: Vec<Compression> = (0..200)
+            .map(|_| {
+                let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
+                let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                let counter = ((rng.next_u32() as u64) << 32) | (rng.next_u32() as u64);
+                (cv, m, counter, 64u32, 11u32)
+            })
+            .collect();
+        let mut ch_p = FsChallenger::new(b"flock-union-ag-part");
+        let (proof, commitment, claim_p) = setup.prove_fast_union_ag(&blocks, &mut ch_p);
+        let mut ch_v = FsChallenger::new(b"flock-union-ag-part");
+        let claim_v = setup
+            .verify_union_ag(&commitment, &proof, &mut ch_v)
+            .unwrap_or_else(|e| panic!("partial-utilization union-AG rejected: {e:?}"));
+        assert_eq!(claim_p, claim_v, "verifier claim != prover claim");
+
+        let mut ch_p2 = FsChallenger::new(b"flock-union-ag-part");
+        let (proof2, _, _) = setup.prove_fast_union_ag(&blocks, &mut ch_p2);
+        assert_eq!(proof, proof2, "re-prove over pooled-dirty buffers");
+    }
+
     #[test]
     fn layout_constants() {
         // I/O-aligned layout: cv in slot 0, out_lo in slot 1 (both 256-bit),

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -2530,6 +2530,29 @@ mod tests {
                 "must reject a corrupted grinding nonce"
             );
         }
+
+        // The FUSED r1 nonce: any change must reject (bad PoW, bad point, or
+        // a diverged r1 failing the c-eval bind).
+        let mut bad = proof.clone();
+        bad.boolean.ag.r1_nonce = bad.boolean.ag.r1_nonce.wrapping_add(1);
+        let mut ch = FsChallenger::new(b"flock-union-ag-v0");
+        assert!(
+            setup.verify_union_ag(&commitment, &bad, &mut ch).is_err(),
+            "must reject a tampered fused r1 nonce"
+        );
+
+        // The lincheck's FUSED AG skip nonce (the last lincheck nonce).
+        let mut bad = proof.clone();
+        *bad.boolean
+            .lincheck
+            .grinding_nonces
+            .last_mut()
+            .expect("the AG arm carries a fused skip nonce") ^= 1;
+        let mut ch = FsChallenger::new(b"flock-union-ag-v0");
+        assert!(
+            setup.verify_union_ag(&commitment, &bad, &mut ch).is_err(),
+            "must reject a tampered fused lincheck skip nonce"
+        );
     }
 
     #[test]

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -1725,7 +1725,12 @@ impl Blake3Setup {
             generate_witness_batch_major_partial(blocks, self.n_blocks_log()),
             self.r1cs.csc_lincheck_circuit(),
         );
-        crate::prover::prove_fast_ligerito_union_ag(&union, &self.pcs_params, vec![slot], challenger)
+        crate::prover::prove_fast_ligerito_union_ag(
+            &union,
+            &self.pcs_params,
+            vec![slot],
+            challenger,
+        )
     }
 
     /// Verify a [`Self::prove_fast_union_ag`] proof. (Unlike the prove side,

--- a/crates/flock-prover/src/tower.rs
+++ b/crates/flock-prover/src/tower.rs
@@ -108,6 +108,14 @@ fn leaf_zc_ag() -> bool {
         && !matches!(std::env::var("TOWER_LEAF_ZC").as_deref(), Ok("rs"))
 }
 
+/// Phase C flip-in-place: the envelope OUTERS (FL / internal / spine)
+/// prove under the AG skip on the same terms as the leaf.
+/// `TOWER_OUTER_ZC=rs` forces the RS outers for A/B measurement.
+fn outer_zc_ag() -> bool {
+    cfg!(target_arch = "aarch64")
+        && !matches!(std::env::var("TOWER_OUTER_ZC").as_deref(), Ok("rs"))
+}
+
 fn tower_fold_grinding(cfg: TowerConfig) -> flock_core::matrix_fold::FoldGrinding {
     let profile = cfg.outer_profile();
     PcsParams {
@@ -6028,7 +6036,7 @@ fn emit_opening(
 pub struct LeafOuter {
     shape: flock_core::circuit::builder::CircuitShape,
     public: Vec<F128>,
-    proof: flock_core::proof::R1csProofCircuitMerged,
+    proof: MixedProof,
     commitment: flock_core::pcs::Commitment,
     pcs: PcsParams,
     b3_r1cs: flock_core::r1cs::BlockR1cs,
@@ -6158,8 +6166,8 @@ struct RealTape<'p> {
     /// (g_v, ch, fin) per boolean lc round — messages feed the in-circuit
     /// lincheck replay.
     lc_rounds_b: Vec<(usize, usize, usize)>,
-    zskip_ch: usize,
-    zskip_fin: usize,
+    /// The z_skip transcript surface, by flavor — see [`ZskipTapeRec`].
+    zskip: ZskipTapeRec,
     zp_v: usize,
     /// The rs regions: (s_hat_v ordinal, r_dprime fin, r_dprime ch), plus
     /// the two rs gammas' `(fin, word offset)` and challenge ordinals — the
@@ -6218,17 +6226,18 @@ impl<'p> RealTape<'p> {
         // the tape cost halved when the second pass dissolved.
         let mut rec = RecordingChallenger::new(FsChallenger::with_chained_blake3(domain));
         let (mat_assert, el_assert, sigma_native, jag_assert, claims) = {
-            let (claims, work, sigma) = verifier::verify_ligerito_union_circuit_deferred(
-                &union_i,
-                &lo.shape.circuit,
-                &lo.public,
-                &lcs,
-                &lo.commitment,
-                &lo.proof,
-                &lo.pcs,
-                &mut rec,
-            )
-            .expect("the deferred verify accepts the leaf outer");
+            let (claims, work, sigma) = lo
+                .proof
+                .verify_circuit_deferred(
+                    &union_i,
+                    &lo.shape.circuit,
+                    &lo.public,
+                    &lcs,
+                    &lo.commitment,
+                    &lo.pcs,
+                    &mut rec,
+                )
+                .expect("the deferred verify accepts the leaf outer");
             assert!(
                 claims.boolean.is_some(),
                 "boolean claims from the real inner"
@@ -6291,7 +6300,24 @@ impl<'p> RealTape<'p> {
                 })
                 .collect()
         };
-        let zc_l = find(b"flock-zerocheck-v0");
+        // The boolean zerocheck region's anchor is flavor-specific; the
+        // OTHER flavor's label must be absent (one boolean zerocheck).
+        let zc_l = match &lo.proof {
+            MixedProof::Rs(_) => {
+                assert!(
+                    find(b"flock-ag-skip-v1").is_empty(),
+                    "an RS tape carries no AG-skip region"
+                );
+                find(b"flock-zerocheck-v0")
+            }
+            MixedProof::Ag(_) => {
+                assert!(
+                    find(b"flock-zerocheck-v0").is_empty(),
+                    "an AG tape carries no RS zerocheck region"
+                );
+                find(b"flock-ag-skip-v1")
+            }
+        };
         let lc_l = find(b"flock-lincheck-v0");
         let elzc_l = find(b"flock-element-union-zc-v0");
         let el_l = find(b"flock-element-union-lc-v0");
@@ -6329,7 +6355,7 @@ impl<'p> RealTape<'p> {
 
         // parse_open_levels + level_geometry — the assembly's own walkers,
         // unchanged, on the real-inner tape.
-        let lig = &lo.proof.pcs_open.inner.ligerito;
+        let lig = &lo.proof.pcs_open().inner.ligerito;
         let r = lig.recursive_caps.len();
         let lvl_src = level_sources(lig);
         let (start_v_i, piop_i, gammas_i, w_rounds, mp_i, inner_pd_i, yr_v_i, levels) =
@@ -6337,7 +6363,7 @@ impl<'p> RealTape<'p> {
         assert_eq!(levels.len(), r + 1);
         let piop_i = piop_i.expect("the real inner HAS an element PIOP");
         assert!(!piop_i.zc_rounds.is_empty() && !piop_i.lc_rounds.is_empty());
-        let n_gather = lo.proof.wiring.gather.len();
+        let n_gather = lo.proof.wiring().gather.len();
         assert_eq!(
             gammas_i.len(),
             2 + n_gather,
@@ -6357,7 +6383,7 @@ impl<'p> RealTape<'p> {
         );
 
         // The R=2 + P schedule replays to the anchor's claimed v.
-        let n_p = lo.proof.pcs_open.frobenius.group_values.len();
+        let n_p = lo.proof.pcs_open().frobenius.group_values.len();
         assert!(n_p > 0, "the mixed inner groups its pd claims");
         assert_eq!(
             mp_i.val_vs.len(),
@@ -6388,7 +6414,7 @@ impl<'p> RealTape<'p> {
         // the whole layer recursion natively in lockstep, input checks
         // included — the rhs consuming the DEFERRED s_sigma from the proof.
         let gkr_rec = {
-            let gkr = &lo.proof.wiring.gkr;
+            let gkr = &lo.proof.wiring().gkr;
             let mut i = gkr_l[0] + 1;
             while matches!(ops[i], Op::Pow { .. }) {
                 i += 1;
@@ -6669,7 +6695,7 @@ impl<'p> RealTape<'p> {
                 let (sv, _) = vc_at(i2);
                 assert_eq!(
                     &vals_rec[sv..sv + 128],
-                    &lo.proof.pcs_open.ring_switches[k].s_hat_v[..],
+                    &lo.proof.pcs_open().ring_switches[k].s_hat_v[..],
                     "s_hat_v {k} on the stream"
                 );
                 i2 += 1;
@@ -6733,7 +6759,7 @@ impl<'p> RealTape<'p> {
                 let g0 = running + g1;
                 running = g0 + (g1 + g0 + gi) * rc + gi * rc * rc;
             }
-            let fro = &lo.proof.pcs_open.frobenius;
+            let fro = &lo.proof.pcs_open().frobenius;
             let mut vrs = F128::ZERO;
             for (k, cs) in coeffs.iter().enumerate() {
                 for (j, &cj) in cs.iter().enumerate() {
@@ -6774,7 +6800,7 @@ impl<'p> RealTape<'p> {
         // whose 16-of-16 lanes make the commit exactly full) takes the
         // IDENTITY pairing, same as the native side's rotate gate and
         // ChildTape's conditional.
-        let yr_len = lo.proof.pcs_open.inner.ligerito.final_proof.yr.len() / 2;
+        let yr_len = lo.proof.pcs_open().inner.ligerito.final_proof.yr.len() / 2;
         let lane_major = geo[0].row_words < geo[0].lanes;
         let w_resid: Vec<RoundRec> = if lane_major {
             let k_rot = w_rounds.len() - levels[0].fold_fins.len();
@@ -6889,7 +6915,7 @@ impl<'p> RealTape<'p> {
             lo.shape.circuit.cells(),
             n_log_i,
             &lo.public,
-            &lo.proof.wiring.gather,
+            &lo.proof.wiring().gather,
             &gammas_i,
             2,
             &vals_rec,
@@ -6920,9 +6946,22 @@ impl<'p> RealTape<'p> {
         // The boolean PIOP's round ordinals, located with fins — plus the
         // MatrixAssertion surfaces the 2→1 merge connects to (z_skip's
         // squeeze, z_partial's slice).
+        // Byte-payload ordinal of the op at `end` (ObserveBytes and Pow
+        // share the payload counter — see [`bytes_payload_mask`]).
+        let payload_at = |end: usize| -> usize {
+            ops[..end]
+                .iter()
+                .filter(|o| {
+                    matches!(
+                        o,
+                        Op::ObserveBytes(_) | Op::Pow { .. } | Op::LegacyPow { .. }
+                    )
+                })
+                .count()
+        };
         let (
             zc_rounds_b,
-            (zskip_ch, zskip_fin),
+            zskip,
             (outer_ch_b, outer_fin_b, outer_len),
             bl_alpha,
             betas_b,
@@ -6939,24 +6978,74 @@ impl<'p> RealTape<'p> {
             while matches!(ops[i2], Op::Pow { .. }) {
                 i2 += 1;
             }
-            assert!(matches!(ops[i2], Op::SqueezeSlice(_)), "r_skip slice");
-            i2 += 1;
-            let outer_len = match ops[i2] {
-                Op::SqueezeSlice(n) => n,
-                ref o => panic!("r_outer slice, got {o:?}"),
+            // The flavored region head — the ChildTape walk's twin: RS has
+            // two squeeze slices + 64/64 round-1 + the fused z_skip
+            // squeeze; AG has ONE r_outer slice, 158/64 round-1, and r₁'s
+            // 5-op seed/nonce surface (the point has no transcript word).
+            let (outer, zskip) = match &lo.proof {
+                MixedProof::Rs(_) => {
+                    assert!(matches!(ops[i2], Op::SqueezeSlice(_)), "r_skip slice");
+                    i2 += 1;
+                    let outer_len = match ops[i2] {
+                        Op::SqueezeSlice(n) => n,
+                        ref o => panic!("r_outer slice, got {o:?}"),
+                    };
+                    let outer = (vc_at(i2).1, fin_at(i2), outer_len);
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::ObserveSlice(64)), "round1_ab");
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::ObserveSlice(64)), "round1_c");
+                    i2 += 1;
+                    while matches!(ops[i2], Op::Pow { .. }) {
+                        i2 += 1;
+                    }
+                    assert!(matches!(ops[i2], Op::SqueezeScalar), "z_skip");
+                    let zskip = ZskipTapeRec::Rs {
+                        ch: vc_at(i2).1,
+                        fin: fin_at(i2),
+                    };
+                    i2 += 1;
+                    (outer, zskip)
+                }
+                MixedProof::Ag(_) => {
+                    let outer_len = match ops[i2] {
+                        Op::SqueezeSlice(n) => n,
+                        ref o => panic!("ag r_outer slice, got {o:?}"),
+                    };
+                    let outer = (vc_at(i2).1, fin_at(i2), outer_len);
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::ObserveSlice(158)), "ag round1_ab");
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::ObserveSlice(64)), "ag round1_c");
+                    i2 += 1;
+                    assert!(
+                        matches!(&ops[i2], Op::Label(l) if l.as_slice() == b"flock-ag-skip-r1-point"),
+                        "ag r1 seed label"
+                    );
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::SqueezeScalar), "ag r1 seed s0");
+                    let seed_ch = vc_at(i2).1;
+                    let seed_fin0 = fin_at(i2);
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::SqueezeScalar), "ag r1 seed s1");
+                    assert_eq!(vc_at(i2).1, seed_ch + 1, "seed words are adjacent");
+                    let seed_fin1 = fin_at(i2);
+                    i2 += 1;
+                    assert!(
+                        matches!(&ops[i2], Op::Label(l) if l.as_slice() == b"flock-ag-skip-r1-nonce"),
+                        "ag r1 nonce label"
+                    );
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::ObserveBytes(4)), "ag r1 nonce bytes");
+                    let zskip = ZskipTapeRec::Ag {
+                        seed_ch,
+                        seed_fins: [seed_fin0, seed_fin1],
+                        nonce_payload: payload_at(i2),
+                    };
+                    i2 += 1;
+                    (outer, zskip)
+                }
             };
-            let outer = (vc_at(i2).1, fin_at(i2), outer_len);
-            i2 += 1;
-            assert!(matches!(ops[i2], Op::ObserveSlice(64)), "round1_ab");
-            i2 += 1;
-            assert!(matches!(ops[i2], Op::ObserveSlice(64)), "round1_c");
-            i2 += 1;
-            while matches!(ops[i2], Op::Pow { .. }) {
-                i2 += 1;
-            }
-            assert!(matches!(ops[i2], Op::SqueezeScalar), "z_skip");
-            let zskip = (vc_at(i2).1, fin_at(i2));
-            i2 += 1;
             let mut zc_r: Vec<(usize, usize)> = Vec::new();
             while matches!(ops[i2], Op::ObserveScalar) && matches!(ops[i2 + 1], Op::ObserveScalar) {
                 let mut squeeze_i = i2 + 2;
@@ -7039,7 +7128,28 @@ impl<'p> RealTape<'p> {
                     "rr {j} is the located lc round, reversed"
                 );
             }
-            assert_eq!(chals[zskip_ch], mat_assert.z_skip.phi8(), "z_skip located");
+            // The z_skip pin, by flavor: RS locates the fused squeeze; AG
+            // rebuilds the seed from the two located squeezes and pins the
+            // assertion's point to the fused H(seed ‖ nonce) decode.
+            match (&lo.proof, &zskip) {
+                (MixedProof::Rs(_), ZskipTapeRec::Rs { ch, .. }) => {
+                    assert_eq!(chals[*ch], mat_assert.z_skip.phi8(), "z_skip located");
+                }
+                (MixedProof::Ag(p), ZskipTapeRec::Ag { seed_ch, .. }) => {
+                    let nonce = p.boolean.as_ref().expect("boolean side present").ag.r1_nonce;
+                    let pt = decode_ag_point(
+                        &ag_seed_bytes(chals[*seed_ch], chals[*seed_ch + 1]),
+                        nonce,
+                        lo.pcs.zerocheck_grinding().ag_r1_bits(),
+                    );
+                    assert_eq!(
+                        mat_assert.z_skip,
+                        flock_core::lincheck::SkipPoint::Ag(pt),
+                        "z_skip is the r1 point decoded from the located seed + nonce"
+                    );
+                }
+                _ => unreachable!("the tape's zskip record matches the proof flavor"),
+            }
             assert_eq!(
                 &vals_rec[zp_v..zp_v + 64],
                 &mat_assert.z_partial[..],
@@ -7399,8 +7509,7 @@ impl<'p> RealTape<'p> {
             zc_finals_v,
             eps_n,
             lc_rounds_b,
-            zskip_ch,
-            zskip_fin,
+            zskip,
             zp_v,
             rs_recs: rs_recs2,
             rs_gam_fins: rs_gam_fin2,
@@ -7456,8 +7565,8 @@ struct RealRegion {
     /// side's shared constant publics).
     jag_sig_w: Vec<Wire>,
     jag_row_w: Vec<Vec<Wire>>,
-    /// The z_skip squeeze wire — see [`ChildRegion::zskip_w`].
-    zskip_w: Wire,
+    /// The z_skip surface, by flavor — see [`ZskipWires`].
+    zskip: ZskipWires,
     /// Every fresh claim in `sigma_native.claims()` as `(row, col, value)`
     /// wires, in accumulator order.
     structure_claim_w: Vec<(Vec<Wire>, Vec<Wire>, Wire)>,
@@ -8302,13 +8411,21 @@ fn emit_real_child_region(
             pw.push((cv2, w));
         }
     };
-    use flock_core::zerocheck::univariate_skip_optimized::{
-        medium_challenges_ghash, small_challenges_ghash,
+    // The c-point's 7 baked inner constants are the zerocheck's friendly
+    // challenges — the RS ghash set or the AG set, by the tape's flavor.
+    let t_vals_b: Vec<F128> = match &rt.zskip {
+        ZskipTapeRec::Rs { .. } => {
+            use flock_core::zerocheck::univariate_skip_optimized::{
+                medium_challenges_ghash, small_challenges_ghash,
+            };
+            let mut v: Vec<F128> = Vec::new();
+            v.extend_from_slice(&small_challenges_ghash());
+            v.extend_from_slice(&medium_challenges_ghash());
+            v
+        }
+        ZskipTapeRec::Ag { .. } => flock_core::zerocheck::ag_skip::friendly_challenges().to_vec(),
     };
-    let mut t_vals_b: Vec<F128> = Vec::new();
-    t_vals_b.extend_from_slice(&small_challenges_ghash());
-    t_vals_b.extend_from_slice(&medium_challenges_ghash());
-    assert_eq!(t_vals_b.len(), 7, "the seven baked ghash weights");
+    assert_eq!(t_vals_b.len(), 7, "the seven baked inner constants");
     let mlv_pw: Vec<(F128, Wire)> = rt
         .zc_rounds_b
         .iter()
@@ -8330,9 +8447,14 @@ fn emit_real_child_region(
             if k2 < 7 {
                 (t_vals_b[k2], cw(sb, vals, consts, t_vals_b[k2]))
             } else {
+                // The exact (row, word) map — a FUSED slice squeeze (the
+                // AG r_outer grind) reserves one word per row for the PoW
+                // predicate, so the naive 4-per-row split misaddresses.
                 let j = k2 - 7;
-                let sq2 = &trace.squeezes[outer_fin_b];
-                (chals[outer_ch_b + j], outs[sq2[j / 4]][j % 4])
+                (
+                    chals[outer_ch_b + j],
+                    squeeze_word_wire(&outs, trace, outer_fin_b, j),
+                )
             }
         })
         .collect();
@@ -8559,9 +8681,9 @@ fn emit_real_child_region(
     for &(_, _, fin) in &rt.lc_rounds_b {
         mat_pub.push(outs[trace.squeezes[fin][0]][0]);
     }
-    let bp_i = rt.lo.proof.boolean.as_ref().expect("boolean side present");
+    let lc_i = rt.lo.proof.boolean_lincheck();
     let mut mat_eval_w: Vec<(Wire, Wire)> = Vec::new();
-    for &(a, b) in &bp_i.lincheck.matrix_evals {
+    for &(a, b) in &lc_i.matrix_evals {
         vals.push(a);
         let aw = sb.public_input();
         vals.push(b);
@@ -8799,7 +8921,34 @@ fn emit_real_child_region(
         jag_w,
         jag_sig_w: mp_sig_w.clone(),
         jag_row_w,
-        zskip_w: outs[trace.squeezes[rt.zskip_fin][0]][0],
+        zskip: match &rt.zskip {
+            ZskipTapeRec::Rs { fin, .. } => ZskipWires::Rs(outs[trace.squeezes[*fin][0]][0]),
+            ZskipTapeRec::Ag {
+                seed_fins,
+                nonce_payload,
+                ..
+            } => {
+                let nonce_wi = rt
+                    .stream
+                    .words
+                    .iter()
+                    .position(|w| {
+                        matches!(
+                            w,
+                            flock_core::transcript_record::StreamWord::Bytes { payload, word: 0 }
+                                if *payload == *nonce_payload
+                        )
+                    })
+                    .expect("the r1 nonce rides one stream word");
+                ZskipWires::Ag {
+                    seed_w: [
+                        squeeze_word_wire(&outs, trace, seed_fins[0], 0),
+                        squeeze_word_wire(&outs, trace, seed_fins[1], 0),
+                    ],
+                    nonce_w: ww[nonce_wi].expect("the nonce payload word is wired"),
+                }
+            }
+        },
         n_ela_pub: ela_pub.len(),
         structure_claim_w,
         pt_w,
@@ -8879,7 +9028,7 @@ fn check_real_child_region(public: &[F128], rt: &RealTape<'_>, r: &RealRegion) -
     // no publics, no checker items; the proof itself carries them.
     let sig_base = sp_base + 4 + 2 * rt.levels.len() * rt.yr_len + 2;
     assert_eq!(
-        public[sig_base], rt.lo.proof.wiring.gkr.s_sigma_eval,
+        public[sig_base], rt.lo.proof.wiring().gkr.s_sigma_eval,
         "the emitted sigma value is the proof's deferred evaluation"
     );
     let sa = flock_core::circuit::SigmaAssertion {
@@ -8928,8 +9077,8 @@ fn check_real_child_region(public: &[F128], rt: &RealTape<'_>, r: &RealRegion) -
             "matrix point coord {j} is the located round wire"
         );
     }
-    let bp_i = rt.lo.proof.boolean.as_ref().expect("boolean side present");
-    for (j, &(a, b)) in bp_i.lincheck.matrix_evals.iter().enumerate() {
+    let lc_i = rt.lo.proof.boolean_lincheck();
+    for (j, &(a, b)) in lc_i.matrix_evals.iter().enumerate() {
         assert_eq!(
             (
                 public[mat_base + 1 + rt.lc_rounds_b.len() + 2 * j],
@@ -8941,7 +9090,7 @@ fn check_real_child_region(public: &[F128], rt: &RealTape<'_>, r: &RealRegion) -
     }
     // ROUND 0's extension: every remaining datum of the MatrixAssertion
     // equation, published and held against the assertion itself.
-    let mut mq = mat_base + 1 + rt.lc_rounds_b.len() + 2 * bp_i.lincheck.matrix_evals.len();
+    let mut mq = mat_base + 1 + rt.lc_rounds_b.len() + 2 * lc_i.matrix_evals.len();
     for (j, &x) in rt.mat_assert.x_inner_rest.iter().enumerate() {
         assert_eq!(public[mq + j], x, "x_inner_rest {j} published");
     }
@@ -9060,12 +9209,14 @@ fn check_real_child_region(public: &[F128], rt: &RealTape<'_>, r: &RealRegion) -
 /// (message words), so same-parameter instances share the CIRCUIT — and its
 /// digest, the key the accumulator folds sigma under — while their claims
 /// land at unrelated FS points, which is what a merge node actually sees.
-/// A chain leaf's proof by boolean-zerocheck FLAVOR — parallel arms so the
-/// RS deprecation endgame is arm-deletion, not surgery
-/// (docs/ag-recursion-plan.md). The element region, the wiring argument,
-/// and the merged open are shape-identical across flavors, so shared
-/// consumers read them through the accessors; only the zerocheck walk and
-/// its z_skip surface match on the arm.
+/// A circuit-union proof by boolean-zerocheck FLAVOR — parallel arms so
+/// the RS deprecation endgame is arm-deletion, not surgery
+/// (docs/ag-recursion-plan.md). Carried by the chain leaf ([`MixedInner`])
+/// AND the envelope outers ([`LeafOuter`]). The element region, the wiring
+/// argument, and the merged open are shape-identical across flavors, so
+/// shared consumers read them through the accessors; only the zerocheck
+/// walk and its z_skip surface match on the arm.
+#[derive(serde::Serialize)]
 enum MixedProof {
     Rs(flock_core::proof::R1csProofCircuitMerged),
     /// Constructed only where the AG round-1 prover kernel exists
@@ -9091,6 +9242,64 @@ impl MixedProof {
         match self {
             MixedProof::Rs(p) => p.element.as_ref(),
             MixedProof::Ag(p) => p.element.as_ref(),
+        }
+    }
+    /// The boolean LINCHECK sub-proof — flavor-shared (both boolean proof
+    /// structs carry it verbatim; only round 1 differs).
+    fn boolean_lincheck(&self) -> &flock_core::lincheck::LincheckProof {
+        match self {
+            MixedProof::Rs(p) => &p.boolean.as_ref().expect("boolean side present").lincheck,
+            MixedProof::Ag(p) => &p.boolean.as_ref().expect("boolean side present").lincheck,
+        }
+    }
+    /// The plain (assertions-discharged) circuit verify, flavor-dispatched.
+    #[allow(clippy::too_many_arguments)]
+    fn verify_circuit<Ch: flock_core::challenger::Challenger>(
+        &self,
+        union: &UnionInstance<'_>,
+        circuit: &flock_core::circuit::Circuit,
+        public: &[F128],
+        lcs: &[&dyn flock_core::lincheck::LincheckCircuit],
+        commitment: &flock_core::pcs::commit::Commitment,
+        pcs: &PcsParams,
+        ch: &mut Ch,
+    ) -> Result<flock_core::proof::UnionClassClaims, flock_core::verifier::VerifyError> {
+        match self {
+            MixedProof::Rs(p) => verifier::verify_ligerito_union_circuit(
+                union, circuit, public, lcs, commitment, p, pcs, ch,
+            ),
+            MixedProof::Ag(p) => verifier::verify_ligerito_union_circuit_ag(
+                union, circuit, public, lcs, commitment, p, pcs, ch,
+            ),
+        }
+    }
+    /// The DEFERRED circuit verify (assertions returned, not discharged),
+    /// flavor-dispatched — what the recursion tapes record.
+    #[allow(clippy::too_many_arguments)]
+    fn verify_circuit_deferred<Ch: flock_core::challenger::Challenger>(
+        &self,
+        union: &UnionInstance<'_>,
+        circuit: &flock_core::circuit::Circuit,
+        public: &[F128],
+        lcs: &[&dyn flock_core::lincheck::LincheckCircuit],
+        commitment: &flock_core::pcs::commit::Commitment,
+        pcs: &PcsParams,
+        ch: &mut Ch,
+    ) -> Result<
+        (
+            flock_core::proof::UnionClassClaims,
+            flock_core::verifier::DeferredMatrixWork,
+            flock_core::circuit::SigmaAssertion,
+        ),
+        flock_core::verifier::VerifyError,
+    > {
+        match self {
+            MixedProof::Rs(p) => verifier::verify_ligerito_union_circuit_deferred(
+                union, circuit, public, lcs, commitment, p, pcs, ch,
+            ),
+            MixedProof::Ag(p) => verifier::verify_ligerito_union_circuit_ag_deferred(
+                union, circuit, public, lcs, commitment, p, pcs, ch,
+            ),
         }
     }
 }
@@ -10999,29 +11208,48 @@ pub fn build_fl_node_k(cfg: TowerConfig, cps: &[&ChainProof]) -> FlNode {
             let asm_ms = t_asm.elapsed().as_secs_f64() * 1e3;
             let t_prove = std::time::Instant::now();
             let mut ch2 = FsChallenger::with_chained_blake3(DOMAIN);
-            let (oproof, ocommit, _) = prover::prove_fast_ligerito_union_circuit(
-                &union2,
-                &shape2.circuit,
-                &built2.public,
-                &pcs2,
-                bslots.into_iter().map(|(_, x)| x).collect(),
-                el_inputs,
-                &mut ch2,
-            );
+            let (oproof, ocommit) = if outer_zc_ag() {
+                #[cfg(target_arch = "aarch64")]
+                {
+                    let (p, c, _) = prover::prove_fast_ligerito_union_circuit_ag(
+                        &union2,
+                        &shape2.circuit,
+                        &built2.public,
+                        &pcs2,
+                        bslots.into_iter().map(|(_, x)| x).collect(),
+                        el_inputs,
+                        &mut ch2,
+                    );
+                    (MixedProof::Ag(p), c)
+                }
+                #[cfg(not(target_arch = "aarch64"))]
+                unreachable!("outer_zc_ag() is false off aarch64")
+            } else {
+                let (p, c, _) = prover::prove_fast_ligerito_union_circuit(
+                    &union2,
+                    &shape2.circuit,
+                    &built2.public,
+                    &pcs2,
+                    bslots.into_iter().map(|(_, x)| x).collect(),
+                    el_inputs,
+                    &mut ch2,
+                );
+                (MixedProof::Rs(p), c)
+            };
             let prove_ms = t_prove.elapsed().as_secs_f64() * 1e3;
             let t_ver = std::time::Instant::now();
             let mut ch2 = FsChallenger::with_chained_blake3(DOMAIN);
-            verifier::verify_ligerito_union_circuit(
-                &union2,
-                &shape2.circuit,
-                &built2.public,
-                &lcs2,
-                &ocommit,
-                &oproof,
-                &pcs2,
-                &mut ch2,
-            )
-            .expect("the first-level node verifies over the circuit path");
+            oproof
+                .verify_circuit(
+                    &union2,
+                    &shape2.circuit,
+                    &built2.public,
+                    &lcs2,
+                    &ocommit,
+                    &pcs2,
+                    &mut ch2,
+                )
+                .expect("the first-level node verifies over the circuit path");
             let verify_ms2 = t_ver.elapsed().as_secs_f64() * 1e3;
             onlines.push(Online {
                 setup_ms: build_ms,
@@ -16079,17 +16307,17 @@ fn record_child_verify(lo: &LeafOuter, domain: &'static [u8]) {
     let union_i = outer_union(&lo.shape.registry, lo.shape.counts.clone());
     let lcs = leaf_boolean_lcs(lo);
     let mut rec = RecordingChallenger::new(FsChallenger::with_chained_blake3(domain));
-    verifier::verify_ligerito_union_circuit_deferred(
-        &union_i,
-        &lo.shape.circuit,
-        &lo.public,
-        &lcs,
-        &lo.commitment,
-        &lo.proof,
-        &lo.pcs,
-        &mut rec,
-    )
-    .expect("the child verifies (recorded)");
+    lo.proof
+        .verify_circuit_deferred(
+            &union_i,
+            &lo.shape.circuit,
+            &lo.public,
+            &lcs,
+            &lo.commitment,
+            &lo.pcs,
+            &mut rec,
+        )
+        .expect("the child verifies (recorded)");
 }
 
 /// A node's PUBLISHED ACC_MAIN block, entry for entry — the surface a
@@ -17244,22 +17472,31 @@ pub fn build_node_outer_app(
         // in-circuit derivation adds).
         use flock_core::field::PHI_8_TABLE;
         use flock_core::zerocheck::K_SKIP;
-        use flock_core::zerocheck::multilinear::{
-            lagrange_weights_naive, subspace_denominator_pair,
-        };
-        let lam_base = sb.public_len();
-        let lam_w: Vec<Wire> = PHI_8_TABLE[..1 << K_SKIP]
+        use flock_core::zerocheck::multilinear::subspace_denominator_pair;
+        // The RS lows machinery is emitted only when an RS child consumes
+        // it; AG children take the Tier-0 published surface instead.
+        let any_rs = rts
             .iter()
-            .map(|&v| {
-                vals.push(v);
-                sb.public_input()
-            })
-            .collect();
-        vals.push(subspace_denominator_pair(K_SKIP).1);
-        let deninv_w = sb.public_input();
-        // The lows' assert-zero anchor: producers only, no consumer edges.
-        vals.push(F128::ZERO);
-        let lag_zassert = sb.public_input();
+            .any(|tk| matches!(tk.zskip, ZskipTapeRec::Rs { .. }));
+        let rs_lam: Option<(usize, Vec<Wire>, Wire, Wire)> = any_rs.then(|| {
+            let lam_base = sb.public_len();
+            let lam_w: Vec<Wire> = PHI_8_TABLE[..1 << K_SKIP]
+                .iter()
+                .map(|&v| {
+                    vals.push(v);
+                    sb.public_input()
+                })
+                .collect();
+            vals.push(subspace_denominator_pair(K_SKIP).1);
+            let deninv_w = sb.public_input();
+            // The lows' assert-zero anchor: producers only, no consumers.
+            vals.push(F128::ZERO);
+            let lag_zassert = sb.public_input();
+            (lam_base, lam_w, deninv_w, lag_zassert)
+        });
+        // Per AG child, the Tier-0 public block's base — the layout
+        // [`check_ag_skip_publics`] walks.
+        let mut ag_pub_bases: Vec<Option<usize>> = Vec::new();
         // THE PRIOR's uniform surfaces (the spine): claim 0 of every group.
         // The registry-keyed matrix entries ride in exactly as the lane's
         // priors do — LOWS to the child's live word, points and value
@@ -17306,28 +17543,73 @@ pub fn build_node_outer_app(
             0
         };
         for (k, (tk, rk)) in rts.iter().zip(&regions).enumerate() {
-            // The lagrange row lows, IN-CIRCUIT from the child's z_skip wire
-            // (native pre-assert first: the fold's absorbed lows ARE the closed
-            // form at the located z_skip).
+            // Basis-generic native pre-assert: the fold's absorbed lows
+            // ARE the skip functional at the child's own z_skip point.
             assert_eq!(
                 &fold_claims[0][cj + k].row.low[..],
-                &lagrange_weights_naive(K_SKIP, tk.chals[tk.zskip_ch])[..],
-                "child {k}: the fold's lagrange lows are the closed form"
+                &tk.mat_assert.z_skip.weights(K_SKIP)[..],
+                "child {k}: the fold's row lows are the skip functional"
             );
-            let lows = emit_lagrange_lows(
-                &mut sb,
-                cs.macs,
-                &lam_w,
-                deninv_w,
-                rk.zskip_w,
-                tk.chals[tk.zskip_ch],
-                &mut vals,
-                zw,
-                ow,
-                lag_zassert,
-            );
-            for (j, &lw2) in lows.iter().enumerate() {
-                sb.connect(lw2, wv(locs[0].claims[cj + k].row_low_v + j));
+            match (&tk.zskip, &rk.zskip) {
+                (ZskipTapeRec::Rs { ch, .. }, ZskipWires::Rs(zskip_w)) => {
+                    let (_, lam_w, deninv_w, lag_zassert) =
+                        rs_lam.as_ref().expect("the RS lows machinery is emitted");
+                    let lows = emit_lagrange_lows(
+                        &mut sb,
+                        cs.macs,
+                        lam_w,
+                        *deninv_w,
+                        *zskip_w,
+                        tk.chals[*ch],
+                        &mut vals,
+                        zw,
+                        ow,
+                        *lag_zassert,
+                    );
+                    for (j, &lw2) in lows.iter().enumerate() {
+                        sb.connect(lw2, wv(locs[0].claims[cj + k].row_low_v + j));
+                    }
+                    ag_pub_bases.push(None);
+                }
+                (ZskipTapeRec::Ag { seed_ch, .. }, ZskipWires::Ag { seed_w, nonce_w }) => {
+                    // Tier 0 (docs/ag-recursion-plan.md): publish the whole
+                    // surface — seed and nonce CONNECTED to the child's
+                    // transcript wires, the point as advice, and the fold's
+                    // absorbed row lows word-for-word — and let the native
+                    // checker re-derive the point and the lows.
+                    let base = sb.public_len();
+                    for (v, src) in [
+                        (tk.chals[*seed_ch], seed_w[0]),
+                        (tk.chals[*seed_ch + 1], seed_w[1]),
+                    ] {
+                        vals.push(v);
+                        let w = sb.public_input();
+                        sb.connect(w, src);
+                    }
+                    let nonce = match &tk.lo.proof {
+                        MixedProof::Ag(p) => {
+                            p.boolean.as_ref().expect("boolean side present").ag.r1_nonce
+                        }
+                        MixedProof::Rs(_) => unreachable!("an AG tape carries an AG proof"),
+                    };
+                    vals.push(F128::new(u64::from(nonce), 0));
+                    let w = sb.public_input();
+                    sb.connect(w, *nonce_w);
+                    let flock_core::lincheck::SkipPoint::Ag(pt) = tk.mat_assert.z_skip else {
+                        unreachable!("an AG tape carries an AG skip point")
+                    };
+                    for c in [pt.x, pt.y, pt.z1, pt.z2, pt.z3] {
+                        vals.push(c);
+                        sb.public_input();
+                    }
+                    for (j, &lv) in fold_claims[0][cj + k].row.low.iter().enumerate() {
+                        vals.push(lv);
+                        let lw2 = sb.public_input();
+                        sb.connect(lw2, wv(locs[0].claims[cj + k].row_low_v + j));
+                    }
+                    ag_pub_bases.push(Some(base));
+                }
+                _ => unreachable!("the region's zskip wires match the tape flavor"),
             }
             // Native pre-asserts (the method-note discipline).
             for t in 0..n_bool {
@@ -18230,22 +18512,36 @@ pub fn build_node_outer_app(
             // The lagrange-low constants: the one public surface the in-circuit
             // derivation adds — validated against the verifier's own values.
             {
-                for (i, &v) in PHI_8_TABLE[..1 << K_SKIP].iter().enumerate() {
-                    assert_eq!(built2.public[lam_base + i], v, "λ const {i}");
+                if let Some((lam_base, _, _, _)) = &rs_lam {
+                    for (i, &v) in PHI_8_TABLE[..1 << K_SKIP].iter().enumerate() {
+                        assert_eq!(built2.public[*lam_base + i], v, "λ const {i}");
+                    }
+                    assert_eq!(
+                        built2.public[*lam_base + (1 << K_SKIP)],
+                        subspace_denominator_pair(K_SKIP).1,
+                        "the subspace denominator inverse const"
+                    );
+                    assert_eq!(
+                        built2.public[*lam_base + (1 << K_SKIP) + 1],
+                        F128::ZERO,
+                        "the lows' assert-zero anchor"
+                    );
+                }
+                // The Tier-0 AG-skip blocks: point re-derived from the
+                // published (seed, nonce) under the child's grinding
+                // schedule, row lows re-derived from the point.
+                for (lo_c, base) in los.iter().zip(&ag_pub_bases) {
+                    if let Some(base) = base {
+                        check_ag_skip_publics(
+                            &built2.public,
+                            *base,
+                            lo_c.pcs.zerocheck_grinding().ag_r1_bits(),
+                        );
+                    }
                 }
                 for &(v, idx) in &jag_const_rec {
                     assert_eq!(built2.public[idx], v, "jagged shared constant public");
                 }
-                assert_eq!(
-                    built2.public[lam_base + (1 << K_SKIP)],
-                    subspace_denominator_pair(K_SKIP).1,
-                    "the subspace denominator inverse const"
-                );
-                assert_eq!(
-                    built2.public[lam_base + (1 << K_SKIP) + 1],
-                    F128::ZERO,
-                    "the lows' assert-zero anchor"
-                );
                 // UNDER the envelope the publish blocks live on the reserved
                 // tail, so the body simply has to fit — which
                 // `pad_envelope_counts` asserts — and the tail layout is
@@ -18424,25 +18720,43 @@ pub fn build_node_outer_app(
             let asm_ms = t_asm.elapsed().as_secs_f64() * 1e3;
             let t0p = std::time::Instant::now();
             let mut ch2 = FsChallenger::with_chained_blake3(DOMAIN);
-            let (oproof, ocommit, _) = prover::prove_fast_ligerito_union_circuit(
-                &union2,
-                &shape2.circuit,
-                &built2.public,
-                &pcs2,
-                bslots.into_iter().map(|(_, x)| x).collect(),
-                el_inputs,
-                &mut ch2,
-            );
+            let (oproof, ocommit) = if outer_zc_ag() {
+                #[cfg(target_arch = "aarch64")]
+                {
+                    let (p, c, _) = prover::prove_fast_ligerito_union_circuit_ag(
+                        &union2,
+                        &shape2.circuit,
+                        &built2.public,
+                        &pcs2,
+                        bslots.into_iter().map(|(_, x)| x).collect(),
+                        el_inputs,
+                        &mut ch2,
+                    );
+                    (MixedProof::Ag(p), c)
+                }
+                #[cfg(not(target_arch = "aarch64"))]
+                unreachable!("outer_zc_ag() is false off aarch64")
+            } else {
+                let (p, c, _) = prover::prove_fast_ligerito_union_circuit(
+                    &union2,
+                    &shape2.circuit,
+                    &built2.public,
+                    &pcs2,
+                    bslots.into_iter().map(|(_, x)| x).collect(),
+                    el_inputs,
+                    &mut ch2,
+                );
+                (MixedProof::Rs(p), c)
+            };
             let prove_ms = t0p.elapsed().as_secs_f64() * 1e3;
             let t0v = std::time::Instant::now();
             let mut ch2 = FsChallenger::with_chained_blake3(DOMAIN);
-            let vres = verifier::verify_ligerito_union_circuit(
+            let vres = oproof.verify_circuit(
                 &union2,
                 &shape2.circuit,
                 &built2.public,
                 &lcs2,
                 &ocommit,
-                &oproof,
                 &pcs2,
                 &mut ch2,
             );
@@ -18469,17 +18783,17 @@ pub fn build_node_outer_app(
             } else {
                 let t0d = std::time::Instant::now();
                 let mut ch2 = FsChallenger::with_chained_blake3(DOMAIN);
-                verifier::verify_ligerito_union_circuit_deferred(
-                    &union2,
-                    &shape2.circuit,
-                    &built2.public,
-                    &lcs2,
-                    &ocommit,
-                    &oproof,
-                    &pcs2,
-                    &mut ch2,
-                )
-                .expect("the 2->1 node verifies deferred");
+                oproof
+                    .verify_circuit_deferred(
+                        &union2,
+                        &shape2.circuit,
+                        &built2.public,
+                        &lcs2,
+                        &ocommit,
+                        &pcs2,
+                        &mut ch2,
+                    )
+                    .expect("the 2->1 node verifies deferred");
                 t0d.elapsed().as_secs_f64() * 1e3
             };
             let b3_live: Vec<usize> = std::iter::once(cs.q.b3)
@@ -18997,17 +19311,17 @@ fn chain_spine_converges() {
         let u = outer_union(&lo.shape.registry, lo.shape.counts.clone());
         let lcs = leaf_boolean_lcs(lo);
         let mut ch = FsChallenger::with_chained_blake3(DOMAIN);
-        verifier::verify_ligerito_union_circuit(
-            &u,
-            &lo.shape.circuit,
-            publics,
-            &lcs,
-            &lo.commitment,
-            &lo.proof,
-            &lo.pcs,
-            &mut ch,
-        )
-        .is_ok()
+        lo.proof
+            .verify_circuit(
+                &u,
+                &lo.shape.circuit,
+                publics,
+                &lcs,
+                &lo.commitment,
+                &lo.pcs,
+                &mut ch,
+            )
+            .is_ok()
     };
     // (a) THE FORGED LIVE FOLD — the load-bearing leg. A cheating node_3
     // re-witnesses the match-gate to claim the D_base entry MATCHES and
@@ -19216,17 +19530,18 @@ fn chain_tower_e2e_with_lane() {
         bad[fl0.stmt_base + 4] += F128::ONE;
         let mut ch = FsChallenger::with_chained_blake3(DOMAIN);
         assert!(
-            verifier::verify_ligerito_union_circuit(
-                &union_f,
-                &fl0.lo.shape.circuit,
-                &bad,
-                &lcs_f,
-                &fl0.lo.commitment,
-                &fl0.lo.proof,
-                &fl0.lo.pcs,
-                &mut ch,
-            )
-            .is_err(),
+            fl0.lo
+                .proof
+                .verify_circuit(
+                    &union_f,
+                    &fl0.lo.shape.circuit,
+                    &bad,
+                    &lcs_f,
+                    &fl0.lo.commitment,
+                    &fl0.lo.pcs,
+                    &mut ch,
+                )
+                .is_err(),
             "a tampered FL h_end must be rejected"
         );
     }
@@ -19286,17 +19601,17 @@ fn chain_tower_e2e_with_lane() {
         bad[app + 7] += F128::ONE;
         let mut ch = FsChallenger::with_chained_blake3(DOMAIN);
         assert!(
-            verifier::verify_ligerito_union_circuit(
-                &union_n,
-                &node.shape.circuit,
-                &bad,
-                &lcs_n,
-                &node.commitment,
-                &node.proof,
-                &node.pcs,
-                &mut ch,
-            )
-            .is_err(),
+            node.proof
+                .verify_circuit(
+                    &union_n,
+                    &node.shape.circuit,
+                    &bad,
+                    &lcs_n,
+                    &node.commitment,
+                    &node.pcs,
+                    &mut ch,
+                )
+                .is_err(),
             "a tampered internal h_end must be rejected"
         );
     }
@@ -19457,9 +19772,9 @@ fn chain_tower_m32_headline() {
             .unwrap_or(0) as f64
             / 1024.0,
     );
-    proof_census("internal node", &node.proof, &node.pcs);
+    proof_census_mixed("internal node", &node.proof, &node.pcs);
     proof_census_mixed("chain leaf (m32 Fast)", &cp0.inner.proof, &cp0.inner.pcs);
-    proof_census("FL node", &fl0.lo.proof, &fl0.lo.pcs);
+    proof_census_mixed("FL node", &fl0.lo.proof, &fl0.lo.pcs);
 }
 
 /// **THE ONLINE BENCH: leaf, first-level node, internal node.** One number

--- a/crates/flock-prover/src/tower.rs
+++ b/crates/flock-prover/src/tower.rs
@@ -10735,13 +10735,13 @@ pub fn build_fl_node_k(cfg: TowerConfig, cps: &[&ChainProof]) -> FlNode {
                     ag_pub_bases.push(None);
                 }
                 (ZskipTapeRec::Ag { seed_ch, .. }, ZskipWires::Ag { seed_w, nonce_w }) => {
-                    // Tier 0: the AG point has no transcript word and no
-                    // in-circuit derivation yet (Phase D's emit_ag_lows),
-                    // so publish the whole surface — seed and nonce
-                    // CONNECTED to the child's transcript wires, the point
-                    // as advice, and the fold's absorbed row lows
-                    // word-for-word — and let the native checker re-derive
-                    // the point and the lows.
+                    // TIER 1 (phase D): publish [seed₂, nonce, point₅,
+                    // lows₆₄] — seed/nonce/lows wire-connected as before —
+                    // and BIND the point in-circuit
+                    // ([`emit_ag_point_binding`]: the two BLAKE3 decode
+                    // rows, the fused-PoW row, the fiber algebra over the
+                    // published coordinate wires). The native checker keeps
+                    // only `lows == bf(point)`.
                     let base = sb.public_len();
                     for (v, src) in [
                         (tk.chals[*seed_ch], seed_w[0]),
@@ -10763,15 +10763,33 @@ pub fn build_fl_node_k(cfg: TowerConfig, cps: &[&ChainProof]) -> FlNode {
                     let flock_core::lincheck::SkipPoint::Ag(pt) = tk.bool_assert.z_skip else {
                         unreachable!("an AG tape carries an AG skip point")
                     };
-                    for c in [pt.x, pt.y, pt.z1, pt.z2, pt.z3] {
+                    let pt_w: [Wire; 5] = [pt.x, pt.y, pt.z1, pt.z2, pt.z3].map(|c| {
                         vals.push(c);
-                        sb.public_input();
-                    }
+                        sb.public_input()
+                    });
                     for (j, &lv) in fold_claims[0][n_priors + k].row.low.iter().enumerate() {
                         vals.push(lv);
                         let lw2 = sb.public_input();
                         sb.connect(lw2, wv(locs[0].claims[n_priors + k].row_low_v + j));
                     }
+                    emit_ag_point_binding(
+                        &mut sb,
+                        cs.q.b3,
+                        cs.q.pow,
+                        cs.macs,
+                        iv2,
+                        *seed_w,
+                        *nonce_w,
+                        &pt_w,
+                        [tk.chals[*seed_ch], tk.chals[*seed_ch + 1]],
+                        nonce,
+                        &pt,
+                        cps[k].inner.pcs.zerocheck_grinding().ag_r1_bits(),
+                        &mut vals,
+                        &mut consts,
+                        zw,
+                        ow,
+                    );
                     ag_pub_bases.push(Some(base));
                 }
                 _ => unreachable!("the region's zskip wires match the tape flavor"),
@@ -11065,17 +11083,10 @@ pub fn build_fl_node_k(cfg: TowerConfig, cps: &[&ChainProof]) -> FlNode {
                     assert_eq!(built2.public[*lam_base + i], v, "λ const {i}");
                 }
             }
-            // The Tier-0 AG-skip blocks: point re-derived from the
-            // published (seed, nonce) under the child's grinding schedule,
-            // row lows re-derived from the point.
-            for (cp, base) in cps.iter().zip(&ag_pub_bases) {
-                if let Some(base) = base {
-                    check_ag_skip_publics(
-                        &built2.public,
-                        *base,
-                        cp.inner.pcs.zerocheck_grinding().ag_r1_bits(),
-                    );
-                }
+            // The AG-skip blocks: the decode is in-circuit since phase D;
+            // the checker holds the row lows to the published point.
+            for base in ag_pub_bases.iter().flatten() {
+                check_ag_skip_publics(&built2.public, *base);
             }
             for &(v, idx) in &jag_const_rec {
                 assert_eq!(built2.public[idx], v, "jagged shared constant public");
@@ -11791,6 +11802,277 @@ fn emit_element_reported_check(
 }
 
 /// **THE LAGRANGE ROW LOWS in-circuit (round 4).** The 64 weights
+/// PHASE D (docs/ag-recursion-plan.md): the AG z_skip point's IN-CIRCUIT
+/// binding — the Tier-1 successor of the Tier-0 decode checker. From the
+/// child's transcript wires (the two seed squeezes and the absorbed 4-byte
+/// nonce), two BLAKE3 rows recompute the nonce-seed `ns = H(seed ‖ nonce)`
+/// and its first XOF block; a PowMask row enforces the fused grinding
+/// target on `ns[16..32]` (the Phase-A convention alignment cashing in);
+/// and the published point coordinates are constrained to a fiber point
+/// over the XOF-derived `x`:
+///
+///   x = XOF word 0                       (a wire connect)
+///   t² + t = x³ + x                      (advice t — the factored base
+///   y² + u·y = x·u·t,   u = x + 1        fiber with s eliminated: y = u·s
+///                                        turns both AS levels inverse-free)
+///   D₀·(z₁² + z₁) = Σⱼ P₀ⱼ(x)·yʲ         (denominators cleared; D₀, D₁
+///   D₀D₁·(z₂² + z₂) = D₁·Σⱼ<₃ P₁ⱼ·yʲ     guarded nonzero by advice
+///                       + D₀·P₁₃·y³       inverses against a fixed ONE)
+///   D₀·(z₃² + z₃) = Σⱼ P₂ⱼ(x)·yʲ
+///
+/// CANONICITY IS RELAXED BY DESIGN: any of the ≤ 32 fiber points over `x`
+/// satisfies these rows — the sampler's slot/choice bits are deliberately
+/// unbound, and the fiber's 5 bits of prover freedom are repaid by the
+/// all-explicit `R1_POW_BITS = 9` fused target (the schedule constant
+/// moved with this emitter; the total stays `bits_for(474)`). The one
+/// checker item left on this surface is `lows == bf(point)`
+/// ([`check_ag_skip_publics`]).
+#[allow(clippy::too_many_arguments)]
+fn emit_ag_point_binding(
+    sb: &mut ShapeBuilder,
+    b3: flock_core::circuit::builder::SlotId,
+    pow: flock_core::circuit::builder::SlotId,
+    macs: flock_core::circuit::builder::SlotId,
+    iv: [Wire; 2],
+    seed_w: [Wire; 2],
+    nonce_w: Wire,
+    pt_w: &[Wire; 5],
+    seed_n: [F128; 2],
+    nonce_n: u32,
+    pt_n: &flock_core::genus95_curve_code::EvaluationPoint,
+    ag_r1_bits: Option<u32>,
+    vals: &mut Vec<F128>,
+    consts: &mut Vec<(F128, Wire)>,
+    zw: Wire,
+    ow: Wire,
+) {
+    use crate::r1cs_hashes::blake3 as b3m;
+    let flags = CHUNK_START | CHUNK_END | ROOT;
+    // ---- native replicas of the decode chain the rows must reproduce ----
+    let seed_bytes = ag_seed_bytes(seed_n[0], seed_n[1]);
+    let mut block36 = [0u8; 64];
+    block36[..32].copy_from_slice(&seed_bytes);
+    block36[32..36].copy_from_slice(&nonce_n.to_le_bytes());
+    let words36: [u32; 16] =
+        std::array::from_fn(|i| u32::from_le_bytes(block36[4 * i..4 * i + 4].try_into().unwrap()));
+    let ns16 = b3m::blake3_compress(&IV, &words36, 0, 36, flags);
+    let ns_bytes: [u8; 32] = std::array::from_fn(|i| (ns16[i / 4] >> (8 * (i % 4))) as u8);
+    let mut block32 = [0u8; 64];
+    block32[..32].copy_from_slice(&ns_bytes);
+    let words32: [u32; 16] =
+        std::array::from_fn(|i| u32::from_le_bytes(block32[4 * i..4 * i + 4].try_into().unwrap()));
+    let xof16 = b3m::blake3_compress(&IV, &words32, 0, 32, flags);
+    let x_native = F128::new(
+        u64::from(xof16[0]) | (u64::from(xof16[1]) << 32),
+        u64::from(xof16[2]) | (u64::from(xof16[3]) << 32),
+    );
+    assert_eq!(x_native, pt_n.x, "the XOF x is the point's x");
+    if let Some(bits) = ag_r1_bits {
+        assert!(
+            flock_core::challenger::has_leading_zero_bits(&ns_bytes[16..32], bits),
+            "the honest nonce clears the fused target"
+        );
+    }
+    let (x, y) = (pt_n.x, pt_n.y);
+    let u_n = x + F128::ONE;
+    let t_n = if x == F128::ZERO || u_n == F128::ZERO {
+        F128::ZERO
+    } else {
+        let s = y * u_n.inv();
+        u_n * (s * s + s) * x.inv()
+    };
+    assert_eq!(t_n * t_n + t_n, x * x * x + x, "t solves the base AS level");
+    assert_eq!(y * y + u_n * y, x * u_n * t_n, "y sits on the fiber over x");
+    let mut xp = [F128::ONE; 12];
+    for d in 1..12 {
+        xp[d] = xp[d - 1] * x;
+    }
+    let d0_n = xp[10] + xp[4] + F128::ONE;
+    let d1_n = xp[11] + xp[10] + xp[5] + xp[4] + xp[1] + F128::ONE;
+    let (d0_inv_n, d1_inv_n) = (
+        d0_n.inv(), // the honest decode rejected D₀ = 0 nonces
+        d1_n.inv(),
+    );
+    // Native replicas of the cleared AS equations (mirroring the sampler's
+    // rhs masks) — the method-note discipline before the rows land.
+    let pv = |degs: &[usize], plus_one: bool| -> F128 {
+        degs.iter().fold(
+            if plus_one { F128::ONE } else { F128::ZERO },
+            |acc, &d| acc + xp[d],
+        )
+    };
+    let yp_n = [F128::ONE, y, y * y, y * y * y];
+    let z_n = [pt_n.z1, pt_n.z2, pt_n.z3];
+    for (i, (zi, p)) in [
+        (
+            z_n[0],
+            [
+                pv(&[9, 6, 5, 4, 3, 2], false),
+                pv(&[5, 4, 3, 2], true),
+                pv(&[4, 3, 2], false),
+                pv(&[3], true),
+            ],
+        ),
+        (
+            z_n[2],
+            [
+                pv(&[6, 4, 3, 2], false),
+                pv(&[5], true),
+                pv(&[3, 2, 1], true),
+                pv(&[3, 2], false),
+            ],
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let rhs: F128 = (0..4).fold(F128::ZERO, |acc, j| acc + p[j] * yp_n[j]);
+        assert_eq!(
+            d0_n * (zi * zi + zi),
+            rhs,
+            "cleared AS level {} closes at the honest point",
+            [1, 3][i]
+        );
+    }
+    {
+        let p1_n = [
+            pv(&[8, 5, 4, 3, 2, 1], false),
+            pv(&[6, 5, 2, 1], false),
+            pv(&[3, 1], false),
+            pv(&[4, 2, 1], false),
+        ];
+        let inner: F128 = (0..3).fold(F128::ZERO, |acc, j| acc + p1_n[j] * yp_n[j]);
+        assert_eq!(
+            d0_n * d1_n * (z_n[1] * z_n[1] + z_n[1]),
+            d1_n * inner + d0_n * p1_n[3] * yp_n[3],
+            "cleared AS level 2 closes at the honest point"
+        );
+    }
+
+    // ---- the two BLAKE3 rows + the fused-PoW row ----
+    let params36 = cw(sb, vals, consts, pack_params(0, 36, flags));
+    let ns_out = sb.gate(
+        b3,
+        &[iv[0], iv[1], seed_w[0], seed_w[1], nonce_w, zw, params36],
+    );
+    let params32 = cw(sb, vals, consts, pack_params(0, 32, flags));
+    let xof_out = sb.gate(
+        b3,
+        &[iv[0], iv[1], ns_out[0], ns_out[1], zw, zw, params32],
+    );
+    sb.connect(xof_out[0], pt_w[0]);
+    if let Some(bits) = ag_r1_bits {
+        emit_pow_checks(
+            sb,
+            b3,
+            pow,
+            iv,
+            &[([ns_out[1], nonce_w], bits)],
+            vals,
+            consts,
+        );
+    }
+
+    // ---- the fiber algebra over the published point wires ----
+    let zass = cw(sb, vals, consts, F128::ZERO);
+    let one_w = cw(sb, vals, consts, F128::ONE);
+    let (xw, yw) = (pt_w[0], pt_w[1]);
+    let zwires = [pt_w[2], pt_w[3], pt_w[4]];
+    // x-powers x²..x^11 (x⁰/x¹ are ow/xw).
+    let mut xpw = [ow; 12];
+    xpw[1] = xw;
+    for d in 2..12 {
+        xpw[d] = sb.gate(macs, &[zw, xpw[d - 1], xw])[0];
+    }
+    // y-powers y², y³.
+    let y2w = sb.gate(macs, &[zw, yw, yw])[0];
+    let y3w = sb.gate(macs, &[zw, y2w, yw])[0];
+    let ypw = [ow, yw, y2w, y3w];
+    // C1: t² + t + x³ + x == 0.
+    vals.push(t_n);
+    let tw = sb.input();
+    let t2w = sb.gate(macs, &[zw, tw, tw])[0];
+    let mut c1 = sb.gate(macs, &[t2w, tw, ow])[0];
+    c1 = sb.gate(macs, &[c1, xpw[3], ow])[0];
+    c1 = sb.gate(macs, &[c1, xw, ow])[0];
+    sb.connect(c1, zass);
+    // C2: y² + u·y + x·u·t == 0 with u = x + 1.
+    let uw = sb.gate(macs, &[ow, xw, ow])[0];
+    let xuw = sb.gate(macs, &[zw, xw, uw])[0];
+    let xutw = sb.gate(macs, &[zw, xuw, tw])[0];
+    let mut c2 = sb.gate(macs, &[y2w, uw, yw])[0];
+    c2 = sb.gate(macs, &[c2, xutw, ow])[0];
+    sb.connect(c2, zass);
+    // D₀, D₁ + their nonzero guards (advice inverses against the fixed ONE).
+    let mut d0w = sb.gate(macs, &[ow, xpw[4], ow])[0];
+    d0w = sb.gate(macs, &[d0w, xpw[10], ow])[0];
+    let mut d1w = sb.gate(macs, &[ow, xw, ow])[0];
+    for d in [4, 5, 10, 11] {
+        d1w = sb.gate(macs, &[d1w, xpw[d], ow])[0];
+    }
+    vals.push(d0_inv_n);
+    let d0iw = sb.input();
+    let g0 = sb.gate(macs, &[zw, d0w, d0iw])[0];
+    sb.connect(g0, one_w);
+    vals.push(d1_inv_n);
+    let d1iw = sb.input();
+    let g1 = sb.gate(macs, &[zw, d1w, d1iw])[0];
+    sb.connect(g1, one_w);
+    // The three Artin–Schreier levels, denominators cleared. The Pᵢⱼ masks
+    // mirror `sampling::sample_artin_schreier_rhs_coeffs_cached` exactly
+    // (there `d0`/`d1` NAME the inverses; clearing multiplies them away).
+    let poly = |sb: &mut ShapeBuilder, degs: &[usize], plus_one: bool| -> Wire {
+        let mut acc = if plus_one { ow } else { zw };
+        for &d in degs {
+            acc = sb.gate(macs, &[acc, xpw[d], ow])[0];
+        }
+        acc
+    };
+    let p0: [Wire; 4] = [
+        poly(sb, &[9, 6, 5, 4, 3, 2], false),
+        poly(sb, &[5, 4, 3, 2], true),
+        poly(sb, &[4, 3, 2], false),
+        poly(sb, &[3], true),
+    ];
+    let p1: [Wire; 4] = [
+        poly(sb, &[8, 5, 4, 3, 2, 1], false),
+        poly(sb, &[6, 5, 2, 1], false),
+        poly(sb, &[3, 1], false),
+        poly(sb, &[4, 2, 1], false),
+    ];
+    let p2: [Wire; 4] = [
+        poly(sb, &[6, 4, 3, 2], false),
+        poly(sb, &[5], true),
+        poly(sb, &[3, 2, 1], true),
+        poly(sb, &[3, 2], false),
+    ];
+    // i = 0, 2 (all over D₀): D₀·(z² + z) + Σⱼ Pⱼ·yʲ == 0.
+    for (zi, p) in [(zwires[0], &p0), (zwires[2], &p2)] {
+        let z2 = sb.gate(macs, &[zw, zi, zi])[0];
+        let z2z = sb.gate(macs, &[z2, zi, ow])[0];
+        let mut acc = sb.gate(macs, &[zw, d0w, z2z])[0];
+        for j in 0..4 {
+            acc = sb.gate(macs, &[acc, p[j], ypw[j]])[0];
+        }
+        sb.connect(acc, zass);
+    }
+    // i = 1 (mixed D₀/D₁): D₀D₁·(z²+z) + D₁·Σⱼ<₃ Pⱼ·yʲ + D₀·P₃·y³ == 0.
+    {
+        let zi = zwires[1];
+        let z2 = sb.gate(macs, &[zw, zi, zi])[0];
+        let z2z = sb.gate(macs, &[z2, zi, ow])[0];
+        let d0d1 = sb.gate(macs, &[zw, d0w, d1w])[0];
+        let mut inner = sb.gate(macs, &[zw, p1[0], ow])[0];
+        inner = sb.gate(macs, &[inner, p1[1], yw])[0];
+        inner = sb.gate(macs, &[inner, p1[2], y2w])[0];
+        let p3y3 = sb.gate(macs, &[zw, p1[3], y3w])[0];
+        let mut acc = sb.gate(macs, &[zw, d0d1, z2z])[0];
+        acc = sb.gate(macs, &[acc, d1w, inner])[0];
+        acc = sb.gate(macs, &[acc, d0w, p3y3])[0];
+        sb.connect(acc, zass);
+    }
+}
+
 /// `L_i(z_skip) = Z_N(z)·(z + λ_i)^{-1}·den^{-1}` a merge fold's boolean
 /// claims carry, derived from the child's z_skip WIRE instead of published
 /// and checker-rebuilt: `t_i = z + λ_i` against the shared λ const wires,
@@ -15576,29 +15858,22 @@ fn read_acc_entry(
     )
 }
 
-/// The Tier-0 AG-skip checker (docs/ag-recursion-plan.md, Phase B): walk
-/// one AG child's published block `[seed0, seed1, nonce, point ×5,
-/// lows ×64]` — re-derive the point from `H(seed ‖ nonce)` under the
-/// child's grinding schedule (fused PoW + decode on ONE hash) and the row
-/// lows as the point's base evaluation functional. The seed and nonce
-/// publics are wire-connected to the child's transcript and the lows
-/// publics to the fold's absorbed row lows, so this closes the same
-/// binding [`emit_lagrange_lows`] gives an RS child in-circuit. Returns
-/// the number of public words consumed.
-fn check_ag_skip_publics(public: &[F128], base: usize, ag_r1_bits: Option<u32>) -> usize {
-    let seed = ag_seed_bytes(public[base], public[base + 1]);
-    let nonce_word = public[base + 2];
-    assert_eq!(nonce_word.hi, 0, "the nonce word's high half is zero");
-    let nonce = u32::try_from(nonce_word.lo).expect("the nonce fits 32 bits");
-    let budget = match ag_r1_bits {
-        Some(_) => flock_core::zerocheck::ag_skip::R1_FUSED_ATTEMPT_BUDGET,
-        None => flock_core::genus95_curve_code::SAMPLE_ATTEMPT_BUDGET,
+/// The AG-skip surface checker: walk one AG child's published block
+/// `[seed₂, nonce, point ×5, lows ×64]` and hold the row lows to the
+/// published point's base evaluation functional. Since phase D the decode
+/// itself (seed/nonce → point, fused PoW included) is IN-CIRCUIT
+/// ([`emit_ag_point_binding`]), so `lows == bf(point)` is the ONE item
+/// this surface leaves at the checker tier — the same class as the leaf's
+/// skip-interpolation items, with the genus-95 sampler gone from the exit
+/// contract. Returns the number of public words consumed.
+fn check_ag_skip_publics(public: &[F128], base: usize) -> usize {
+    let pt = flock_core::genus95_curve_code::EvaluationPoint {
+        x: public[base + 3],
+        y: public[base + 4],
+        z1: public[base + 5],
+        z2: public[base + 6],
+        z3: public[base + 7],
     };
-    assert!(nonce < budget, "the nonce is inside the prover's scan budget");
-    let pt = decode_ag_point(&seed, nonce, ag_r1_bits);
-    for (j, c) in [pt.x, pt.y, pt.z1, pt.z2, pt.z3].into_iter().enumerate() {
-        assert_eq!(public[base + 3 + j], c, "published AG point coord {j}");
-    }
     let bf = flock_core::genus95_curve_code::base_evaluation_functional(&pt)
         .expect("the base functional exists at a decoded point");
     for j in 0..64 {
@@ -15634,25 +15909,22 @@ fn ag_skip_publics_checker_rejects_tampers() {
     public.extend([pt.x, pt.y, pt.z1, pt.z2, pt.z3]);
     public.extend((0..64).map(|j| bf[j]));
     assert_eq!(
-        check_ag_skip_publics(&public, base, Some(R1_POW_BITS)),
+        check_ag_skip_publics(&public, base),
         72,
         "the honest block passes"
     );
 
+    // Since phase D the seed/nonce/decode bindings are IN-CIRCUIT
+    // (emit_ag_point_binding); the checker's remaining item is the
+    // lows-to-point functional, so its tamper matrix is point + lows.
     let rejects = |mutate: &dyn Fn(&mut [F128])| -> bool {
         let mut bad = public.clone();
         mutate(&mut bad);
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            check_ag_skip_publics(&bad, base, Some(R1_POW_BITS))
+            check_ag_skip_publics(&bad, base)
         }))
         .is_err()
     };
-    assert!(rejects(&|p| p[base] += F128::ONE), "tampered seed word");
-    assert!(rejects(&|p| p[base + 2] += F128::ONE), "shifted nonce");
-    assert!(
-        rejects(&|p| p[base + 2] = F128::new(u64::from(R1_FUSED_ATTEMPT_BUDGET), 0)),
-        "out-of-budget nonce"
-    );
     assert!(rejects(&|p| p[base + 4] += F128::ONE), "tampered point coord");
     assert!(rejects(&|p| p[base + 8 + 17] += F128::ONE), "tampered row low");
 }
@@ -17572,11 +17844,11 @@ pub fn build_node_outer_app(
                     ag_pub_bases.push(None);
                 }
                 (ZskipTapeRec::Ag { seed_ch, .. }, ZskipWires::Ag { seed_w, nonce_w }) => {
-                    // Tier 0 (docs/ag-recursion-plan.md): publish the whole
-                    // surface — seed and nonce CONNECTED to the child's
-                    // transcript wires, the point as advice, and the fold's
-                    // absorbed row lows word-for-word — and let the native
-                    // checker re-derive the point and the lows.
+                    // TIER 1 (phase D): publish [seed₂, nonce, point₅,
+                    // lows₆₄] — seed/nonce/lows wire-connected as before —
+                    // and BIND the point in-circuit
+                    // ([`emit_ag_point_binding`]). The native checker keeps
+                    // only `lows == bf(point)`.
                     let base = sb.public_len();
                     for (v, src) in [
                         (tk.chals[*seed_ch], seed_w[0]),
@@ -17598,15 +17870,33 @@ pub fn build_node_outer_app(
                     let flock_core::lincheck::SkipPoint::Ag(pt) = tk.mat_assert.z_skip else {
                         unreachable!("an AG tape carries an AG skip point")
                     };
-                    for c in [pt.x, pt.y, pt.z1, pt.z2, pt.z3] {
+                    let pt_w: [Wire; 5] = [pt.x, pt.y, pt.z1, pt.z2, pt.z3].map(|c| {
                         vals.push(c);
-                        sb.public_input();
-                    }
+                        sb.public_input()
+                    });
                     for (j, &lv) in fold_claims[0][cj + k].row.low.iter().enumerate() {
                         vals.push(lv);
                         let lw2 = sb.public_input();
                         sb.connect(lw2, wv(locs[0].claims[cj + k].row_low_v + j));
                     }
+                    emit_ag_point_binding(
+                        &mut sb,
+                        cs.q.b3,
+                        cs.q.pow,
+                        cs.macs,
+                        iv2,
+                        *seed_w,
+                        *nonce_w,
+                        &pt_w,
+                        [tk.chals[*seed_ch], tk.chals[*seed_ch + 1]],
+                        nonce,
+                        &pt,
+                        los[k].pcs.zerocheck_grinding().ag_r1_bits(),
+                        &mut vals,
+                        &mut consts,
+                        zw,
+                        ow,
+                    );
                     ag_pub_bases.push(Some(base));
                 }
                 _ => unreachable!("the region's zskip wires match the tape flavor"),
@@ -18527,17 +18817,10 @@ pub fn build_node_outer_app(
                         "the lows' assert-zero anchor"
                     );
                 }
-                // The Tier-0 AG-skip blocks: point re-derived from the
-                // published (seed, nonce) under the child's grinding
-                // schedule, row lows re-derived from the point.
-                for (lo_c, base) in los.iter().zip(&ag_pub_bases) {
-                    if let Some(base) = base {
-                        check_ag_skip_publics(
-                            &built2.public,
-                            *base,
-                            lo_c.pcs.zerocheck_grinding().ag_r1_bits(),
-                        );
-                    }
+                // The AG-skip blocks: the decode is in-circuit since
+                // phase D; the checker holds the lows to the point.
+                for base in ag_pub_bases.iter().flatten() {
+                    check_ag_skip_publics(&built2.public, *base);
                 }
                 for &(v, idx) in &jag_const_rec {
                     assert_eq!(built2.public[idx], v, "jagged shared constant public");

--- a/crates/flock-prover/src/tower.rs
+++ b/crates/flock-prover/src/tower.rs
@@ -9202,13 +9202,6 @@ fn check_real_child_region(public: &[F128], rt: &RealTape<'_>, r: &RealRegion) -
 // child-tape region per child — the build_leaf_outer precedent)
 // ---------------------------------------------------------------------------
 
-/// A minimal MIXED circuit inner — a blake3 chain feeding MacGate rows across
-/// the class boundary, ends published — proven over the circuit path and
-/// verified DEFERRED. The shape mvp10 pins at `(256, 32)` and the mvp11 merge
-/// children instantiate at `(128, 16)`. The seed varies only the witness
-/// (message words), so same-parameter instances share the CIRCUIT — and its
-/// digest, the key the accumulator folds sigma under — while their claims
-/// land at unrelated FS points, which is what a merge node actually sees.
 /// A circuit-union proof by boolean-zerocheck FLAVOR — parallel arms so
 /// the RS deprecation endgame is arm-deletion, not surgery
 /// (docs/ag-recursion-plan.md). Carried by the chain leaf ([`MixedInner`])
@@ -9304,6 +9297,13 @@ impl MixedProof {
     }
 }
 
+/// A minimal MIXED circuit inner — a blake3 chain feeding MacGate rows across
+/// the class boundary, ends published — proven over the circuit path and
+/// verified DEFERRED. The shape mvp10 pins at `(256, 32)` and the mvp11 merge
+/// children instantiate at `(128, 16)`. The seed varies only the witness
+/// (message words), so same-parameter instances share the CIRCUIT — and its
+/// digest, the key the accumulator folds sigma under — while their claims
+/// land at unrelated FS points, which is what a merge node actually sees.
 struct MixedInner {
     nu: usize,
     built: flock_core::circuit::builder::BuiltCircuit,
@@ -10741,7 +10741,7 @@ pub fn build_fl_node_k(cfg: TowerConfig, cps: &[&ChainProof]) -> FlNode {
                     // ([`emit_ag_point_binding`]: the two BLAKE3 decode
                     // rows, the fused-PoW row, the fiber algebra over the
                     // published coordinate wires). The native checker keeps
-                    // only `lows == bf(point)`.
+                    // the nonce range and `lows == bf(point)`.
                     let base = sb.public_len();
                     for (v, src) in [
                         (tk.chals[*seed_ch], seed_w[0]),
@@ -11084,9 +11084,15 @@ pub fn build_fl_node_k(cfg: TowerConfig, cps: &[&ChainProof]) -> FlNode {
                 }
             }
             // The AG-skip blocks: the decode is in-circuit since phase D;
-            // the checker holds the row lows to the published point.
-            for base in ag_pub_bases.iter().flatten() {
-                check_ag_skip_publics(&built2.public, *base);
+            // the checker holds the nonce range and the row lows.
+            for (cp, base) in cps.iter().zip(&ag_pub_bases) {
+                if let Some(base) = base {
+                    check_ag_skip_publics(
+                        &built2.public,
+                        *base,
+                        cp.inner.pcs.zerocheck_grinding().ag_r1_bits(),
+                    );
+                }
             }
             for &(v, idx) in &jag_const_rec {
                 assert_eq!(built2.public[idx], v, "jagged shared constant public");
@@ -11801,7 +11807,6 @@ fn emit_element_reported_check(
     sb.connect(rhs, target_w);
 }
 
-/// **THE LAGRANGE ROW LOWS in-circuit (round 4).** The 64 weights
 /// PHASE D (docs/ag-recursion-plan.md): the AG z_skip point's IN-CIRCUIT
 /// binding — the Tier-1 successor of the Tier-0 decode checker. From the
 /// child's transcript wires (the two seed squeezes and the absorbed 4-byte
@@ -11824,9 +11829,10 @@ fn emit_element_reported_check(
 /// satisfies these rows — the sampler's slot/choice bits are deliberately
 /// unbound, and the fiber's 5 bits of prover freedom are repaid by the
 /// all-explicit `R1_POW_BITS = 9` fused target (the schedule constant
-/// moved with this emitter; the total stays `bits_for(474)`). The one
-/// checker item left on this surface is `lows == bf(point)`
-/// ([`check_ag_skip_publics`]).
+/// moved with this emitter; the total stays `bits_for(474)`). The checker
+/// items left on this surface are the nonce range and `lows == bf(point)`
+/// ([`check_ag_skip_publics`] — the PowMask row pins only the nonce
+/// word's high half, and Chain100 emits no row).
 #[allow(clippy::too_many_arguments)]
 fn emit_ag_point_binding(
     sb: &mut ShapeBuilder,
@@ -12073,6 +12079,7 @@ fn emit_ag_point_binding(
     }
 }
 
+/// **THE LAGRANGE ROW LOWS in-circuit (round 4).** The 64 weights
 /// `L_i(z_skip) = Z_N(z)·(z + λ_i)^{-1}·den^{-1}` a merge fold's boolean
 /// claims carry, derived from the child's z_skip WIRE instead of published
 /// and checker-rebuilt: `t_i = z + λ_i` against the shared λ const wires,
@@ -12319,8 +12326,10 @@ struct ChildTape<'p> {
 /// its wire in-circuit ([`emit_lagrange_lows`]). AG: the point has NO
 /// transcript word — it decodes from (seed = two squeezes, nonce = a
 /// 4-byte observe) through a STANDALONE hash, so the tape records the seed
-/// ordinals and the nonce's payload ordinal, and the consumer publishes
-/// (seed, nonce, point, row lows) for the Tier-0 native checker
+/// ordinals and the nonce's payload ordinal; the consumer publishes
+/// (seed, nonce, point, row lows), binds the decode IN-CIRCUIT
+/// ([`emit_ag_point_binding`]), and leaves the nonce range + the
+/// lows-to-functional items to the native checker
 /// ([`check_ag_skip_publics`], docs/ag-recursion-plan.md).
 enum ZskipTapeRec {
     Rs {
@@ -13974,22 +13983,24 @@ impl ChildSlots {
     }
 }
 
-/// What one emitted child region hands back: where its public block starts,
-/// the walk counts the checker needs, and the assertion-emission wires the
-/// mvp11 merge node CONNECTS the fold region's claim words to.
 /// A child region's z_skip wires, by flavor. RS: the one fused-squeeze
 /// output — the merge assembly derives the 64 Lagrange row lows from it
 /// IN-CIRCUIT ([`emit_lagrange_lows`]; no publish, no checker rebuild).
 /// AG: the seed squeezes' outputs and the r₁ nonce's stream-word wire —
 /// the merge assembly publishes them beside the point and the row lows,
-/// and the Tier-0 checker ([`check_ag_skip_publics`]) re-derives the point
-/// and the lows natively (docs/ag-recursion-plan.md; the in-circuit
-/// derivation is Phase D's `emit_ag_lows`).
+/// binds the decode IN-CIRCUIT from these wires
+/// ([`emit_ag_point_binding`]: hash, PoW, fiber membership), and leaves
+/// the nonce range + the lows-to-functional items to the native checker
+/// ([`check_ag_skip_publics`]); the in-circuit lows derivation
+/// (`emit_ag_lows`) is measured-rejected — see docs/ag-recursion-plan.md.
 enum ZskipWires {
     Rs(Wire),
     Ag { seed_w: [Wire; 2], nonce_w: Wire },
 }
 
+/// What one emitted child region hands back: where its public block starts,
+/// the walk counts the checker needs, and the assertion-emission wires the
+/// mvp11 merge node CONNECTS the fold region's claim words to.
 struct ChildRegion {
     pub_base: usize,
     n_query_pub: usize,
@@ -15859,14 +15870,30 @@ fn read_acc_entry(
 }
 
 /// The AG-skip surface checker: walk one AG child's published block
-/// `[seed₂, nonce, point ×5, lows ×64]` and hold the row lows to the
-/// published point's base evaluation functional. Since phase D the decode
-/// itself (seed/nonce → point, fused PoW included) is IN-CIRCUIT
-/// ([`emit_ag_point_binding`]), so `lows == bf(point)` is the ONE item
-/// this surface leaves at the checker tier — the same class as the leaf's
-/// skip-interpolation items, with the genus-95 sampler gone from the exit
-/// contract. Returns the number of public words consumed.
-fn check_ag_skip_publics(public: &[F128], base: usize) -> usize {
+/// `[seed₂, nonce, point ×5, lows ×64]`. Two items stay at the checker
+/// tier since phase D moved the decode in-circuit
+/// ([`emit_ag_point_binding`]):
+/// - the NONCE RANGE — the published nonce word (wire-connected to the
+///   absorbed stream word) must be a native nonce: high half zero, low
+///   half inside the schedule's scan budget. The in-circuit PowMask row
+///   pins only the word's high 64 bits (and Chain100 emits no row), so
+///   without this item the circuit would accept nonce words no native
+///   verifier accepts;
+/// - `lows == bf(point)` — the base functional at the published point.
+/// Both are the leaf skip-interpolation class of obligation; the
+/// genus-95 sampler itself stays out of the exit checker set. Returns
+/// the number of public words consumed.
+fn check_ag_skip_publics(public: &[F128], base: usize, ag_r1_bits: Option<u32>) -> usize {
+    let nonce_word = public[base + 2];
+    assert_eq!(nonce_word.hi, 0, "the nonce word's high half is zero");
+    let budget = match ag_r1_bits {
+        Some(_) => flock_core::zerocheck::ag_skip::R1_FUSED_ATTEMPT_BUDGET,
+        None => flock_core::genus95_curve_code::SAMPLE_ATTEMPT_BUDGET,
+    };
+    assert!(
+        nonce_word.lo < u64::from(budget),
+        "the nonce is inside the schedule's scan budget"
+    );
     let pt = flock_core::genus95_curve_code::EvaluationPoint {
         x: public[base + 3],
         y: public[base + 4],
@@ -15882,12 +15909,12 @@ fn check_ag_skip_publics(public: &[F128], base: usize) -> usize {
     72
 }
 
-/// The Tier-0 checker rejects every tampered surface of the published AG
-/// block: a shifted nonce (fails the fused PoW+decode — and if a shifted
-/// nonce happens to decode, its point differs and the coord pin catches
-/// it), a tampered point coordinate, a tampered row low, an out-of-budget
-/// nonce, and a tampered seed word. The honest block passes and consumes
-/// exactly 72 words.
+/// The checker rejects every surface its two items cover: a non-native
+/// nonce word (high half set, or low half past the scan budget), a
+/// tampered point coordinate, and a tampered row low. The honest block
+/// passes and consumes exactly 72 words. (Seed and decode tampers are
+/// IN-CIRCUIT since phase D — `emit_ag_point_binding` — and are outside
+/// this checker's coverage by design.)
 #[test]
 fn ag_skip_publics_checker_rejects_tampers() {
     use flock_core::genus95_curve_code::{
@@ -15909,22 +15936,27 @@ fn ag_skip_publics_checker_rejects_tampers() {
     public.extend([pt.x, pt.y, pt.z1, pt.z2, pt.z3]);
     public.extend((0..64).map(|j| bf[j]));
     assert_eq!(
-        check_ag_skip_publics(&public, base),
+        check_ag_skip_publics(&public, base, Some(R1_POW_BITS)),
         72,
         "the honest block passes"
     );
 
-    // Since phase D the seed/nonce/decode bindings are IN-CIRCUIT
-    // (emit_ag_point_binding); the checker's remaining item is the
-    // lows-to-point functional, so its tamper matrix is point + lows.
     let rejects = |mutate: &dyn Fn(&mut [F128])| -> bool {
         let mut bad = public.clone();
         mutate(&mut bad);
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            check_ag_skip_publics(&bad, base)
+            check_ag_skip_publics(&bad, base, Some(R1_POW_BITS))
         }))
         .is_err()
     };
+    assert!(
+        rejects(&|p| p[base + 2] = F128::new(u64::from(nonce), 1)),
+        "a set nonce high half is rejected"
+    );
+    assert!(
+        rejects(&|p| p[base + 2] = F128::new(u64::from(R1_FUSED_ATTEMPT_BUDGET), 0)),
+        "an out-of-budget nonce is rejected"
+    );
     assert!(rejects(&|p| p[base + 4] += F128::ONE), "tampered point coord");
     assert!(rejects(&|p| p[base + 8 + 17] += F128::ONE), "tampered row low");
 }
@@ -17848,7 +17880,7 @@ pub fn build_node_outer_app(
                     // lows₆₄] — seed/nonce/lows wire-connected as before —
                     // and BIND the point in-circuit
                     // ([`emit_ag_point_binding`]). The native checker keeps
-                    // only `lows == bf(point)`.
+                    // the nonce range and `lows == bf(point)`.
                     let base = sb.public_len();
                     for (v, src) in [
                         (tk.chals[*seed_ch], seed_w[0]),
@@ -18818,9 +18850,15 @@ pub fn build_node_outer_app(
                     );
                 }
                 // The AG-skip blocks: the decode is in-circuit since
-                // phase D; the checker holds the lows to the point.
-                for base in ag_pub_bases.iter().flatten() {
-                    check_ag_skip_publics(&built2.public, *base);
+                // phase D; the checker holds the nonce range and the lows.
+                for (lo_c, base) in los.iter().zip(&ag_pub_bases) {
+                    if let Some(base) = base {
+                        check_ag_skip_publics(
+                            &built2.public,
+                            *base,
+                            lo_c.pcs.zerocheck_grinding().ag_r1_bits(),
+                        );
+                    }
                 }
                 for &(v, idx) in &jag_const_rec {
                     assert_eq!(built2.public[idx], v, "jagged shared constant public");

--- a/crates/flock-prover/src/tower.rs
+++ b/crates/flock-prover/src/tower.rs
@@ -104,16 +104,14 @@ fn test_config() -> TowerConfig {
 /// growing `TowerConfig`. `TOWER_LEAF_ZC=rs` forces the RS leaf for A/B
 /// measurement on aarch64.
 fn leaf_zc_ag() -> bool {
-    cfg!(target_arch = "aarch64")
-        && !matches!(std::env::var("TOWER_LEAF_ZC").as_deref(), Ok("rs"))
+    cfg!(target_arch = "aarch64") && !matches!(std::env::var("TOWER_LEAF_ZC").as_deref(), Ok("rs"))
 }
 
 /// Phase C flip-in-place: the envelope OUTERS (FL / internal / spine)
 /// prove under the AG skip on the same terms as the leaf.
 /// `TOWER_OUTER_ZC=rs` forces the RS outers for A/B measurement.
 fn outer_zc_ag() -> bool {
-    cfg!(target_arch = "aarch64")
-        && !matches!(std::env::var("TOWER_OUTER_ZC").as_deref(), Ok("rs"))
+    cfg!(target_arch = "aarch64") && !matches!(std::env::var("TOWER_OUTER_ZC").as_deref(), Ok("rs"))
 }
 
 fn tower_fold_grinding(cfg: TowerConfig) -> flock_core::matrix_fold::FoldGrinding {
@@ -1700,9 +1698,11 @@ fn decode_ag_point(
             HashKind::Blake3,
             bits,
         ),
-        None => {
-            flock_core::genus95_curve_code::evaluation_point_from_nonce(seed, nonce, HashKind::Blake3)
-        }
+        None => flock_core::genus95_curve_code::evaluation_point_from_nonce(
+            seed,
+            nonce,
+            HashKind::Blake3,
+        ),
     }
     .expect("the AG nonce decodes to a valid cover point")
 }
@@ -7099,7 +7099,12 @@ impl<'p> RealTape<'p> {
                     assert_eq!(chals[*ch], mat_assert.z_skip.phi8(), "z_skip located");
                 }
                 (MixedProof::Ag(p), ZskipTapeRec::Ag { seed_ch, .. }) => {
-                    let nonce = p.boolean.as_ref().expect("boolean side present").ag.r1_nonce;
+                    let nonce = p
+                        .boolean
+                        .as_ref()
+                        .expect("boolean side present")
+                        .ag
+                        .r1_nonce;
                     let pt = decode_ag_point(
                         &ag_seed_bytes(chals[*seed_ch], chals[*seed_ch + 1]),
                         nonce,
@@ -8991,7 +8996,8 @@ fn check_real_child_region(public: &[F128], rt: &RealTape<'_>, r: &RealRegion) -
     // no publics, no checker items; the proof itself carries them.
     let sig_base = sp_base + 4 + 2 * rt.levels.len() * rt.yr_len + 2;
     assert_eq!(
-        public[sig_base], rt.lo.proof.wiring().gkr.s_sigma_eval,
+        public[sig_base],
+        rt.lo.proof.wiring().gkr.s_sigma_eval,
         "the emitted sigma value is the proof's deferred evaluation"
     );
     let sa = flock_core::circuit::SigmaAssertion {
@@ -10720,7 +10726,11 @@ pub fn build_fl_node_k(cfg: TowerConfig, cps: &[&ChainProof]) -> FlNode {
                     }
                     let nonce = match &tk.inner.proof {
                         MixedProof::Ag(p) => {
-                            p.boolean.as_ref().expect("boolean side present").ag.r1_nonce
+                            p.boolean
+                                .as_ref()
+                                .expect("boolean side present")
+                                .ag
+                                .r1_nonce
                         }
                         MixedProof::Rs(_) => unreachable!("an AG tape carries an AG proof"),
                     };
@@ -11869,10 +11879,10 @@ fn emit_ag_point_binding(
     // Native replicas of the cleared AS equations (mirroring the sampler's
     // rhs masks) — the method-note discipline before the rows land.
     let pv = |degs: &[usize], plus_one: bool| -> F128 {
-        degs.iter().fold(
-            if plus_one { F128::ONE } else { F128::ZERO },
-            |acc, &d| acc + xp[d],
-        )
+        degs.iter()
+            .fold(if plus_one { F128::ONE } else { F128::ZERO }, |acc, &d| {
+                acc + xp[d]
+            })
     };
     let yp_n = [F128::ONE, y, y * y, y * y * y];
     let z_n = [pt_n.z1, pt_n.z2, pt_n.z3];
@@ -11929,10 +11939,7 @@ fn emit_ag_point_binding(
         &[iv[0], iv[1], seed_w[0], seed_w[1], nonce_w, zw, params36],
     );
     let params32 = cw(sb, vals, consts, pack_params(0, 32, flags));
-    let xof_out = sb.gate(
-        b3,
-        &[iv[0], iv[1], ns_out[0], ns_out[1], zw, zw, params32],
-    );
+    let xof_out = sb.gate(b3, &[iv[0], iv[1], ns_out[0], ns_out[1], zw, zw, params32]);
     sb.connect(xof_out[0], pt_w[0]);
     if let Some(bits) = ag_r1_bits {
         emit_pow_checks(
@@ -13392,7 +13399,12 @@ impl<'p> ChildTape<'p> {
                     assert_eq!(chals[*ch], bool_assert.z_skip.phi8(), "z_skip located");
                 }
                 (MixedProof::Ag(p), ZskipTapeRec::Ag { seed_ch, .. }) => {
-                    let nonce = p.boolean.as_ref().expect("boolean side present").ag.r1_nonce;
+                    let nonce = p
+                        .boolean
+                        .as_ref()
+                        .expect("boolean side present")
+                        .ag
+                        .r1_nonce;
                     let pt = decode_ag_point(
                         &ag_seed_bytes(chals[*seed_ch], chals[*seed_ch + 1]),
                         nonce,
@@ -15139,7 +15151,8 @@ fn check_child_region(public: &[F128], ct: &ChildTape<'_>, r: &ChildRegion) -> u
     // the mu point coordinates, matched against the native claim.
     let sig_base = mp_base + 5 + 2 * ct.levels.len() * ct.yr_len + 2;
     assert_eq!(
-        public[sig_base], ct.inner.proof.wiring().gkr.s_sigma_eval,
+        public[sig_base],
+        ct.inner.proof.wiring().gkr.s_sigma_eval,
         "the emitted sigma value is the proof's deferred evaluation"
     );
     let sig_rho = &public[sig_base + 1..sig_base + 1 + ct.mu_i];
@@ -15892,8 +15905,7 @@ fn ag_skip_publics_checker_rejects_tampers() {
     let seed = ag_seed_bytes(s0, s1);
     let (nonce, pt) = (0..R1_FUSED_ATTEMPT_BUDGET)
         .find_map(|n| {
-            evaluation_point_from_nonce_pow(&seed, n, HashKind::Blake3, R1_POW_BITS)
-                .map(|p| (n, p))
+            evaluation_point_from_nonce_pow(&seed, n, HashKind::Blake3, R1_POW_BITS).map(|p| (n, p))
         })
         .expect("a valid fused nonce exists in the budget");
     let bf = base_evaluation_functional(&pt).expect("the functional exists at a sampled point");
@@ -15924,8 +15936,14 @@ fn ag_skip_publics_checker_rejects_tampers() {
         rejects(&|p| p[base + 2] = F128::new(u64::from(R1_FUSED_ATTEMPT_BUDGET), 0)),
         "an out-of-budget nonce is rejected"
     );
-    assert!(rejects(&|p| p[base + 4] += F128::ONE), "tampered point coord");
-    assert!(rejects(&|p| p[base + 8 + 17] += F128::ONE), "tampered row low");
+    assert!(
+        rejects(&|p| p[base + 4] += F128::ONE),
+        "tampered point coord"
+    );
+    assert!(
+        rejects(&|p| p[base + 8 + 17] += F128::ONE),
+        "tampered row low"
+    );
 }
 
 /// Walk the published fold blocks from `tail0`: both endpoint deltas zero
@@ -17863,7 +17881,11 @@ pub fn build_node_outer_app(
                     }
                     let nonce = match &tk.lo.proof {
                         MixedProof::Ag(p) => {
-                            p.boolean.as_ref().expect("boolean side present").ag.r1_nonce
+                            p.boolean
+                                .as_ref()
+                                .expect("boolean side present")
+                                .ag
+                                .r1_nonce
                         }
                         MixedProof::Rs(_) => unreachable!("an AG tape carries an AG proof"),
                     };

--- a/crates/flock-prover/src/tower.rs
+++ b/crates/flock-prover/src/tower.rs
@@ -9381,6 +9381,129 @@ pub fn build_chain_proof(cfg: TowerConfig, h_start: [u32; 16], n_blocks: usize) 
     }
 }
 
+/// **Phase B slice 1 (docs/ag-recursion-plan.md): the REAL chain-leaf shape
+/// through the AG-skip circuit entries.** Same cached chain shape, same
+/// statement, same leaf profile — prove with
+/// `prove_fast_ligerito_union_circuit_ag`, deferred-verify with the AG twin,
+/// discharge both assertion families, pin h_end against the native chain,
+/// reject the fused-nonce tampers, and print the same-shape RS vs AG leaf
+/// prove times (the workload number the AG leaf exists for). No tower
+/// plumbing is touched yet — `MixedInner`/`ChildTape` stay RS until the FL
+/// walker grows its AG arm.
+#[cfg(target_arch = "aarch64")]
+#[test]
+#[ignore] // Heavier — run with `-- --ignored`.
+fn chain_leaf_ag_roundtrip() {
+    let cfg = test_config();
+    let n_blocks = 256usize;
+    let mut rng = Rng(0xC4A1_00A6);
+    let h_start: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+
+    let cs: ChainShape = chain_shape_cached(n_blocks).as_ref().clone();
+    let (nu, hash) = (cs.nu, cs.hash);
+    let blake_r1cs = chain_blake_r1cs(nu);
+    let blake_lc = blake_r1cs.csc_lincheck_circuit();
+
+    let witness = cs.shape.run(&chain_vals(&h_start), &[]);
+    let union = UnionInstance::new(&cs.shape.registry, cs.shape.counts.clone());
+    assert!(!union.has_element(), "a chain proof is boolean-only");
+    let pcs_params = PcsParams {
+        m: union.dense_m(),
+        log_inv_rate: 1,
+        profile: cfg.leaf_profile(),
+        log_batch_size: pcs_batch_for(&union, cfg.leaf_profile()),
+        num_lanes: union.commit_lanes(pcs_batch_for(&union, cfg.leaf_profile())),
+        merkle_hash: HashKind::Blake3,
+    };
+    let wit_rows = witness.rows::<Blake3Gate>(hash);
+
+    // Same-shape RS baseline (the flavor delta, not a cross-shape number).
+    let t0 = std::time::Instant::now();
+    let mut ch = FsChallenger::with_chained_blake3(DOMAIN);
+    let (_rs_proof, _, _) = prover::prove_fast_ligerito_union_circuit(
+        &union,
+        &cs.shape.circuit,
+        &witness.public,
+        &pcs_params,
+        vec![UnionSlotProverInput::new(
+            blake3::generate_witness_batch_major_partial(wit_rows, nu),
+            blake_lc,
+        )],
+        Vec::new(),
+        &mut ch,
+    );
+    let rs_ms = t0.elapsed().as_secs_f64() * 1e3;
+
+    let t0 = std::time::Instant::now();
+    let mut ch = FsChallenger::with_chained_blake3(DOMAIN);
+    let (proof, commitment, _) = prover::prove_fast_ligerito_union_circuit_ag(
+        &union,
+        &cs.shape.circuit,
+        &witness.public,
+        &pcs_params,
+        vec![UnionSlotProverInput::new(
+            blake3::generate_witness_batch_major_partial(wit_rows, nu),
+            blake_lc,
+        )],
+        Vec::new(),
+        &mut ch,
+    );
+    let ag_ms = t0.elapsed().as_secs_f64() * 1e3;
+    eprintln!(
+        "[chain-leaf] prove RS {rs_ms:7.2} ms vs AG {ag_ms:7.2} ms (same shape, m = {})",
+        union.dense_m()
+    );
+
+    let lcs: Vec<&dyn flock_core::lincheck::LincheckCircuit> = vec![blake_lc];
+    let verify = |p: &flock_core::proof::R1csProofCircuitMergedAg| {
+        let mut ch = FsChallenger::with_chained_blake3(DOMAIN);
+        verifier::verify_ligerito_union_circuit_ag_deferred(
+            &union,
+            &cs.shape.circuit,
+            &witness.public,
+            &lcs,
+            &commitment,
+            p,
+            &pcs_params,
+            &mut ch,
+        )
+    };
+    let (_claims, work, sigma) = verify(&proof).expect("deferred AG chain leaf verifies");
+    work.boolean
+        .as_ref()
+        .expect("boolean matrix work")
+        .check(&union, &lcs)
+        .expect("boolean matrix work discharges");
+    assert!(work.element.is_none(), "no element class, no element work");
+    assert!(sigma.check(&cs.shape.circuit), "sigma discharges");
+
+    // The statement is bound end to end: the published tail is h_end.
+    let h_end = native_chain(&h_start, n_blocks);
+    let public = &witness.public;
+    for j in 0..4 {
+        assert_eq!(
+            public[public.len() - 4 + j],
+            pack4(h_end[4 * j..4 * j + 4].try_into().unwrap()),
+            "the published tail is the native h_end"
+        );
+    }
+
+    // Fused-nonce tampers on the REAL chain shape.
+    let mut bad = proof.clone();
+    let n = &mut bad.boolean.as_mut().expect("boolean").ag.r1_nonce;
+    *n = n.wrapping_add(1);
+    assert!(verify(&bad).is_err(), "tampered fused r1 nonce accepted");
+    let mut bad = proof.clone();
+    *bad.boolean
+        .as_mut()
+        .expect("boolean")
+        .lincheck
+        .grinding_nonces
+        .last_mut()
+        .expect("fused skip nonce") ^= 1;
+    assert!(verify(&bad).is_err(), "tampered fused skip nonce accepted");
+}
+
 /// **Task 2's pin: the message-chain leaf, honest + the tamper matrix.**
 #[test]
 #[ignore] // Heavier — run with `-- --ignored`.

--- a/crates/flock-prover/src/tower.rs
+++ b/crates/flock-prover/src/tower.rs
@@ -6956,7 +6956,7 @@ impl<'p> RealTape<'p> {
                     "rr {j} is the located lc round, reversed"
                 );
             }
-            assert_eq!(chals[zskip_ch], mat_assert.z_skip, "z_skip located");
+            assert_eq!(chals[zskip_ch], mat_assert.z_skip.phi8(), "z_skip located");
             assert_eq!(
                 &vals_rec[zp_v..zp_v + 64],
                 &mat_assert.z_partial[..],
@@ -12389,7 +12389,7 @@ impl<'p> ChildTape<'p> {
                     "rr {j} is the located lc round, reversed"
                 );
             }
-            assert_eq!(chals[zskip_ch], bool_assert.z_skip, "z_skip located");
+            assert_eq!(chals[zskip_ch], bool_assert.z_skip.phi8(), "z_skip located");
             assert_eq!(
                 &vals_rec[zp_v..zp_v + 64],
                 &bool_assert.z_partial[..],

--- a/crates/flock-prover/src/tower.rs
+++ b/crates/flock-prover/src/tower.rs
@@ -97,6 +97,17 @@ fn test_config() -> TowerConfig {
     }
 }
 
+/// Phase B flip-in-place (docs/ag-recursion-plan.md): the chain leaf proves
+/// under the AG-skip boolean zerocheck wherever the round-1 prover kernel
+/// exists (aarch64 NEON); elsewhere it stays RS until Phase F ports the
+/// kernel. Private on purpose — the endgame deletes the RS arm rather than
+/// growing `TowerConfig`. `TOWER_LEAF_ZC=rs` forces the RS leaf for A/B
+/// measurement on aarch64.
+fn leaf_zc_ag() -> bool {
+    cfg!(target_arch = "aarch64")
+        && !matches!(std::env::var("TOWER_LEAF_ZC").as_deref(), Ok("rs"))
+}
+
 fn tower_fold_grinding(cfg: TowerConfig) -> flock_core::matrix_fold::FoldGrinding {
     let profile = cfg.outer_profile();
     PcsParams {
@@ -726,7 +737,51 @@ fn median_total(runs: &[Online]) -> f64 {
 /// compression per 64 bytes, so at the measured ~6.1 µs per b3 row a KiB of
 /// child proof is ~0.1 ms of parent per child.
 #[cfg(test)]
+fn census_kib<T: serde::Serialize + ?Sized>(v: &T) -> f64 {
+    bincode::serialize(v).map(|b| b.len()).unwrap_or(0) as f64 / 1024.0
+}
+
+#[cfg(test)]
 fn proof_census(label: &str, p: &flock_core::proof::R1csProofCircuitMerged, pcs: &PcsParams) {
+    proof_census_parts(
+        label,
+        census_kib(p),
+        census_kib(&p.boolean),
+        census_kib(&p.element),
+        census_kib(&p.wiring),
+        &p.pcs_open,
+        pcs,
+    )
+}
+
+/// [`proof_census`] over the leaf's flavor enum — the AG flavor differs
+/// only in the boolean PIOP struct; every other section is shape-shared.
+#[cfg(test)]
+fn proof_census_mixed(label: &str, p: &MixedProof, pcs: &PcsParams) {
+    match p {
+        MixedProof::Rs(p) => proof_census(label, p, pcs),
+        MixedProof::Ag(p) => proof_census_parts(
+            label,
+            census_kib(p),
+            census_kib(&p.boolean),
+            census_kib(&p.element),
+            census_kib(&p.wiring),
+            &p.pcs_open,
+            pcs,
+        ),
+    }
+}
+
+#[cfg(test)]
+fn proof_census_parts(
+    label: &str,
+    total: f64,
+    boolean_kib: f64,
+    element_kib: f64,
+    wiring_kib: f64,
+    pcs_open: &flock_core::pcs::MergedOpenProof,
+    pcs: &PcsParams,
+) {
     // Per-level stratified schedules, and the siblings a path emits ABOVE
     // the cap layer. The cap is the whole layer at the DEEPEST summand's
     // depth c1, so every query can be checked with d - c1 siblings — since
@@ -734,7 +789,7 @@ fn proof_census(label: &str, p: &flock_core::proof::R1csProofCircuitMerged, pcs:
     // (not recomputed from the schedule), so `redundant` certifies the
     // truncation stays landed: anything past q·(d − c1) is waste.
     if let Ok(cfg) = pcs.ligerito_prover_config() {
-        let lig = &p.pcs_open.inner.ligerito;
+        let lig = &pcs_open.inner.ligerito;
         let r = lig.recursive_caps.len();
         assert_eq!(cfg.stratified.len(), r + 1, "one schedule per open level");
         let level_paths = |lvl: usize| -> usize {
@@ -770,14 +825,8 @@ fn proof_census(label: &str, p: &flock_core::proof::R1csProofCircuitMerged, pcs:
             100.0 * waste as f64 / emitted as f64,
         );
     }
-    proof_census_inner(label, p)
-}
-
-#[cfg(test)]
-fn proof_census_inner(label: &str, p: &flock_core::proof::R1csProofCircuitMerged) {
     let sz = |b: Result<Vec<u8>, _>| b.map(|v| v.len()).unwrap_or(0) as f64 / 1024.0;
-    let total = sz(bincode::serialize(p));
-    let lig = &p.pcs_open.inner.ligerito;
+    let lig = &pcs_open.inner.ligerito;
     let rows = |v: &Vec<flock_core::pcs::ligerito::RecursiveProof>| -> (f64, f64) {
         (
             v.iter()
@@ -808,14 +857,14 @@ fn proof_census_inner(label: &str, p: &flock_core::proof::R1csProofCircuitMerged
          \x20   inner: caps         {:6.1}   (L0 {:.1} + rec {:.1})\n\
          \x20   inner: final block  {:6.1}\n\
          \x20   inner: sumcheck     {:6.1}",
-        sz(bincode::serialize(&p.boolean)),
-        sz(bincode::serialize(&p.element)),
-        sz(bincode::serialize(&p.wiring)),
-        sz(bincode::serialize(&p.pcs_open.merged_rounds)),
-        sz(bincode::serialize(&p.pcs_open.ring_switches)),
-        sz(bincode::serialize(&p.pcs_open.frobenius.values)),
-        sz(bincode::serialize(&p.pcs_open.frobenius.rounds)),
-        sz(bincode::serialize(&p.pcs_open.frobenius.anchor)),
+        boolean_kib,
+        element_kib,
+        wiring_kib,
+        sz(bincode::serialize(&pcs_open.merged_rounds)),
+        sz(bincode::serialize(&pcs_open.ring_switches)),
+        sz(bincode::serialize(&pcs_open.frobenius.values)),
+        sz(bincode::serialize(&pcs_open.frobenius.rounds)),
+        sz(bincode::serialize(&pcs_open.frobenius.anchor)),
         l0_rows,
         l0_paths,
         rec_rows,
@@ -1651,6 +1700,40 @@ fn bytes_payload_mask(ops: &[flock_core::transcript_record::TranscriptOp]) -> Ve
         }
     }
     v
+}
+
+/// The 32-byte AG sampling seed from its two transcript squeezes — the
+/// exact layout `ag_skip::r1_seed` writes: s0.lo, s0.hi, s1.lo, s1.hi,
+/// each LE.
+fn ag_seed_bytes(s0: F128, s1: F128) -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    seed[0..8].copy_from_slice(&s0.lo.to_le_bytes());
+    seed[8..16].copy_from_slice(&s0.hi.to_le_bytes());
+    seed[16..24].copy_from_slice(&s1.lo.to_le_bytes());
+    seed[24..32].copy_from_slice(&s1.hi.to_le_bytes());
+    seed
+}
+
+/// Re-derive an AG skip point from (seed, nonce) under the child's grinding
+/// schedule — ONE hash + one attempt, the verifier's own fused-nonce
+/// derivation (`H(seed ‖ nonce)` must clear the PoW target AND decode).
+fn decode_ag_point(
+    seed: &[u8; 32],
+    nonce: u32,
+    pow_bits: Option<u32>,
+) -> flock_core::genus95_curve_code::EvaluationPoint {
+    match pow_bits {
+        Some(bits) => flock_core::genus95_curve_code::evaluation_point_from_nonce_pow(
+            seed,
+            nonce,
+            HashKind::Blake3,
+            bits,
+        ),
+        None => {
+            flock_core::genus95_curve_code::evaluation_point_from_nonce(seed, nonce, HashKind::Blake3)
+        }
+    }
+    .expect("the AG nonce decodes to a valid cover point")
 }
 
 /// Replay a recorded transcript's FS chain into the blake3 slot; squeeze
@@ -8977,10 +9060,45 @@ fn check_real_child_region(public: &[F128], rt: &RealTape<'_>, r: &RealRegion) -
 /// (message words), so same-parameter instances share the CIRCUIT — and its
 /// digest, the key the accumulator folds sigma under — while their claims
 /// land at unrelated FS points, which is what a merge node actually sees.
+/// A chain leaf's proof by boolean-zerocheck FLAVOR — parallel arms so the
+/// RS deprecation endgame is arm-deletion, not surgery
+/// (docs/ag-recursion-plan.md). The element region, the wiring argument,
+/// and the merged open are shape-identical across flavors, so shared
+/// consumers read them through the accessors; only the zerocheck walk and
+/// its z_skip surface match on the arm.
+enum MixedProof {
+    Rs(flock_core::proof::R1csProofCircuitMerged),
+    /// Constructed only where the AG round-1 prover kernel exists
+    /// (aarch64); the consuming arms are arch-independent.
+    #[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
+    Ag(flock_core::proof::R1csProofCircuitMergedAg),
+}
+
+impl MixedProof {
+    fn wiring(&self) -> &flock_core::circuit::WiringProof {
+        match self {
+            MixedProof::Rs(p) => &p.wiring,
+            MixedProof::Ag(p) => &p.wiring,
+        }
+    }
+    fn pcs_open(&self) -> &flock_core::pcs::MergedOpenProof {
+        match self {
+            MixedProof::Rs(p) => &p.pcs_open,
+            MixedProof::Ag(p) => &p.pcs_open,
+        }
+    }
+    fn element(&self) -> Option<&flock_core::element_r1cs::union::Proof> {
+        match self {
+            MixedProof::Rs(p) => p.element.as_ref(),
+            MixedProof::Ag(p) => p.element.as_ref(),
+        }
+    }
+}
+
 struct MixedInner {
     nu: usize,
     built: flock_core::circuit::builder::BuiltCircuit,
-    proof: flock_core::proof::R1csProofCircuitMerged,
+    proof: MixedProof,
     commitment: flock_core::pcs::commit::Commitment,
     pcs: PcsParams,
     work: flock_core::verifier::DeferredMatrixWork,
@@ -9293,15 +9411,34 @@ pub fn build_chain_proof(cfg: TowerConfig, h_start: [u32; 16], n_blocks: usize) 
         let witgen_ms = t1.elapsed().as_secs_f64() * 1e3;
         let t2 = std::time::Instant::now();
         let mut ch = FsChallenger::with_chained_blake3(DOMAIN);
-        let (proof, commitment, _) = prover::prove_fast_ligerito_union_circuit(
-            &union,
-            &cs.shape.circuit,
-            &witness.public,
-            &pcs_params,
-            vec![UnionSlotProverInput::new(wit, blake_lc)],
-            Vec::new(),
-            &mut ch,
-        );
+        let (proof, commitment) = if leaf_zc_ag() {
+            #[cfg(target_arch = "aarch64")]
+            {
+                let (p, c, _) = prover::prove_fast_ligerito_union_circuit_ag(
+                    &union,
+                    &cs.shape.circuit,
+                    &witness.public,
+                    &pcs_params,
+                    vec![UnionSlotProverInput::new(wit, blake_lc)],
+                    Vec::new(),
+                    &mut ch,
+                );
+                (MixedProof::Ag(p), c)
+            }
+            #[cfg(not(target_arch = "aarch64"))]
+            unreachable!("leaf_zc_ag() is false off aarch64")
+        } else {
+            let (p, c, _) = prover::prove_fast_ligerito_union_circuit(
+                &union,
+                &cs.shape.circuit,
+                &witness.public,
+                &pcs_params,
+                vec![UnionSlotProverInput::new(wit, blake_lc)],
+                Vec::new(),
+                &mut ch,
+            );
+            (MixedProof::Rs(p), c)
+        };
         let prove_ms = t2.elapsed().as_secs_f64() * 1e3;
         // `t0` opened before the walk, so this is the whole online span in
         // ONE timer — the honest per-leaf number, against which the phase
@@ -9326,16 +9463,28 @@ pub fn build_chain_proof(cfg: TowerConfig, h_start: [u32; 16], n_blocks: usize) 
 
     let lcs: Vec<&dyn flock_core::lincheck::LincheckCircuit> = vec![blake_lc];
     let mut ch = FsChallenger::with_chained_blake3(DOMAIN);
-    let (_claims, work, sigma) = verifier::verify_ligerito_union_circuit_deferred(
-        &union,
-        &built.shape.circuit,
-        &built.witness.public,
-        &lcs,
-        &commitment,
-        &proof,
-        &pcs_params,
-        &mut ch,
-    )
+    let (_claims, work, sigma) = match &proof {
+        MixedProof::Rs(p) => verifier::verify_ligerito_union_circuit_deferred(
+            &union,
+            &built.shape.circuit,
+            &built.witness.public,
+            &lcs,
+            &commitment,
+            p,
+            &pcs_params,
+            &mut ch,
+        ),
+        MixedProof::Ag(p) => verifier::verify_ligerito_union_circuit_ag_deferred(
+            &union,
+            &built.shape.circuit,
+            &built.witness.public,
+            &lcs,
+            &commitment,
+            p,
+            &pcs_params,
+            &mut ch,
+        ),
+    }
     .expect("the deferred verify accepts an honest chain proof");
     work.boolean
         .as_ref()
@@ -9543,20 +9692,30 @@ fn chain_proof_message_chain_roundtrip_and_tampers() {
             &mut ch,
         )
     };
-    let verify = |public: &[F128],
-                  cm: &flock_core::pcs::commit::Commitment,
-                  p: &flock_core::proof::R1csProofCircuitMerged| {
+    let verify = |public: &[F128], cm: &flock_core::pcs::commit::Commitment, p: &MixedProof| {
         let mut ch = FsChallenger::with_chained_blake3(DOMAIN);
-        verifier::verify_ligerito_union_circuit(
-            &union,
-            &built.shape.circuit,
-            public,
-            &lcs,
-            cm,
-            p,
-            &cp.inner.pcs,
-            &mut ch,
-        )
+        match p {
+            MixedProof::Rs(p) => verifier::verify_ligerito_union_circuit(
+                &union,
+                &built.shape.circuit,
+                public,
+                &lcs,
+                cm,
+                p,
+                &cp.inner.pcs,
+                &mut ch,
+            ),
+            MixedProof::Ag(p) => verifier::verify_ligerito_union_circuit_ag(
+                &union,
+                &built.shape.circuit,
+                public,
+                &lcs,
+                cm,
+                p,
+                &cp.inner.pcs,
+                &mut ch,
+            ),
+        }
     };
 
     // (a) A broken chain link: row 100 re-witnessed from a message one bit
@@ -9568,7 +9727,7 @@ fn chain_proof_message_chain_roundtrip_and_tampers() {
         let (p, cm, _) = prove(&bad, &built.witness.public);
         assert!(
             matches!(
-                verify(&built.witness.public, &cm, &p),
+                verify(&built.witness.public, &cm, &MixedProof::Rs(p)),
                 Err(flock_core::verifier::VerifyError::Wiring(
                     flock_core::circuit::WiringError::Gkr(
                         flock_core::product_gkr::VerifyError::ProductMismatch
@@ -9592,7 +9751,7 @@ fn chain_proof_message_chain_roundtrip_and_tampers() {
         );
         let (p, cm, _) = prove(built.rows::<Blake3Gate>(hash), &bad);
         assert!(
-            verify(&bad, &cm, &p).is_err(),
+            verify(&bad, &cm, &MixedProof::Rs(p)).is_err(),
             "statement word {i} must be enforced by the wiring"
         );
     }
@@ -9653,7 +9812,7 @@ fn chain_tape_regions_pinned() {
     assert!(ct.el_assert.is_none(), "no element assertion travels");
     assert_eq!(
         ct.n_pd,
-        cp.inner.proof.wiring.gather.len(),
+        cp.inner.proof.wiring().gather.len(),
         "the pd claims are the wiring gathers ONLY"
     );
     assert!(ct.n_p > 0, "the gathers form scalar groups");
@@ -9680,7 +9839,7 @@ fn chain_tape_regions_pinned() {
         ct.n_pd,
         ct.n_p,
         ct.mu_i,
-        cp.inner.proof.wiring.gkr.layers.len(),
+        cp.inner.proof.wiring().gkr.layers.len(),
         ct.b3_rows,
         ct.geo[0].lanes,
         ct.geo[0].row_words,
@@ -9814,16 +9973,28 @@ fn record_chain_child_verify(
     );
     let lcs: Vec<&dyn flock_core::lincheck::LincheckCircuit> = vec![blake_lc];
     let mut rec = RecordingChallenger::new(FsChallenger::with_chained_blake3(DOMAIN));
-    verifier::verify_ligerito_union_circuit_deferred(
-        &union,
-        &inner.built.shape.circuit,
-        &inner.built.witness.public,
-        &lcs,
-        &inner.commitment,
-        &inner.proof,
-        &inner.pcs,
-        &mut rec,
-    )
+    match &inner.proof {
+        MixedProof::Rs(p) => verifier::verify_ligerito_union_circuit_deferred(
+            &union,
+            &inner.built.shape.circuit,
+            &inner.built.witness.public,
+            &lcs,
+            &inner.commitment,
+            p,
+            &inner.pcs,
+            &mut rec,
+        ),
+        MixedProof::Ag(p) => verifier::verify_ligerito_union_circuit_ag_deferred(
+            &union,
+            &inner.built.shape.circuit,
+            &inner.built.witness.public,
+            &lcs,
+            &inner.commitment,
+            p,
+            &inner.pcs,
+            &mut rec,
+        ),
+    }
     .expect("the chain child verifies (recorded)");
 }
 
@@ -10300,41 +10471,101 @@ pub fn build_fl_node_k(cfg: TowerConfig, cps: &[&ChainProof]) -> FlNode {
         // ---- the connects: fold surfaces == child-region wires ----
         use flock_core::field::PHI_8_TABLE;
         use flock_core::zerocheck::K_SKIP;
-        use flock_core::zerocheck::multilinear::{
-            lagrange_weights_naive, subspace_denominator_pair,
-        };
-        let lam_base = sb.public_len();
-        let lam_w: Vec<Wire> = PHI_8_TABLE[..1 << K_SKIP]
+        use flock_core::zerocheck::multilinear::subspace_denominator_pair;
+        // The RS lows machinery (λ table + denominator + zero anchor) is
+        // emitted only when an RS child consumes it; AG children take the
+        // Tier-0 published surface instead (docs/ag-recursion-plan.md).
+        let any_rs = tapes
             .iter()
-            .map(|&v| {
-                vals.push(v);
-                sb.public_input()
-            })
-            .collect();
-        vals.push(subspace_denominator_pair(K_SKIP).1);
-        let deninv_w = sb.public_input();
-        vals.push(F128::ZERO);
-        let lag_zassert = sb.public_input();
+            .any(|tk| matches!(tk.zskip, ZskipTapeRec::Rs { .. }));
+        let rs_lam: Option<(usize, Vec<Wire>, Wire, Wire)> = any_rs.then(|| {
+            let lam_base = sb.public_len();
+            let lam_w: Vec<Wire> = PHI_8_TABLE[..1 << K_SKIP]
+                .iter()
+                .map(|&v| {
+                    vals.push(v);
+                    sb.public_input()
+                })
+                .collect();
+            vals.push(subspace_denominator_pair(K_SKIP).1);
+            let deninv_w = sb.public_input();
+            vals.push(F128::ZERO);
+            let lag_zassert = sb.public_input();
+            (lam_base, lam_w, deninv_w, lag_zassert)
+        });
+        // Per AG child, the Tier-0 public block's base — the layout
+        // [`check_ag_skip_publics`] walks.
+        let mut ag_pub_bases: Vec<Option<usize>> = Vec::new();
         for (k, (tk, rk)) in tapes.iter().zip(&regions).enumerate() {
+            // Basis-generic native pre-assert: the fold's absorbed lows
+            // ARE the skip functional at the child's own z_skip point.
             assert_eq!(
                 &fold_claims[0][n_priors + k].row.low[..],
-                &lagrange_weights_naive(K_SKIP, tk.chals[tk.zskip_ch])[..],
-                "child {k}: the fold's lagrange lows are the closed form"
+                &tk.bool_assert.z_skip.weights(K_SKIP)[..],
+                "child {k}: the fold's row lows are the skip functional"
             );
-            let lows = emit_lagrange_lows(
-                &mut sb,
-                cs.macs,
-                &lam_w,
-                deninv_w,
-                rk.zskip_w,
-                tk.chals[tk.zskip_ch],
-                &mut vals,
-                zw,
-                ow,
-                lag_zassert,
-            );
-            for (j, &lw2) in lows.iter().enumerate() {
-                sb.connect(lw2, wv(locs[0].claims[n_priors + k].row_low_v + j));
+            match (&tk.zskip, &rk.zskip) {
+                (ZskipTapeRec::Rs { ch, .. }, ZskipWires::Rs(zskip_w)) => {
+                    let (_, lam_w, deninv_w, lag_zassert) =
+                        rs_lam.as_ref().expect("the RS lows machinery is emitted");
+                    let lows = emit_lagrange_lows(
+                        &mut sb,
+                        cs.macs,
+                        lam_w,
+                        *deninv_w,
+                        *zskip_w,
+                        tk.chals[*ch],
+                        &mut vals,
+                        zw,
+                        ow,
+                        *lag_zassert,
+                    );
+                    for (j, &lw2) in lows.iter().enumerate() {
+                        sb.connect(lw2, wv(locs[0].claims[n_priors + k].row_low_v + j));
+                    }
+                    ag_pub_bases.push(None);
+                }
+                (ZskipTapeRec::Ag { seed_ch, .. }, ZskipWires::Ag { seed_w, nonce_w }) => {
+                    // Tier 0: the AG point has no transcript word and no
+                    // in-circuit derivation yet (Phase D's emit_ag_lows),
+                    // so publish the whole surface — seed and nonce
+                    // CONNECTED to the child's transcript wires, the point
+                    // as advice, and the fold's absorbed row lows
+                    // word-for-word — and let the native checker re-derive
+                    // the point and the lows.
+                    let base = sb.public_len();
+                    for (v, src) in [
+                        (tk.chals[*seed_ch], seed_w[0]),
+                        (tk.chals[*seed_ch + 1], seed_w[1]),
+                    ] {
+                        vals.push(v);
+                        let w = sb.public_input();
+                        sb.connect(w, src);
+                    }
+                    let nonce = match &tk.inner.proof {
+                        MixedProof::Ag(p) => {
+                            p.boolean.as_ref().expect("boolean side present").ag.r1_nonce
+                        }
+                        MixedProof::Rs(_) => unreachable!("an AG tape carries an AG proof"),
+                    };
+                    vals.push(F128::new(u64::from(nonce), 0));
+                    let w = sb.public_input();
+                    sb.connect(w, *nonce_w);
+                    let flock_core::lincheck::SkipPoint::Ag(pt) = tk.bool_assert.z_skip else {
+                        unreachable!("an AG tape carries an AG skip point")
+                    };
+                    for c in [pt.x, pt.y, pt.z1, pt.z2, pt.z3] {
+                        vals.push(c);
+                        sb.public_input();
+                    }
+                    for (j, &lv) in fold_claims[0][n_priors + k].row.low.iter().enumerate() {
+                        vals.push(lv);
+                        let lw2 = sb.public_input();
+                        sb.connect(lw2, wv(locs[0].claims[n_priors + k].row_low_v + j));
+                    }
+                    ag_pub_bases.push(Some(base));
+                }
+                _ => unreachable!("the region's zskip wires match the tape flavor"),
             }
             // Native pre-asserts, then the wire connects — all static
             // Product-GKR evaluations, boolean points + z_partial lows.
@@ -10620,8 +10851,22 @@ pub fn build_fl_node_k(cfg: TowerConfig, cps: &[&ChainProof]) -> FlNode {
                     && acc_pub.discharge_jagged(&[(chain_digest, &chain_params_j)]),
                 "the public-segment accumulator discharges all three groups"
             );
-            for (i, &v) in PHI_8_TABLE[..1 << K_SKIP].iter().enumerate() {
-                assert_eq!(built2.public[lam_base + i], v, "λ const {i}");
+            if let Some((lam_base, _, _, _)) = &rs_lam {
+                for (i, &v) in PHI_8_TABLE[..1 << K_SKIP].iter().enumerate() {
+                    assert_eq!(built2.public[*lam_base + i], v, "λ const {i}");
+                }
+            }
+            // The Tier-0 AG-skip blocks: point re-derived from the
+            // published (seed, nonce) under the child's grinding schedule,
+            // row lows re-derived from the point.
+            for (cp, base) in cps.iter().zip(&ag_pub_bases) {
+                if let Some(base) = base {
+                    check_ag_skip_publics(
+                        &built2.public,
+                        *base,
+                        cp.inner.pcs.zerocheck_grinding().ag_r1_bits(),
+                    );
+                }
             }
             for &(v, idx) in &jag_const_rec {
                 assert_eq!(built2.public[idx], v, "jagged shared constant public");
@@ -11508,11 +11753,10 @@ struct ChildTape<'p> {
     lc_msg_vs: Vec<usize>,
     lc_rounds_b: Vec<(usize, usize)>,
     eps_n: Vec<F128>,
-    // z_skip's ordinals (the boolean claims' lagrange row lows derive from
-    // it — published, checker-validated) and z_partial's value ordinal (the
-    // boolean claims' column lows — absorbed child words, connectable).
-    zskip_ch: usize,
-    zskip_fin: usize,
+    // The z_skip transcript surface, by flavor (the boolean claims' row
+    // lows derive from it), and z_partial's value ordinal (the boolean
+    // claims' column lows — absorbed child words, connectable).
+    zskip: ZskipTapeRec,
     zp_v: usize,
     // published chain ordinals
     ga_c: usize,
@@ -11560,6 +11804,30 @@ struct ChildTape<'p> {
     jag: flock_core::matrix_fold::JaggedAssertion,
 }
 
+/// The boolean z_skip's transcript surface, by flavor. RS: the one fused
+/// PoW+squeeze — the merge assembly derives the 64 Lagrange row lows from
+/// its wire in-circuit ([`emit_lagrange_lows`]). AG: the point has NO
+/// transcript word — it decodes from (seed = two squeezes, nonce = a
+/// 4-byte observe) through a STANDALONE hash, so the tape records the seed
+/// ordinals and the nonce's payload ordinal, and the consumer publishes
+/// (seed, nonce, point, row lows) for the Tier-0 native checker
+/// ([`check_ag_skip_publics`], docs/ag-recursion-plan.md).
+enum ZskipTapeRec {
+    Rs {
+        ch: usize,
+        fin: usize,
+    },
+    Ag {
+        /// chals ordinal of seed word s0 (s1 sits at `seed_ch + 1`).
+        seed_ch: usize,
+        /// The two seed squeezes' finalization ordinals.
+        seed_fins: [usize; 2],
+        /// The r₁ nonce's byte-payload ordinal (the ObserveBytes/Pow
+        /// counter — its stream word is public under `bytes_payload_mask`).
+        nonce_payload: usize,
+    },
+}
+
 impl<'p> ChildTape<'p> {
     fn new(inner: &'p MixedInner, domain: &'static [u8]) -> Self {
         use flock_core::transcript_record::{RecordingChallenger, TranscriptOp as Op};
@@ -11571,16 +11839,28 @@ impl<'p> ChildTape<'p> {
         let blake_lc = blake_r1cs.csc_lincheck_circuit();
         let lcs: Vec<&dyn flock_core::lincheck::LincheckCircuit> = vec![blake_lc];
         let mut rec = RecordingChallenger::new(FsChallenger::with_chained_blake3(domain));
-        let all_claims = verifier::verify_ligerito_union_circuit(
-            &union,
-            &built.shape.circuit,
-            &built.witness.public,
-            &lcs,
-            &inner.commitment,
-            proof,
-            &inner.pcs,
-            &mut rec,
-        )
+        let all_claims = match proof {
+            MixedProof::Rs(p) => verifier::verify_ligerito_union_circuit(
+                &union,
+                &built.shape.circuit,
+                &built.witness.public,
+                &lcs,
+                &inner.commitment,
+                p,
+                &inner.pcs,
+                &mut rec,
+            ),
+            MixedProof::Ag(p) => verifier::verify_ligerito_union_circuit_ag(
+                &union,
+                &built.shape.circuit,
+                &built.witness.public,
+                &lcs,
+                &inner.commitment,
+                p,
+                &inner.pcs,
+                &mut rec,
+            ),
+        }
         .expect("the mixed circuit inner verifies");
         let native_claims = all_claims
             .boolean
@@ -11614,7 +11894,24 @@ impl<'p> ChildTape<'p> {
                 })
                 .collect()
         };
-        let zc_l = find(b"flock-zerocheck-v0");
+        // The boolean zerocheck region's anchor is flavor-specific; the
+        // OTHER flavor's label must be absent (one boolean zerocheck).
+        let zc_l = match proof {
+            MixedProof::Rs(_) => {
+                assert!(
+                    find(b"flock-ag-skip-v1").is_empty(),
+                    "an RS tape carries no AG-skip region"
+                );
+                find(b"flock-zerocheck-v0")
+            }
+            MixedProof::Ag(_) => {
+                assert!(
+                    find(b"flock-zerocheck-v0").is_empty(),
+                    "an AG tape carries no RS zerocheck region"
+                );
+                find(b"flock-ag-skip-v1")
+            }
+        };
         let lc_l = find(b"flock-lincheck-v0");
         let elzc_l = find(b"flock-element-union-zc-v0");
         let el_l = find(b"flock-element-union-lc-v0");
@@ -11673,36 +11970,62 @@ impl<'p> ChildTape<'p> {
         let fin_at = |end: usize| ops[..end].iter().filter(|o| o.finalizes()).count();
 
         // ---- the boolean zerocheck slices, same shape as the leaf ----
-        let bp = proof.boolean.as_ref().expect("boolean side present");
         assert_eq!(
-            proof.element.is_some(),
+            proof.element().is_some(),
             has_el,
             "the element proof section mirrors the union's classes"
         );
-        {
-            let mut i = zc_l[0] + 1;
-            while matches!(ops[i], Op::Pow { .. }) {
+        match proof {
+            MixedProof::Rs(p) => {
+                let bp = p.boolean.as_ref().expect("boolean side present");
+                let mut i = zc_l[0] + 1;
+                while matches!(ops[i], Op::Pow { .. }) {
+                    i += 1;
+                }
+                assert!(matches!(ops[i], Op::SqueezeSlice(_)), "zc tau lo");
                 i += 1;
+                assert!(matches!(ops[i], Op::SqueezeSlice(_)), "zc tau hi");
+                i += 1;
+                assert!(matches!(ops[i], Op::ObserveSlice(64)), "round1_ab");
+                let (v0, _) = vc_at(i);
+                assert_eq!(
+                    &vals_rec[v0..v0 + 64],
+                    &bp.zerocheck.round1_ab[..],
+                    "round1_ab on the stream"
+                );
+                i += 1;
+                assert!(matches!(ops[i], Op::ObserveSlice(64)), "round1_c");
+                let (v1, _) = vc_at(i);
+                assert_eq!(
+                    &vals_rec[v1..v1 + 64],
+                    &bp.zerocheck.round1_c[..],
+                    "round1_c on the stream"
+                );
             }
-            assert!(matches!(ops[i], Op::SqueezeSlice(_)), "zc tau lo");
-            i += 1;
-            assert!(matches!(ops[i], Op::SqueezeSlice(_)), "zc tau hi");
-            i += 1;
-            assert!(matches!(ops[i], Op::ObserveSlice(64)), "round1_ab");
-            let (v0, _) = vc_at(i);
-            assert_eq!(
-                &vals_rec[v0..v0 + 64],
-                &bp.zerocheck.round1_ab[..],
-                "round1_ab on the stream"
-            );
-            i += 1;
-            assert!(matches!(ops[i], Op::ObserveSlice(64)), "round1_c");
-            let (v1, _) = vc_at(i);
-            assert_eq!(
-                &vals_rec[v1..v1 + 64],
-                &bp.zerocheck.round1_c[..],
-                "round1_c on the stream"
-            );
+            MixedProof::Ag(p) => {
+                let bp = p.boolean.as_ref().expect("boolean side present");
+                let mut i = zc_l[0] + 1;
+                while matches!(ops[i], Op::Pow { .. }) {
+                    i += 1;
+                }
+                assert!(matches!(ops[i], Op::SqueezeSlice(_)), "ag r_outer");
+                i += 1;
+                assert!(matches!(ops[i], Op::ObserveSlice(158)), "ag round1_ab");
+                let (v0, _) = vc_at(i);
+                assert_eq!(
+                    &vals_rec[v0..v0 + 158],
+                    &bp.ag.round1_ab[..],
+                    "ag round1_ab on the stream"
+                );
+                i += 1;
+                assert!(matches!(ops[i], Op::ObserveSlice(64)), "ag round1_c");
+                let (v1, _) = vc_at(i);
+                assert_eq!(
+                    &vals_rec[v1..v1 + 64],
+                    &bp.ag.round1_c[..],
+                    "ag round1_c on the stream"
+                );
+            }
         }
 
         // ---- the wiring GKR region, walked op by op ----
@@ -11713,7 +12036,7 @@ impl<'p> ChildTape<'p> {
         // (f, g, s_sigma) triple observed last]. The walk also RECORDS the
         // ordinals the assembly wires against, and the per-round `g0` advice.
         let gkr_rec = {
-            let gkr = &proof.wiring.gkr;
+            let gkr = &proof.wiring().gkr;
             let mut i = gkr_l[0] + 1;
             while matches!(ops[i], Op::Pow { .. }) {
                 i += 1;
@@ -11917,7 +12240,7 @@ impl<'p> ChildTape<'p> {
                 let (sv, _) = vc_at(i);
                 assert_eq!(
                     &vals_rec[sv..sv + 128],
-                    &proof.pcs_open.ring_switches[k].s_hat_v[..],
+                    &proof.pcs_open().ring_switches[k].s_hat_v[..],
                     "s_hat_v {k} on the stream"
                 );
                 i += 1;
@@ -11960,7 +12283,7 @@ impl<'p> ChildTape<'p> {
             }
             assert_eq!(
                 w_rounds,
-                proof.pcs_open.merged_rounds.len(),
+                proof.pcs_open().merged_rounds.len(),
                 "the W rounds fill the dense domain"
             );
             while !matches!(&ops[i], Op::Label(l) if l.as_slice() == b"flock-multipoint-twisted-v1")
@@ -11983,11 +12306,11 @@ impl<'p> ChildTape<'p> {
         let n_el_pd = if has_el { 2 } else { 0 };
         assert_eq!(
             pd_recs.len(),
-            n_el_pd + proof.wiring.gather.len(),
+            n_el_pd + proof.wiring().gather.len(),
             "pd claims = element (c, lc) + the wiring gathers"
         );
         let pd_vals: Vec<F128> = pd_recs.iter().map(|&pv| vals_rec[pv]).collect();
-        for (k, g) in proof.wiring.gather.iter().enumerate() {
+        for (k, g) in proof.wiring().gather.iter().enumerate() {
             assert!(
                 pd_vals.contains(g),
                 "gather value {k} rides a packed-direct claim"
@@ -11995,7 +12318,7 @@ impl<'p> ChildTape<'p> {
         }
 
         // ---- the multipoint: the R=2 + P>0 schedule, pinned ----
-        let fro = &proof.pcs_open.frobenius;
+        let fro = &proof.pcs_open().frobenius;
         let n_p = fro.group_values.len();
         assert!(n_p > 0, "a circuit inner carries scalar groups (P > 0)");
         {
@@ -12098,7 +12421,7 @@ impl<'p> ChildTape<'p> {
         assert_chain_replays(&ops, &trace, &chals);
 
         // ---- the open-phase walk + geometry ----
-        let lig = &proof.pcs_open.inner.ligerito;
+        let lig = &proof.pcs_open().inner.ligerito;
         assert_eq!(
             inner.commitment.cap, lig.initial_cap,
             "commitment IS the L0 cap"
@@ -12359,7 +12682,7 @@ impl<'p> ChildTape<'p> {
             inner.built.shape.circuit.cells(),
             n_log_i,
             &inner.built.witness.public,
-            &inner.proof.wiring.gather,
+            &inner.proof.wiring().gather,
             &gammas_o,
             n_el_pd,
             &vals_rec,
@@ -12393,9 +12716,22 @@ impl<'p> ChildTape<'p> {
         // statements sit at points made of its round challenges, and the
         // MatrixAssertion's surfaces (x_inner_rest, rr, z_skip, z_partial)
         // map onto the same walk — the merge node's connects consume them.
+        // Byte-payload ordinal of the op at `end` (ObserveBytes and Pow
+        // share the payload counter — see [`bytes_payload_mask`]).
+        let payload_at = |end: usize| -> usize {
+            ops[..end]
+                .iter()
+                .filter(|o| {
+                    matches!(
+                        o,
+                        Op::ObserveBytes(_) | Op::Pow { .. } | Op::LegacyPow { .. }
+                    )
+                })
+                .count()
+        };
         let (
             zc_rounds_b,
-            (zskip_ch, zskip_fin),
+            zskip,
             (outer_ch_b, outer_fin_b),
             bl_alpha,
             betas_b,
@@ -12408,21 +12744,70 @@ impl<'p> ChildTape<'p> {
             while matches!(ops[i2], Op::Pow { .. }) {
                 i2 += 1;
             }
-            assert!(matches!(ops[i2], Op::SqueezeSlice(_)), "r_skip slice");
-            i2 += 1;
-            assert!(matches!(ops[i2], Op::SqueezeSlice(_)), "r_outer slice");
-            let outer = (vc_at(i2).1, fin_at(i2));
-            i2 += 1;
-            assert!(matches!(ops[i2], Op::ObserveSlice(64)), "round1_ab");
-            i2 += 1;
-            assert!(matches!(ops[i2], Op::ObserveSlice(64)), "round1_c");
-            i2 += 1;
-            while matches!(ops[i2], Op::Pow { .. }) {
-                i2 += 1;
-            }
-            assert!(matches!(ops[i2], Op::SqueezeScalar), "z_skip");
-            let zskip = (vc_at(i2).1, fin_at(i2));
-            i2 += 1;
+            // The flavored region head. RS: two squeeze slices (r_skip +
+            // r_outer), the two 64-slices, then the fused z_skip squeeze.
+            // AG: ONE squeeze slice (r_outer), the 158+64 round-1 slices,
+            // then r₁'s 5-op surface — seed label, two seed squeezes,
+            // nonce label, the 4-byte nonce observe (the point itself has
+            // no transcript word; it decodes from seed ‖ nonce).
+            let (outer, zskip) = match proof {
+                MixedProof::Rs(_) => {
+                    assert!(matches!(ops[i2], Op::SqueezeSlice(_)), "r_skip slice");
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::SqueezeSlice(_)), "r_outer slice");
+                    let outer = (vc_at(i2).1, fin_at(i2));
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::ObserveSlice(64)), "round1_ab");
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::ObserveSlice(64)), "round1_c");
+                    i2 += 1;
+                    while matches!(ops[i2], Op::Pow { .. }) {
+                        i2 += 1;
+                    }
+                    assert!(matches!(ops[i2], Op::SqueezeScalar), "z_skip");
+                    let zskip = ZskipTapeRec::Rs {
+                        ch: vc_at(i2).1,
+                        fin: fin_at(i2),
+                    };
+                    i2 += 1;
+                    (outer, zskip)
+                }
+                MixedProof::Ag(_) => {
+                    assert!(matches!(ops[i2], Op::SqueezeSlice(_)), "ag r_outer slice");
+                    let outer = (vc_at(i2).1, fin_at(i2));
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::ObserveSlice(158)), "ag round1_ab");
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::ObserveSlice(64)), "ag round1_c");
+                    i2 += 1;
+                    assert!(
+                        matches!(&ops[i2], Op::Label(l) if l.as_slice() == b"flock-ag-skip-r1-point"),
+                        "ag r1 seed label"
+                    );
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::SqueezeScalar), "ag r1 seed s0");
+                    let seed_ch = vc_at(i2).1;
+                    let seed_fin0 = fin_at(i2);
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::SqueezeScalar), "ag r1 seed s1");
+                    assert_eq!(vc_at(i2).1, seed_ch + 1, "seed words are adjacent");
+                    let seed_fin1 = fin_at(i2);
+                    i2 += 1;
+                    assert!(
+                        matches!(&ops[i2], Op::Label(l) if l.as_slice() == b"flock-ag-skip-r1-nonce"),
+                        "ag r1 nonce label"
+                    );
+                    i2 += 1;
+                    assert!(matches!(ops[i2], Op::ObserveBytes(4)), "ag r1 nonce bytes");
+                    let zskip = ZskipTapeRec::Ag {
+                        seed_ch,
+                        seed_fins: [seed_fin0, seed_fin1],
+                        nonce_payload: payload_at(i2),
+                    };
+                    i2 += 1;
+                    (outer, zskip)
+                }
+            };
             let mut zc_r: Vec<(usize, usize)> = Vec::new();
             while matches!(ops[i2], Op::ObserveScalar) && matches!(ops[i2 + 1], Op::ObserveScalar) {
                 let mut squeeze_i = i2 + 2;
@@ -12512,7 +12897,29 @@ impl<'p> ChildTape<'p> {
                     "rr {j} is the located lc round, reversed"
                 );
             }
-            assert_eq!(chals[zskip_ch], bool_assert.z_skip.phi8(), "z_skip located");
+            // The z_skip pin, by flavor: RS locates the fused squeeze; AG
+            // has no point word — rebuild the seed from the two located
+            // squeezes, decode H(seed ‖ nonce) under the child's grinding
+            // schedule, and pin the assertion's point to the decode.
+            match (proof, &zskip) {
+                (MixedProof::Rs(_), ZskipTapeRec::Rs { ch, .. }) => {
+                    assert_eq!(chals[*ch], bool_assert.z_skip.phi8(), "z_skip located");
+                }
+                (MixedProof::Ag(p), ZskipTapeRec::Ag { seed_ch, .. }) => {
+                    let nonce = p.boolean.as_ref().expect("boolean side present").ag.r1_nonce;
+                    let pt = decode_ag_point(
+                        &ag_seed_bytes(chals[*seed_ch], chals[*seed_ch + 1]),
+                        nonce,
+                        inner.pcs.zerocheck_grinding().ag_r1_bits(),
+                    );
+                    assert_eq!(
+                        bool_assert.z_skip,
+                        flock_core::lincheck::SkipPoint::Ag(pt),
+                        "z_skip is the r1 point decoded from the located seed + nonce"
+                    );
+                }
+                _ => unreachable!("the tape's zskip record matches the proof flavor"),
+            }
             assert_eq!(
                 &vals_rec[zp_v..zp_v + 64],
                 &bool_assert.z_partial[..],
@@ -12806,7 +13213,7 @@ impl<'p> ChildTape<'p> {
         }
 
         // ---- the residual pairing's rotation (lane-major inners) ----
-        let yr_len = proof.pcs_open.inner.ligerito.final_proof.yr.len() / 2;
+        let yr_len = proof.pcs_open().inner.ligerito.final_proof.yr.len() / 2;
         let lane_major = geo[0].row_words < geo[0].lanes;
         let w_resid: Vec<RoundRec> = if lane_major {
             let k_rot = w_rounds.len() - levels[0].fold_fins.len();
@@ -12862,8 +13269,7 @@ impl<'p> ChildTape<'p> {
             lc_msg_vs,
             lc_rounds_b,
             eps_n,
-            zskip_ch,
-            zskip_fin,
+            zskip,
             zp_v,
             ga_c,
             ga_fin,
@@ -13061,6 +13467,19 @@ impl ChildSlots {
 /// What one emitted child region hands back: where its public block starts,
 /// the walk counts the checker needs, and the assertion-emission wires the
 /// mvp11 merge node CONNECTS the fold region's claim words to.
+/// A child region's z_skip wires, by flavor. RS: the one fused-squeeze
+/// output — the merge assembly derives the 64 Lagrange row lows from it
+/// IN-CIRCUIT ([`emit_lagrange_lows`]; no publish, no checker rebuild).
+/// AG: the seed squeezes' outputs and the r₁ nonce's stream-word wire —
+/// the merge assembly publishes them beside the point and the row lows,
+/// and the Tier-0 checker ([`check_ag_skip_publics`]) re-derives the point
+/// and the lows natively (docs/ag-recursion-plan.md; the in-circuit
+/// derivation is Phase D's `emit_ag_lows`).
+enum ZskipWires {
+    Rs(Wire),
+    Ag { seed_w: [Wire; 2], nonce_w: Wire },
+}
+
 struct ChildRegion {
     pub_base: usize,
     n_query_pub: usize,
@@ -13087,9 +13506,8 @@ struct ChildRegion {
     /// Reported matrix evaluations, constrained by the in-circuit scalar
     /// closure and connected to the aggregate fold's fresh claim values.
     mat_eval_w: Vec<(Wire, Wire)>,
-    /// The z_skip squeeze wire — the merge assemblies derive the lagrange
-    /// row lows from it IN-CIRCUIT (no publish, no checker rebuild).
-    zskip_w: Wire,
+    /// The z_skip surface, by flavor — see [`ZskipWires`].
+    zskip: ZskipWires,
     /// The residual close-out's prefix slot (and width) — reusable by a
     /// caller emitting more prefix products into the same builder.
     pf: (flock_core::circuit::builder::SlotId, usize),
@@ -13624,13 +14042,22 @@ fn emit_child_region(
     // γ^{256+k}·eq(ρ,ρ″)·(w_k·DP_k) over the P groups; claim == expect
     // publishes as a zero-delta. ĝ's inverse-Frobenius points ride as advice
     // bound by forward squaring deltas.
-    use flock_core::zerocheck::univariate_skip_optimized::{
-        medium_challenges_ghash, small_challenges_ghash,
+    // The c-point's 7 baked inner constants are the zerocheck's friendly
+    // challenges — the RS ghash set or the AG set, by the tape's flavor
+    // (baked constants are free in-circuit either way).
+    let t_vals_b: Vec<F128> = match &ct.zskip {
+        ZskipTapeRec::Rs { .. } => {
+            use flock_core::zerocheck::univariate_skip_optimized::{
+                medium_challenges_ghash, small_challenges_ghash,
+            };
+            let mut v: Vec<F128> = Vec::new();
+            v.extend_from_slice(&small_challenges_ghash());
+            v.extend_from_slice(&medium_challenges_ghash());
+            v
+        }
+        ZskipTapeRec::Ag { .. } => flock_core::zerocheck::ag_skip::friendly_challenges().to_vec(),
     };
-    let mut t_vals_b: Vec<F128> = Vec::new();
-    t_vals_b.extend_from_slice(&small_challenges_ghash());
-    t_vals_b.extend_from_slice(&medium_challenges_ghash());
-    assert_eq!(t_vals_b.len(), 7, "the seven baked ghash weights");
+    assert_eq!(t_vals_b.len(), 7, "the seven baked inner constants");
 
     // The statements' points as (native value, wire) pairs, pinned against
     // the native claims: ab = [LAST lc round | zc mlv rounds 1..1+ν | lc
@@ -13667,9 +14094,14 @@ fn emit_child_region(
             if k2 < 7 {
                 (t_vals_b[k2], cw(sb, vals, consts, t_vals_b[k2]))
             } else {
+                // The exact (row, word) map — a FUSED slice squeeze (the
+                // AG r_outer grind) reserves one word per row for the PoW
+                // predicate, so the naive 4-per-row split misaddresses.
                 let j = k2 - 7;
-                let sq2 = &trace.squeezes[outer_fin_b];
-                (chals[outer_ch_b + j], outs[sq2[j / 4]][j % 4])
+                (
+                    chals[outer_ch_b + j],
+                    squeeze_word_wire(&outs, trace, outer_fin_b, j),
+                )
             }
         })
         .collect();
@@ -14083,7 +14515,33 @@ fn emit_child_region(
             .collect(),
         b_zpartial_w: (0..64).map(|i| wv(ct.zp_v + i)).collect(),
         mat_eval_w,
-        zskip_w: outs[trace.squeezes[ct.zskip_fin][0]][0],
+        zskip: match &ct.zskip {
+            ZskipTapeRec::Rs { fin, .. } => ZskipWires::Rs(outs[trace.squeezes[*fin][0]][0]),
+            ZskipTapeRec::Ag {
+                seed_fins,
+                nonce_payload,
+                ..
+            } => {
+                let nonce_wi = stream
+                    .words
+                    .iter()
+                    .position(|w| {
+                        matches!(
+                            w,
+                            flock_core::transcript_record::StreamWord::Bytes { payload, word: 0 }
+                                if *payload == *nonce_payload
+                        )
+                    })
+                    .expect("the r1 nonce rides one stream word");
+                ZskipWires::Ag {
+                    seed_w: [
+                        squeeze_word_wire(&outs, trace, seed_fins[0], 0),
+                        squeeze_word_wire(&outs, trace, seed_fins[1], 0),
+                    ],
+                    nonce_w: ww[nonce_wi].expect("the nonce payload word is wired"),
+                }
+            }
+        },
         pf: (pfslot, pf_w),
         child_pub_w: pub_w,
     }
@@ -14193,7 +14651,7 @@ fn check_child_region(public: &[F128], ct: &ChildTape<'_>, r: &ChildRegion) -> u
     // the mu point coordinates, matched against the native claim.
     let sig_base = mp_base + 5 + 2 * ct.levels.len() * ct.yr_len + 2;
     assert_eq!(
-        public[sig_base], ct.inner.proof.wiring.gkr.s_sigma_eval,
+        public[sig_base], ct.inner.proof.wiring().gkr.s_sigma_eval,
         "the emitted sigma value is the proof's deferred evaluation"
     );
     let sig_rho = &public[sig_base + 1..sig_base + 1 + ct.mu_i];
@@ -14888,6 +15346,87 @@ fn read_acc_entry(
             value,
         },
     )
+}
+
+/// The Tier-0 AG-skip checker (docs/ag-recursion-plan.md, Phase B): walk
+/// one AG child's published block `[seed0, seed1, nonce, point ×5,
+/// lows ×64]` — re-derive the point from `H(seed ‖ nonce)` under the
+/// child's grinding schedule (fused PoW + decode on ONE hash) and the row
+/// lows as the point's base evaluation functional. The seed and nonce
+/// publics are wire-connected to the child's transcript and the lows
+/// publics to the fold's absorbed row lows, so this closes the same
+/// binding [`emit_lagrange_lows`] gives an RS child in-circuit. Returns
+/// the number of public words consumed.
+fn check_ag_skip_publics(public: &[F128], base: usize, ag_r1_bits: Option<u32>) -> usize {
+    let seed = ag_seed_bytes(public[base], public[base + 1]);
+    let nonce_word = public[base + 2];
+    assert_eq!(nonce_word.hi, 0, "the nonce word's high half is zero");
+    let nonce = u32::try_from(nonce_word.lo).expect("the nonce fits 32 bits");
+    let budget = match ag_r1_bits {
+        Some(_) => flock_core::zerocheck::ag_skip::R1_FUSED_ATTEMPT_BUDGET,
+        None => flock_core::genus95_curve_code::SAMPLE_ATTEMPT_BUDGET,
+    };
+    assert!(nonce < budget, "the nonce is inside the prover's scan budget");
+    let pt = decode_ag_point(&seed, nonce, ag_r1_bits);
+    for (j, c) in [pt.x, pt.y, pt.z1, pt.z2, pt.z3].into_iter().enumerate() {
+        assert_eq!(public[base + 3 + j], c, "published AG point coord {j}");
+    }
+    let bf = flock_core::genus95_curve_code::base_evaluation_functional(&pt)
+        .expect("the base functional exists at a decoded point");
+    for j in 0..64 {
+        assert_eq!(public[base + 8 + j], bf[j], "published AG row low {j}");
+    }
+    72
+}
+
+/// The Tier-0 checker rejects every tampered surface of the published AG
+/// block: a shifted nonce (fails the fused PoW+decode — and if a shifted
+/// nonce happens to decode, its point differs and the coord pin catches
+/// it), a tampered point coordinate, a tampered row low, an out-of-budget
+/// nonce, and a tampered seed word. The honest block passes and consumes
+/// exactly 72 words.
+#[test]
+fn ag_skip_publics_checker_rejects_tampers() {
+    use flock_core::genus95_curve_code::{
+        base_evaluation_functional, evaluation_point_from_nonce_pow,
+    };
+    use flock_core::zerocheck::ag_skip::{R1_FUSED_ATTEMPT_BUDGET, R1_POW_BITS};
+    let (s0, s1) = (F128::new(0xA6, 0x51), F128::new(0x1F, 0xB3));
+    let seed = ag_seed_bytes(s0, s1);
+    let (nonce, pt) = (0..R1_FUSED_ATTEMPT_BUDGET)
+        .find_map(|n| {
+            evaluation_point_from_nonce_pow(&seed, n, HashKind::Blake3, R1_POW_BITS)
+                .map(|p| (n, p))
+        })
+        .expect("a valid fused nonce exists in the budget");
+    let bf = base_evaluation_functional(&pt).expect("the functional exists at a sampled point");
+    let base = 3usize; // the checker walks from an arbitrary base
+    let mut public = vec![F128::ZERO; base];
+    public.extend([s0, s1, F128::new(u64::from(nonce), 0)]);
+    public.extend([pt.x, pt.y, pt.z1, pt.z2, pt.z3]);
+    public.extend((0..64).map(|j| bf[j]));
+    assert_eq!(
+        check_ag_skip_publics(&public, base, Some(R1_POW_BITS)),
+        72,
+        "the honest block passes"
+    );
+
+    let rejects = |mutate: &dyn Fn(&mut [F128])| -> bool {
+        let mut bad = public.clone();
+        mutate(&mut bad);
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            check_ag_skip_publics(&bad, base, Some(R1_POW_BITS))
+        }))
+        .is_err()
+    };
+    assert!(rejects(&|p| p[base] += F128::ONE), "tampered seed word");
+    assert!(rejects(&|p| p[base + 2] += F128::ONE), "shifted nonce");
+    assert!(
+        rejects(&|p| p[base + 2] = F128::new(u64::from(R1_FUSED_ATTEMPT_BUDGET), 0)),
+        "out-of-budget nonce"
+    );
+    assert!(rejects(&|p| p[base + 4] += F128::ONE), "tampered point coord");
+    assert!(rejects(&|p| p[base + 8 + 17] += F128::ONE), "tampered row low");
 }
 
 /// Walk the published fold blocks from `tail0`: both endpoint deltas zero
@@ -18919,7 +19458,7 @@ fn chain_tower_m32_headline() {
             / 1024.0,
     );
     proof_census("internal node", &node.proof, &node.pcs);
-    proof_census("chain leaf (m32 Fast)", &cp0.inner.proof, &cp0.inner.pcs);
+    proof_census_mixed("chain leaf (m32 Fast)", &cp0.inner.proof, &cp0.inner.pcs);
     proof_census("FL node", &fl0.lo.proof, &fl0.lo.pcs);
 }
 

--- a/crates/flock-prover/tests/circuit_wiring.rs
+++ b/crates/flock-prover/tests/circuit_wiring.rs
@@ -1678,3 +1678,133 @@ fn a_merge_node_folds_two_circuit_proofs() {
         "both children's sigma claims fold through the merge to one root discharge"
     );
 }
+
+/// AG-flavor twin of [`cross_class_hash_into_mult`]: the SAME mixed
+/// boolean+element circuit (SHA-256 gate crossing into an element mult, one
+/// public product) proven and verified through the **AG-skip** circuit
+/// entries — the element class and wiring are flavor-independent, only the
+/// boolean zerocheck's round 1 changes. Plus the AG-specific tamper arms:
+/// the fused r₁ nonce and the fused lincheck skip nonce must reject.
+#[cfg(target_arch = "aarch64")]
+#[test]
+#[ignore] // Heavier — run with `-- --ignored`.
+fn cross_class_circuit_ag_roundtrip() {
+    let (nu, kappa) = (7usize, 2usize);
+    let r1cs = sha2::build_block_r1cs(nu);
+    let registry = Registry::new(
+        vec![
+            mult_ty(kappa),
+            TableType::from_block_r1cs(&r1cs).with_io_schema(sha2_schema()),
+        ],
+        nu,
+    );
+
+    let mut rng = Rng::new(0xA6C2_0001);
+    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+    let h_out = sha2::sha256_compress(&sha2::SHA256_IV, &m);
+    let out_words = pack_u32_words(&h_out);
+    let (o0, o1) = (out_words[0], out_words[1]);
+
+    let mut public = pack_u32_words(&sha2::SHA256_IV);
+    public.extend(pack_u32_words(&m));
+    public.push(o0 * o1);
+
+    const EL: usize = 8;
+    const PUB: usize = 11;
+    let wires = vec![
+        vec![Cell::new(PUB, 0), Cell::new(SHA_H0, 0)],
+        vec![Cell::new(PUB, 1), Cell::new(SHA_H1, 0)],
+        vec![Cell::new(PUB, 2), Cell::new(SHA_M0, 0)],
+        vec![Cell::new(PUB, 3), Cell::new(SHA_M0 + 1, 0)],
+        vec![Cell::new(PUB, 4), Cell::new(SHA_M0 + 2, 0)],
+        vec![Cell::new(PUB, 5), Cell::new(SHA_M0 + 3, 0)],
+        vec![Cell::new(SHA_O0, 0), Cell::new(EL + EL_A, 0)],
+        vec![Cell::new(SHA_O1, 0), Cell::new(EL + EL_B, 0)],
+        vec![Cell::new(EL + EL_C, 0), Cell::new(PUB, 6)],
+    ];
+
+    let counts = vec![1usize, 1];
+    let union = UnionInstance::new(&registry, counts.clone());
+    let pcs_params = union_pcs_params(&union);
+    let circuit = Circuit::new(&registry, counts, public.len(), wires).expect("valid");
+
+    let el_ty = registry.types()[1].element_type().expect("element");
+    let mut z = vec![F128::ZERO; el_ty.width() << nu];
+    z[0 << nu] = o0;
+    z[1 << nu] = o1;
+    z[2 << nu] = o0 * o1;
+    let circuit_lc = r1cs.csc_lincheck_circuit();
+
+    let z_gen = z.clone();
+    let mut ch = FsChallenger::new(DOMAIN);
+    let (proof, commitment, claims) = prover::prove_fast_ligerito_union_circuit_ag(
+        &union,
+        &circuit,
+        &public,
+        &pcs_params,
+        vec![UnionSlotProverInput::new(
+            sha2::generate_witness_batch_major_partial(&[(sha2::SHA256_IV, m)], nu),
+            circuit_lc,
+        )],
+        vec![UnionElementSlotInput::new(move |dst: &mut [F128]| {
+            dst.copy_from_slice(&z_gen)
+        })],
+        &mut ch,
+    );
+    assert!(claims.boolean.is_some() && claims.element.is_some());
+
+    let verify = |p: &flock_core::proof::R1csProofCircuitMergedAg| {
+        let mut ch = FsChallenger::new(DOMAIN);
+        verifier::verify_ligerito_union_circuit_ag(
+            &union,
+            &circuit,
+            &public,
+            &[circuit_lc],
+            &commitment,
+            p,
+            &pcs_params,
+            &mut ch,
+        )
+    };
+    verify(&proof).expect("honest AG cross-class circuit verifies");
+
+    // The DEFERRED twin accepts and returns dischargeable work.
+    let mut ch = FsChallenger::new(DOMAIN);
+    let (_, work, _sigma) = verifier::verify_ligerito_union_circuit_ag_deferred(
+        &union,
+        &circuit,
+        &public,
+        &[circuit_lc],
+        &commitment,
+        &proof,
+        &pcs_params,
+        &mut ch,
+    )
+    .expect("deferred AG verify accepts");
+    work.boolean
+        .expect("boolean assertion present")
+        .check(&union, &[circuit_lc])
+        .expect("deferred boolean matrix work discharges");
+
+    // AG round-1 message tamper.
+    let mut bad = proof.clone();
+    bad.boolean.as_mut().expect("boolean").ag.round1_ab[0] += F128::ONE;
+    assert!(verify(&bad).is_err(), "tampered AG round-1 accepted");
+
+    // Fused r₁ nonce tamper.
+    let mut bad = proof.clone();
+    let n = &mut bad.boolean.as_mut().expect("boolean").ag.r1_nonce;
+    *n = n.wrapping_add(1);
+    assert!(verify(&bad).is_err(), "tampered fused r1 nonce accepted");
+
+    // Fused lincheck skip nonce tamper (the last lincheck nonce).
+    let mut bad = proof.clone();
+    *bad.boolean
+        .as_mut()
+        .expect("boolean")
+        .lincheck
+        .grinding_nonces
+        .last_mut()
+        .expect("AG arm carries a fused skip nonce") ^= 1;
+    assert!(verify(&bad).is_err(), "tampered fused skip nonce accepted");
+}

--- a/docs/128-bit-grinding-audit.md
+++ b/docs/128-bit-grinding-audit.md
@@ -571,8 +571,12 @@ rejection sampling from a transcript seed, with a nonce in the proof
 strict schedule the nonce is FUSED: `H(seed || nonce)` must clear the
 explicit PoW target AND decode to a valid point — both criteria on the same
 hash, so every candidate an adversary evaluates re-enters the PoW and there
-is no free choice among valid nonces. The verifier is one attempt
-(constant-shape, no rejection replay).
+is no free choice among valid nonces. The PoW predicate is the transcript
+convention: leading zero bits, MSB-first within each serialized byte, of the
+hash's second 16-byte word — the same predicate word and bit order the
+recursion circuit's `PowMaskTable` checks, so the in-circuit form is a
+gadget reuse. The verifier is one attempt (constant-shape, no rejection
+replay).
 
 The rejection sampling itself contributes exactly `log2(32) = 5` bits, by
 two facts, neither empirical:

--- a/docs/128-bit-grinding-audit.md
+++ b/docs/128-bit-grinding-audit.md
@@ -223,7 +223,7 @@ All bit counts below are sufficient for the strict local rule.
 | Boolean lincheck batching/pins | 1 | 1 |
 | Boolean lincheck ordinary round | 2 | 2 |
 | Boolean lincheck final skip | `2^k-1` | `k` |
-| AG-skip zerocheck `r_1` (fused nonce) | 474 | 4 explicit + 5 sampling credit |
+| AG-skip zerocheck `r_1` (fused nonce) | 474 | 9 explicit (no sampling credit at `r_1`) |
 | AG-basis lincheck final skip (fused nonce) | 158 | 3 explicit + 5 sampling credit |
 | Element zerocheck initial equality point | `m_words` | `bits_for_degree(m_words)` |
 | Element zerocheck/lincheck ordinary round | 2 | 2 |
@@ -590,8 +590,14 @@ two facts, neither empirical:
 
 Work-normalized, a candidate costs at least one hash and succeeds with
 probability `p * 2^-b * numerator / N <= 2^-(b+5) * numerator / 2^128 * (1 + 2^-55)`,
-so `b_explicit = bits_for_degree(numerator) - 5`: **4 bits at `r_1`, 3 at
-the lincheck skip**. The constants are tied together by
+so `b_explicit = bits_for_degree(numerator) - 5` where the sampling credit
+applies. The credit applies at the LINCHECK skip only (**3 explicit
+bits**): its decode stays canonical end-to-end. At `r_1` the recursion
+circuit binds the decode with RELAXED canonicity (`emit_ag_point_binding`
+accepts any of the <= 32 fiber points over the XOF-derived `x`), which
+returns the sampler's 5 flattening bits to a circuit-side prover — so
+`r_1` carries **all `bits_for_degree(474) = 9` bits explicitly** and the
+total budget is unchanged. The constants are tied together by
 `ag_skip::credit_constants_are_pinned` (code degrees, the `4 * 8 = 32`
 sampler shape, and both explicit-bit splits) and the statistical pin
 `genus95_curve_code::tests::acceptance_rate_is_one_in_32`; a sampler

--- a/docs/128-bit-grinding-audit.md
+++ b/docs/128-bit-grinding-audit.md
@@ -223,6 +223,8 @@ All bit counts below are sufficient for the strict local rule.
 | Boolean lincheck batching/pins | 1 | 1 |
 | Boolean lincheck ordinary round | 2 | 2 |
 | Boolean lincheck final skip | `2^k-1` | `k` |
+| AG-skip zerocheck `r_1` (fused nonce) | 474 | 4 explicit + 5 sampling credit |
+| AG-basis lincheck final skip (fused nonce) | 158 | 3 explicit + 5 sampling credit |
 | Element zerocheck initial equality point | `m_words` | `bits_for_degree(m_words)` |
 | Element zerocheck/lincheck ordinary round | 2 | 2 |
 | Element lincheck batching | 1 | 1 |
@@ -537,6 +539,73 @@ For each initial vector, the union of its sampled exceptional hyperplanes has
 degree at most the dimension used by `bits_for_degree`. Thus that exceptional
 family, treated as its own algebraic part, also has a strict sub-`2^-128`
 work-normalized term.
+
+### AG-skip challenge family (union-AG route)
+
+The AG-skip zerocheck (`zerocheck/ag_skip.rs`) and the AG-basis lincheck
+skip replace two φ₈-basis challenges with points on the genus-95 cover.
+Both are covered by the same strict local rule, with two AG-specific
+ingredients: code-degree numerators and a provable sampling credit.
+
+**Numerators.** Code dimensions fix the degrees through Riemann–Roch
+(`deg = dim + g - 1`, `g = 95`): the base code `L(D)` has `dim 64`, so
+`deg D = 158`; the product code `L(2D)` has `dim 222`, so `deg 2D = 316`.
+
+- `r_1` protects the round-1 message pair: a false message survives only if
+  a nonzero product-code word (at most 316 zeros — the ab check) or a
+  nonzero base-code word (at most 158 — the c check) vanishes at `r_1`:
+  numerator `474`, so `bits_for_degree(474) = 9`.
+- The lincheck's fresh AG skip point protects `z_partial` exactly as the φ₈
+  final skip does, but the interpolant is a base-code word: numerator `158`,
+  so `bits_for_degree(158) = 8` (the φ₈ basis's `2^6 - 1 = 63 -> 6` row).
+
+The challenge space is the set of valid cover points: Hasse–Weil bounds the
+genus-95 cover's count within `2 * 95 * 2^64` of `2^128`, and the sampler's
+exclusions (denominator poles — the x-degree-49 product denominator — and
+points at infinity) remove a few hundred more, so the denominator is
+`2^128 (1 - 2^-56)`; the slack is absorbed by the strict `+1` bit.
+
+**Fused nonce and the sampling credit.** Both sites derive their point by
+rejection sampling from a transcript seed, with a nonce in the proof
+(`AgProof::r1_nonce`; the lincheck's skip slot in its nonce vector). Under a
+strict schedule the nonce is FUSED: `H(seed || nonce)` must clear the
+explicit PoW target AND decode to a valid point — both criteria on the same
+hash, so every candidate an adversary evaluates re-enters the PoW and there
+is no free choice among valid nonces. The verifier is one attempt
+(constant-shape, no rejection replay).
+
+The rejection sampling itself contributes exactly `log2(32) = 5` bits, by
+two facts, neither empirical:
+
+1. *Uniformity*: the sampler weights every reachable cover point at exactly
+   `1 / (2^128 * 4 * 8)` — slot flattening over the degree-4 base fiber,
+   and the z-fiber is all-or-nothing (three Artin–Schreier levels, eight
+   lifts selected by three uniform choice bits; any failure rejects the
+   whole x). So a valid draw costs at least `~32` attempts.
+2. *Hasse–Weil* pins the acceptance probability to `(1/32)(1 ± 2^-56)`.
+
+Work-normalized, a candidate costs at least one hash and succeeds with
+probability `p * 2^-b * numerator / N <= 2^-(b+5) * numerator / 2^128 * (1 + 2^-55)`,
+so `b_explicit = bits_for_degree(numerator) - 5`: **4 bits at `r_1`, 3 at
+the lincheck skip**. The constants are tied together by
+`ag_skip::credit_constants_are_pinned` (code degrees, the `4 * 8 = 32`
+sampler shape, and both explicit-bit splits) and the statistical pin
+`genus95_curve_code::tests::acceptance_rate_is_one_in_32`; a sampler
+reshape breaks the guard tests before it can silently void the credit.
+
+The AG protocol's seven friendly inner coordinates are protocol-fixed
+constants (the γ-geometric weights), not challenges — the same treatment as
+the boolean zerocheck's seven fixed inner coordinates in the
+challenge-dependent denominator audit above. The ungrinded direct route
+(`prove_fast_ag`) keeps the plain single-attempt nonce and makes no 128-bit
+claim (its nonce freedom is at most `log2(20000) = 14.3` bits).
+
+Remaining AG-specific obligations before a strict profile may select this
+family: an external check of the curve data underlying both uses of
+Hasse–Weil (genus, absolute irreducibility — the `AG_codes`
+`F2_human_audit/` artifacts, which the code-degree soundness already
+assumes), and the recursive-circuit treatment of the fused check (one hash
+plus one point evaluation; constant-shape by construction).
 
 ## Production coverage matrix
 

--- a/docs/ag-recursion-plan.md
+++ b/docs/ag-recursion-plan.md
@@ -69,17 +69,27 @@ same session — `TOWER_LEAF_ZC=rs` vs default): leaf online 520.9 → 469.8 ms
 (prove 475.8 → 427.7, −10.1%); amortised 762 → 688 ms/leaf = 344k → 381k
 compressions/sec (+10.7%). The internal/spine arms flipped between the two
 runs (wide bands on one arm — box noise); the leaf bands are tight, so the
-leaf delta is the solid number. OPEN ATTRIBUTION: the recorded union-AG
-margin (466.0 → 367.3 at m32, −98.7 ms) predicted ~−100 ms; the leaf shows
-−48 on the prove. The RS arm matches its union twin (475.8 ≈ 466 + wiring),
-the AG arm runs ~50 ms above its (427.7 vs ~377). The honest-zero forcing
-is NOT the cause: the chain leaf is identity-compacted, so BOTH flavors run
-PooledZeroed (verified with PCS_TRACE — the RS arm's PooledDirty election
-requires !identity), and the padding cost is identical across arms. The gap
-is unattributed; candidates: the AG round-1's dense full-region scan vs the
-RS run-list gating on this shape, or the recorded three-arm bench's arm not
-matching the leaf's exact profile/transport. Worth one attribution pass
-before Phase C multiplies it across the outers.
+leaf delta is the solid number. ATTRIBUTION RESOLVED (same day, evening 3): **the ~50 ms "gap" was not a
+real AG cost — the reference was stale.** The recorded union numbers
+(466.0/367.3, margin 98.7) came from a pressured-box session; re-run fresh
+on a quiet box the same bench reads 375.3/319.1 (margin 56.2, 1.176×).
+Three independent same-session probes then agree at m32:
+- isolated zerocheck (ag_e2e_zerocheck): 161.7 → 101.4, margin 60.3
+  (round-1 URM 2.29×, fold 1.24×, mlv tail 1.00× — the win is ALL round 1);
+- union prove (blake3_rs_vs_ag): 375.3 → 319.1, margin 56.2;
+- leaf PIOP∥wiring phase (PCS_TRACE): 172.9 → 119.8, margin 53.1 —
+  commit and open are flavor-identical code and their apparent deltas
+  (±10) are the cross-run noise floor.
+So the flavor margin carries through the circuit path undiminished — the
+wiring (μ = 22, 11 claims) hides inside BOTH flavors' PIOP spans — and
+there is nothing leaf-specific to fix. WHY the stale margin was 99: the RS
+round-1 URM is memory-bandwidth-bound and inflates disproportionately
+under box pressure (466 → 375 = +24% vs AG's +15%) — the same mechanism as
+the recorded a503066 swapping-box incident. LESSON: flavor A/B RATIOS are
+box-state-dependent; trust same-process interleaved A/Bs (the three-arm
+bench's warm-up discipline), never cross-session number reuse. The honest
+quiet-box m32 zerocheck margin is ~53–60 ms ≈ 1.6× isolated, 1.18× on the
+union prove.
 
 **AG/RS OPTIMIZATION PARITY (Ron's call, same day): CLOSED** — the AG
 zerocheck now has every RS-branch optimization (commits on this branch):

--- a/docs/ag-recursion-plan.md
+++ b/docs/ag-recursion-plan.md
@@ -12,6 +12,62 @@ than optional; the in-circuit AG lows (Phase D) are the *successor* of
 flip-in-place + delete, not permanent parallel API; and Phase F lists the
 removal blockers (x86 + CUDA AG kernels chief among them).
 
+## Status + next-session entry point (updated 2026-08-18)
+
+DONE: **Phase A complete** (commit d6a0eb1 — circuit-AG entries
+`R1csProofCircuitMergedAg` / `prove_fast_ligerito_union_circuit_ag` /
+`verify_ligerito_union_circuit_ag{,_deferred}`; fused PoW predicate aligned
+to the PowMask convention; `cross_class_circuit_ag_roundtrip` green).
+**Phase B slice 1 done** (5a35c4e — `chain_leaf_ag_roundtrip`: the real
+chain shape proves under AG, RS 17.6 vs AG 12.3 ms at m22 dev size).
+
+NEXT — **Phase B remainder**, all in `crates/flock-prover/src/tower.rs`
+(line refs at 5a35c4e):
+
+1. `MixedInner.proof` becomes a flavor enum (`Rs(R1csProofCircuitMerged) |
+   Ag(R1csProofCircuitMergedAg)`), with accessors for the shared fields
+   (lincheck / wiring / pcs_open) so the non-zerocheck pins stay one code
+   path. `build_chain_proof` proves AG behind a private flavor switch
+   (flip-in-place — no public TowerConfig change).
+2. `ChildTape::new` AG arm:
+   - native verify under the recorder → `verify_ligerito_union_circuit_ag`
+     (11451); assertions still from `inner.work`.
+   - region anchor `find(b"flock-ag-skip-v1")` instead of
+     `flock-zerocheck-v0` (11494).
+   - round-1 pins: `ObserveSlice(158)`/`(64)` against `bp.ag.round1_ab/_c`
+     (11553-11583).
+   - the locator walk (12284-12354): ONE `SqueezeSlice` (r_outer — RS has
+     two: r_skip + r_outer); then in place of `[Pow] + SqueezeScalar`
+     z_skip: `Label("flock-ag-skip-r1-point") + SqueezeScalar ×2 +
+     Label("flock-ag-skip-r1-nonce") + ObserveBytes(4)`. The mlv loop code
+     is unchanged. After `z_partial`, the lincheck fresh-skip is the same
+     5-op AG shape (label + 2 squeezes + label + ObserveBytes(4)).
+   - the `.phi8()` pin (12392) → native point pin: rebuild the 32-byte seed
+     from the two located seed chals (`ag_skip::r1_seed` layout: s0.lo,
+     s0.hi, s1.lo, s1.hi LE), run `evaluation_point_from_nonce_pow(seed,
+     proof.r1_nonce, kind, R1_POW_BITS)`, compare to
+     `bool_assert.z_skip` (`SkipPoint::Ag`).
+   - GOTCHA: the nonce payload rides the STREAM WORDS (`ww`), not
+     `vals_rec` (ObserveBytes contributes no vals entries);
+     `bytes_payload_mask` marks it public by default — desired here.
+3. `ChildRegion`: for AG children skip `emit_lagrange_lows` (FL connects at
+   10201-10215) and instead publish (seed₂, nonce, point₅) via the
+   `FoldPub`/`AlphaRec` publics pattern (14558/14244); extend the FL
+   checker (sibling of `check_fold_publics`, 14770) to recompute the point
+   from (seed, nonce) and `base_evaluation_functional(point)` against the
+   fold row-lows. The fold tape itself is unchanged (64-wide lows both
+   bases). Publics count (5684 at tower.rs:362) moves — it is shape, not a
+   pinned digest.
+4. c-point baked constants: the 7 ghash inner constants →
+   `ag_skip::friendly_challenges()` (13504-13511) for AG children.
+5. Tests: FL node over AG leaves (twin of the existing FL roundtrip),
+   shape-diff, capacity asserts, then `tower_online_bench` with the AG
+   leaf (`CHAIN_BLOCKS=262144`; expect ~−100 ms/leaf at m32).
+
+Memory track: `recursion-track.md` (machine-local) mirrors this and adds
+session gotchas. The two survey reports' full maps are summarized in the
+section below; anything deeper re-derives quickly from the line refs.
+
 ## What the survey established (tower @ `ag-union` tip)
 
 1. **The boolean zerocheck's arithmetic is NOT wired in-circuit today.** The

--- a/docs/ag-recursion-plan.md
+++ b/docs/ag-recursion-plan.md
@@ -151,16 +151,46 @@ The node wins are capped by the PIOP∥wiring join (the wiring GKR no
 longer hides fully under the faster AG PIOP); the leaf carries the bulk.
 Proof sizes: node 252.8→254.3 KiB (+1.5, the AG round-1 message).
 
+**Phase D COMPLETE (same day, evening 5) — with a redesign on measured
+evidence.** The plan's (b) `emit_ag_lows` is MEASURED-REJECTED: the base
+functional's coordinate masks are ~48% dense (920 monomials, 28,464 XOR
+terms, ~24.5k MAC rows/child even with four-Russians sharing —
+`base_functional_circuit_census` in flock-core is the receipt), 20× the
+plan's estimate and past the mac slot's cap for two children. What
+landed instead ((a)+(c), Ron's call):
+- `emit_ag_point_binding` at BOTH consumers: two BLAKE3 rows recompute
+  `ns = H(seed‖nonce)` and its XOF block from the child's transcript
+  wires (x binds by wire connect); a PowMask row enforces the fused
+  target on `ns[16..32]`; and the point coordinates are constrained to a
+  fiber point over x — the factored base fiber with `s` eliminated
+  (`t²+t = x³+x`, `y²+uy = xut`, inverse-free) + the three
+  denominator-cleared AS levels (D₀/D₁ guarded by advice inverses).
+  ~110 mac rows + 2 b3 + 1 pow per AG child. (a) on-curve is subsumed —
+  the fiber constraints ARE curve membership.
+- CANONICITY RELAXED BY DESIGN: any of the ≤32 fiber points satisfies
+  the rows; the sampler's 5 flattening bits return to the prover and are
+  repaid by the all-explicit `R1_POW_BITS = 9` (was 4+5 credit; total
+  unchanged; scan budget 2^24; the lincheck site keeps 3+5 — its decode
+  stays canonical end-to-end).
+- `check_ag_skip_publics` slims to ONE item: `lows == bf(point)`. The
+  genus-95 sampler/DRBG/AS-solver leave the exit contract; `bf()` stays.
+Whole pipeline green under everything (all knobs, Chain100+128), 687
+workspace tests, x86 clean. m32 bench with the binding in place:
+amortised 637 ms/leaf = 412k c/s (leaf 429.6, FL 209.2, internal 196.6,
+spine 205.0) — the ~110 rows/child and the 9-bit grind cost nothing
+measurable.
+
 NEXT (order per the endgame):
 1. **Phase F long-lead kernels, start now**: the x86 AVX-512 AG round-1
    (RS removal otherwise kills x86 proving) and the CUDA AG round-1
    (GPU runs full RS zerocheck on-device; mlv tail carries over).
-2. **Phase D — Tier-1 in-circuit AG lows** (`emit_ag_lows` + on-curve +
-   standalone-hash binding), replacing the Tier-0 72-publics blocks at
-   BOTH consumers (FL over leaves, nodes over outers) — scheduled before
-   RS removal.
-3. Phase E audit/docs; then Phase F removal (locator arm deletion,
-   fixture/proof-IO retirement, SkipPoint collapse).
+2. Phase E audit/docs — the audit ledger's AG rows move with the 9-bit
+   split (guard tests already updated); the recursive-agreement section
+   records the in-circuit decode + the one remaining checker item.
+3. Phase F removal (locator arm deletion, fixture/proof-IO retirement,
+   SkipPoint collapse). If the lows publics ever need to go fully
+   in-circuit, the recorded path is a dedicated static-table route for
+   the dense mask map, not per-term MACs.
 
 Memory track: `recursion-track.md` (machine-local) mirrors this and adds
 session gotchas. The two survey reports' full maps are summarized in the

--- a/docs/ag-recursion-plan.md
+++ b/docs/ag-recursion-plan.md
@@ -1,0 +1,118 @@
+# AG-skip in the recursion tower — plan
+
+Status: PLAN (2026-08-18, branch `ag-union`). Goal: the tower's provers run the
+AG-skip boolean zerocheck (union-AG measured −21% prove at m32) and the
+recursion circuit replays those proofs.
+
+## What the survey established (tower @ `ag-union` tip)
+
+1. **The boolean zerocheck's arithmetic is NOT wired in-circuit today.** The
+   tower binds a child's boolean zerocheck transcript-positionally (the FS
+   chain rows force the observed proof words) and consumes only four surfaces:
+   the `r_outer` squeeze words (→ c-claim point wires), the `z_skip` squeeze
+   wire (→ `emit_lagrange_lows` → fold row-lows, tower.rs:11210 + call sites
+   10201/16655), the finals `v_a, v_b` (→ lincheck-entry replay), and
+   `z_partial`. The Λ-interpolation, round checks, and the ring-switch
+   `claim_check` are never arithmetized. **Consequence: AG's 222-coordinate
+   round-1 costs zero new in-circuit arithmetic under the current posture.**
+2. **Proof shapes**: all three levels prove `R1csProofCircuitMerged` via
+   `prove_fast_ligerito_union_circuit`; leaf = 1 boolean type, no element;
+   FL/internal/spine = the envelope registry (6 boolean + 15 element types).
+   Tapes record `verify_ligerito_union_circuit_deferred` under a
+   `RecordingChallenger`. There is no AG circuit-flavor entry yet.
+3. **The fold region is already flavor-generic**: `SkipPoint::weights(6)` is
+   64-wide in both bases, so `MatrixClaim` widths, the fold tape shape, and
+   `emit_weight` are unchanged. Only the row-lows *derivation* (today:
+   `emit_lagrange_lows` from the one `zskip_w` wire, ~260 MAC rows) is
+   φ8-specific.
+4. **Capacity is not the constraint**: AG round-1 adds +94 observed words ≈
+   +23.5 BLAKE3 compressions per child region (~0.25% of a region; b3 slots
+   have ~7k rows headroom each). An in-circuit base-functional derivation
+   would be ~1.0–1.5k MAC rows per child vs the mac slot's ~49k.
+5. **The AG points have no transcript word.** RS gives one located squeeze
+   wire; AG's `r₁` and the lincheck's fresh skip are decoded from
+   (seed = 2 squeezes, nonce = ObserveBytes(4)) through a STANDALONE hash
+   (outside the duplex sponge) — the existing `Op::Pow`/PowMask machinery
+   never sees the fused PoW. Binding the point is the one real design
+   decision.
+
+## The design decision: how the recursion binds an AG point
+
+**Tier 0 — checker-published (recommended start).** Per AG child, publish
+(seed₂, nonce, point₅) in the outer proof's public segment; the fold row-lows
+already ride the fold tape as observed words. The consumer's native checker
+(the same tier as `check_fold_publics` / `AlphaRec`) re-derives
+`evaluation_point_from_nonce_pow(seed, nonce) == point` (one hash + one
+attempt, ~1 µs) and `base_evaluation_functional(point) == row-lows`, and the
+`.phi8()`-style native pins become point pins. Zero new gates, zero new table
+types (the registry-diet lesson: type COUNT costs ~20% node time), ~8 extra
+publics/child (publics count 5684 moves — it is shape, not a pinned digest).
+This is exactly the documented pre-in-circuit boundary posture the stale
+comments at tower.rs:16571-16580 describe.
+
+**Tier 1 — in-circuit upgrade (later, if the exit contract wants it).**
+(a) on-curve predicate for the advice point (each Artin–Schreier equation
+`z² + z = rhs` is one square + add; base equation a handful of mults);
+(b) `emit_ag_lows`: base functional from point wires — x-powers ≤ 31,
+4 y-powers, 8 z-monomials, per-push MACs, one denominator inverse via the
+existing advice-inverse/zassert idiom (~1.0–1.5k MAC rows);
+(c) standalone-hash binding of H(seed‖nonce) via the `emit_opening`-style
+Blake3 rows + a PowMask row + XOF-stream binding of x/slot/choice bits.
+Decode-canonicity (which AS root) either pinned via linear functionals
+(Frobenius-chain idiom exists) or compensated with ~5 extra PoW bits.
+
+## Phases
+
+**Phase A — native entries + hygiene (small).**
+- `R1csProofCircuitMergedAg` + `prove_fast_ligerito_union_circuit_ag`
+  (aarch64) + `verify_ligerito_union_circuit_ag{,_deferred}` — thin over the
+  already-flavored shared bodies (`prove_union_with_binding_zc`,
+  `verify_union_piops`/`BooleanPiopRef`). Lift the boolean-only assert for the
+  mixed/circuit AG arms (element region is flavor-independent; the AG flavor
+  already forces honest-zero witness mode).
+- **Align the fused PoW predicate with the PowMask convention** (MSB-first
+  leading bits on the hash's serialized bytes, replacing low-LE-bits) NOW,
+  while the AG transcript is unshipped — Tier 0 doesn't need it, Tier 1 does,
+  and it's free today, frozen later.
+- Circuit-AG roundtrip tests (leaf-shaped: blake3 circuit + wiring).
+
+**Phase B — leaf-AG (the first payoff: workload −21% at m32).**
+- `TowerConfig` grows the AG flavor for the leaf (decision: new variants
+  `Chain128Ag`… vs a `leaf_zc` field).
+- `build_chain_proof` proves circuit-AG; `ChildTape` gets the AG walk
+  (anchor `flock-ag-skip-v1`; no r_skip slice; ObserveSlice(158)+(64);
+  r₁ = Label + 2 Squeeze + Label + ObserveBytes(4); AG fresh-skip 5-op shape;
+  round-1 pins typed to `AgProof`), tower.rs:12288-12300 / 11560-11582 /
+  11494.
+- `ChildRegion`: `zskip_w` → the Tier-0 surface (publish seed/nonce/point,
+  skip `emit_lagrange_lows` for AG children, checker recomputes lows +
+  point derivation); `.phi8()` pin at 12392 → point pin.
+- c-point baked constants: the 7 ghash inner constants →
+  `ag_skip::friendly_challenges()` (tower.rs:13504-13511).
+- FL-over-AG-leaves roundtrip, shape-diff, capacity asserts, then
+  tower_online_bench (expect leaf ~−100 ms at m32 ≈ +12-16% throughput).
+
+**Phase C — outers-AG (envelope nodes).**
+- Same items on `RealTape`/`RealRegion` (6211, 6859-6875, 6959, 8719,
+  8222-8227, 10178-10212) + mixed-class-with-element AG entries.
+- Envelope re-checks (nu* ≤ 14 per b3 slot, m* = 29 content, publics count),
+  internal/spine digest equality, `chain_spine_converges` re-run.
+- Expect node prove −10-15% (zerocheck share at m29).
+
+**Phase D — optional Tier-1 upgrade** (in-circuit lows + on-curve + hash
+binding), driven by the recursion exit contract, not performance.
+
+**Phase E — audit + docs.** Extend the audit's recursive-agreement section:
+AG rows are checker-tier obligations (like the fold publics), not PowMask
+rows; friendly constants ≠ 1 is free in-circuit (baked constants); update
+`docs/local/recursion-handoff.md` censuses and the memory track.
+
+## Open decisions (for Ron)
+
+1. Tier 0 vs Tier 1 to start — recommend Tier 0.
+2. TowerConfig shape for the flavor — variants vs field.
+3. Proof struct: separate `R1csProofCircuitMergedAg` (recommended — matches
+   the existing Ag pattern, keeps RS byte-compat) vs an enum field.
+4. Scope order leaf-first — recommend yes (Phase B is where the workload
+   payoff is; Phase C is optional-until-measured).
+5. PoW-convention alignment in Phase A — recommend yes.

--- a/docs/ag-recursion-plan.md
+++ b/docs/ag-recursion-plan.md
@@ -12,7 +12,7 @@ than optional; the in-circuit AG lows (Phase D) are the *successor* of
 flip-in-place + delete, not permanent parallel API; and Phase F lists the
 removal blockers (x86 + CUDA AG kernels chief among them).
 
-## Status + next-session entry point (updated 2026-08-18)
+## Status + next-session entry point (updated 2026-08-18, evening 2)
 
 DONE: **Phase A complete** (commit d6a0eb1 — circuit-AG entries
 `R1csProofCircuitMergedAg` / `prove_fast_ligerito_union_circuit_ag` /
@@ -20,49 +20,73 @@ DONE: **Phase A complete** (commit d6a0eb1 — circuit-AG entries
 to the PowMask convention; `cross_class_circuit_ag_roundtrip` green).
 **Phase B slice 1 done** (5a35c4e — `chain_leaf_ag_roundtrip`: the real
 chain shape proves under AG, RS 17.6 vs AG 12.3 ms at m22 dev size).
+**Phase B COMPLETE** (this branch): the tower's chain leaf proves under AG
+on aarch64 and the whole pipeline replays it. What landed, all in
+`crates/flock-prover/src/tower.rs` unless noted:
 
-NEXT — **Phase B remainder**, all in `crates/flock-prover/src/tower.rs`
-(line refs at 5a35c4e):
+1. `MixedProof` flavor enum (`Rs | Ag`) with `wiring()/pcs_open()/element()`
+   accessors; `build_chain_proof` proves AG behind the private
+   `leaf_zc_ag()` switch — aarch64 only (the round-1 kernel), with
+   `TOWER_LEAF_ZC=rs` as the A/B override. No public TowerConfig change.
+2. `ChildTape::new` AG arm: flavored recording verify; anchor
+   `flock-ag-skip-v1` (and the OTHER flavor's label asserted absent);
+   round-1 pins ObserveSlice(158)/(64) vs `bp.ag.round1_ab/_c`; the
+   locator walk's flavored head (ONE r_outer slice; r₁'s 5-op surface:
+   point label + 2 seed squeezes + nonce label + ObserveBytes(4), recorded
+   as `ZskipTapeRec::Ag { seed_ch, seed_fins, nonce_payload }`); the
+   `.phi8()` pin replaced by the native point pin (seed rebuilt from the
+   located chals, `decode_ag_point` under
+   `pcs.zerocheck_grinding().ag_r1_bits()`, compared to
+   `bool_assert.z_skip`).
+3. Tier 0 landed as PUBLISH-THE-WHOLE-SURFACE: per AG child the FL
+   publishes `[seed₂ (wire-connected), nonce (wire-connected to the
+   ObserveBytes stream word), point₅ (advice), row-lows₆₄ (wire-connected
+   to the fold's absorbed lows)]` — 72 publics/child — and
+   `check_ag_skip_publics` re-derives point + lows natively (fused decode,
+   budget bound, functional). `emit_lagrange_lows` + the λ-table publics
+   are now emitted only for RS children. The envelope publics cap (5684)
+   absorbed the delta — no envelope change needed at k=2.
+4. c-point baked constants: flavored — `ag_skip::friendly_challenges()`
+   for AG children (same 7-slot shape as the ghash set).
+5. Tests: the WHOLE existing tower suite runs AG on aarch64 (leaf
+   roundtrip+tampers, tape pins, region-alone, FL, internal, spine
+   converges, e2e+lane) — the RS arm stays covered by the x86 CI arm and
+   the `TOWER_LEAF_ZC=rs` knob; new `ag_skip_publics_checker_rejects_tampers`
+   (seed/nonce/budget/point/low tampers all rejected).
 
-1. `MixedInner.proof` becomes a flavor enum (`Rs(R1csProofCircuitMerged) |
-   Ag(R1csProofCircuitMergedAg)`), with accessors for the shared fields
-   (lincheck / wiring / pcs_open) so the non-zerocheck pins stay one code
-   path. `build_chain_proof` proves AG behind a private flavor switch
-   (flip-in-place — no public TowerConfig change).
-2. `ChildTape::new` AG arm:
-   - native verify under the recorder → `verify_ligerito_union_circuit_ag`
-     (11451); assertions still from `inner.work`.
-   - region anchor `find(b"flock-ag-skip-v1")` instead of
-     `flock-zerocheck-v0` (11494).
-   - round-1 pins: `ObserveSlice(158)`/`(64)` against `bp.ag.round1_ab/_c`
-     (11553-11583).
-   - the locator walk (12284-12354): ONE `SqueezeSlice` (r_outer — RS has
-     two: r_skip + r_outer); then in place of `[Pow] + SqueezeScalar`
-     z_skip: `Label("flock-ag-skip-r1-point") + SqueezeScalar ×2 +
-     Label("flock-ag-skip-r1-nonce") + ObserveBytes(4)`. The mlv loop code
-     is unchanged. After `z_partial`, the lincheck fresh-skip is the same
-     5-op AG shape (label + 2 squeezes + label + ObserveBytes(4)).
-   - the `.phi8()` pin (12392) → native point pin: rebuild the 32-byte seed
-     from the two located seed chals (`ag_skip::r1_seed` layout: s0.lo,
-     s0.hi, s1.lo, s1.hi LE), run `evaluation_point_from_nonce_pow(seed,
-     proof.r1_nonce, kind, R1_POW_BITS)`, compare to
-     `bool_assert.z_skip` (`SkipPoint::Ag`).
-   - GOTCHA: the nonce payload rides the STREAM WORDS (`ww`), not
-     `vals_rec` (ObserveBytes contributes no vals entries);
-     `bytes_payload_mask` marks it public by default — desired here.
-3. `ChildRegion`: for AG children skip `emit_lagrange_lows` (FL connects at
-   10201-10215) and instead publish (seed₂, nonce, point₅) via the
-   `FoldPub`/`AlphaRec` publics pattern (14558/14244); extend the FL
-   checker (sibling of `check_fold_publics`, 14770) to recompute the point
-   from (seed, nonce) and `base_evaluation_functional(point)` against the
-   fold row-lows. The fold tape itself is unchanged (64-wide lows both
-   bases). Publics count (5684 at tower.rs:362) moves — it is shape, not a
-   pinned digest.
-4. c-point baked constants: the 7 ghash inner constants →
-   `ag_skip::friendly_challenges()` (13504-13511) for AG children.
-5. Tests: FL node over AG leaves (twin of the existing FL roundtrip),
-   shape-diff, capacity asserts, then `tower_online_bench` with the AG
-   leaf (`CHAIN_BLOCKS=262144`; expect ~−100 ms/leaf at m32).
+Two bugs flushed en route (both latent, both would bite anything AG):
+- `RecordingChallenger` did not forward `hash_kind()` — the trait default
+  (SHA-256) silently diverged the AG nonce decode from the BLAKE3
+  transcript during recording (flock-core/src/transcript_record.rs).
+  Nothing had ever recorded an AG proof.
+- The c-point r_outer wires used a naive 4-words-per-row squeeze map;
+  a FUSED slice squeeze (the AG initial grind) reserves one word per row
+  for the PoW predicate, so the map misaddressed. Now
+  `squeeze_word_wire` (the exact map) everywhere.
+
+m32 A/B (tower_online_bench, CHAIN_BLOCKS=262144, warm medians, same box
+same session — `TOWER_LEAF_ZC=rs` vs default): leaf online 520.9 → 469.8 ms
+(prove 475.8 → 427.7, −10.1%); amortised 762 → 688 ms/leaf = 344k → 381k
+compressions/sec (+10.7%). The internal/spine arms flipped between the two
+runs (wide bands on one arm — box noise); the leaf bands are tight, so the
+leaf delta is the solid number. OPEN ATTRIBUTION: the recorded union-AG
+margin (466.0 → 367.3 at m32, −98.7 ms) predicted ~−100 ms; the leaf shows
+−48 on the prove. The RS arm matches its union twin (475.8 ≈ 466 + wiring),
+the AG arm runs ~50 ms above its (427.7 vs ~377) — the forced honest-zero
+witness mode inside the circuit-AG prove path is the prime suspect
+(the RS arm keeps pooled-dirty pages). Worth one attribution pass before
+Phase C multiplies it across the outers.
+
+NEXT — **Phase C (outers-AG)**: the same five items on
+`RealTape`/`RealRegion` (`zc_l` find at 6222, round-1 pins ~6300s, walk
+~6848s, `zskip_ch/zskip_fin` fields at 7422/8764, `emit_lagrange_lows`
+call in `build_node_outer_app` at ~17000s, the ghash constants at 8273) +
+mixed-class-with-element AG entries. The envelope moves: re-check nu* ≤ 14
+per b3 slot, m* = 29 content, the publics cap (now shared with the FL's AG
+blocks), internal/spine digest equality, `chain_spine_converges`. Note the
+mixed outers carry an ELEMENT class — the AG flavor forces honest-zero
+witness mode (already enforced in the shared prove body). Then Phase F's
+long-lead kernels (x86 AVX-512 + CUDA round-1) can start.
 
 Memory track: `recursion-track.md` (machine-local) mirrors this and adds
 session gotchas. The two survey reports' full maps are summarized in the

--- a/docs/ag-recursion-plan.md
+++ b/docs/ag-recursion-plan.md
@@ -147,8 +147,16 @@ bench-only unfused arm. `FLOCK_ZC_TIMING` now prints the AG phases.
 m32 A/B (tower_online_bench, warm medians, same box): all-RS 721 ms/leaf
 amortised (364k c/s) → all-AG **660 ms (397k c/s, +9.1%)**: leaf
 494.6→442.1, FL 224.1→222.1, internal 224.7→214.2, spine 228.0→213.7.
-The node wins are capped by the PIOP∥wiring join (the wiring GKR no
-longer hides fully under the faster AG PIOP); the leaf carries the bulk.
+NODE-DELTA CAVEAT (Ron's catch, corrected next day): nodes were ~200 ms
+under RS on a prior good-box day, so the cross-run node totals above are
+mostly BOX DRIFT — node cost is ~195–230 ms under BOTH flavors by box
+state. The within-run evidence (flavor-identical commit/open lining up
+across runs): the node's PIOP∥wiring joint reads 35–41 ms under AG vs
+45–85 under RS — a real but small ~10 ms flavor win, often swallowed by
+the wiring join and noise, exactly as the join-cap mechanism predicts.
+The LEAF win (~50–60 ms, three same-process probes) is the arc's real
+measured speed gain; phases C/D buy the nodes uniformity for RS removal
+and the soundness posture, not speed.
 Proof sizes: node 252.8→254.3 KiB (+1.5, the AG round-1 message).
 
 **Phase D COMPLETE (same day, evening 5) — with a redesign on measured
@@ -178,7 +186,8 @@ Whole pipeline green under everything (all knobs, Chain100+128), 687
 workspace tests, x86 clean. m32 bench with the binding in place:
 amortised 637 ms/leaf = 412k c/s (leaf 429.6, FL 209.2, internal 196.6,
 spine 205.0) — the ~110 rows/child and the 9-bit grind cost nothing
-measurable.
+measurable (the run's absolute node numbers reflect a friendly box; see
+the node-delta caveat above — cost-NEUTRALITY is the claim, not a win).
 
 NEXT (order per the endgame):
 1. **Phase F long-lead kernels, start now**: the x86 AVX-512 AG round-1

--- a/docs/ag-recursion-plan.md
+++ b/docs/ag-recursion-plan.md
@@ -4,6 +4,14 @@ Status: PLAN (2026-08-18, branch `ag-union`). Goal: the tower's provers run the
 AG-skip boolean zerocheck (union-AG measured −21% prove at m32) and the
 recursion circuit replays those proofs.
 
+ENDGAME (Ron, 2026-08-18): the RS/φ8 univariate skip will EVENTUALLY be
+deprecated and removed — AG becomes the only skip basis. Not immediate, but
+it re-weights this plan: AG-everywhere (Phase C) is the critical path rather
+than optional; the in-circuit AG lows (Phase D) are the *successor* of
+`emit_lagrange_lows`, not an optional upgrade; migration knobs should be
+flip-in-place + delete, not permanent parallel API; and Phase F lists the
+removal blockers (x86 + CUDA AG kernels chief among them).
+
 ## What the survey established (tower @ `ag-union` tip)
 
 1. **The boolean zerocheck's arithmetic is NOT wired in-circuit today.** The
@@ -99,20 +107,59 @@ Decode-canonicity (which AS root) either pinned via linear functionals
   internal/spine digest equality, `chain_spine_converges` re-run.
 - Expect node prove −10-15% (zerocheck share at m29).
 
-**Phase D — optional Tier-1 upgrade** (in-circuit lows + on-curve + hash
-binding), driven by the recursion exit contract, not performance.
+**Phase D — Tier-1 upgrade** (in-circuit lows + on-curve + hash binding).
+Under the deprecation endgame this is SCHEDULED, not optional: when RS is
+removed, `emit_lagrange_lows` dies and `emit_ag_lows` is its mainline
+replacement — going to Tier 0 permanently would be a posture REGRESSION
+(the in-circuit lows were the recorded upgrade over the checker boundary).
+Tier 0 remains the right FIRST landing; D closes the loop before removal.
 
 **Phase E — audit + docs.** Extend the audit's recursive-agreement section:
 AG rows are checker-tier obligations (like the fold publics), not PowMask
 rows; friendly constants ≠ 1 is free in-circuit (baked constants); update
 `docs/local/recursion-handoff.md` censuses and the memory track.
 
+**Phase F — RS deprecation prerequisites** (the removal blockers, so they
+can be scheduled early rather than discovered late):
+1. **x86 AG round-1 kernel.** The AG prover's round-1 is aarch64-NEON SLP
+   only; RS removal without an AVX-512 port kills x86 proving entirely
+   (x86 VERIFY already works — `verify_ag`/`verify_with_grinding` are
+   arch-independent).
+2. **CUDA AG round-1 kernel.** The GPU prover runs the full RS zerocheck
+   on-device (`cuda-ghash/zerocheck_round1/2/tail.cuh`, z_skip→lincheck
+   hand-off resident); RS removal needs the AG twin (the mlv tail carries
+   over — it is shape-identical — but round-1 over the genus-95 product
+   code is a new kernel + vectors).
+3. Recursion: delete the RS locator arms + `emit_lagrange_lows` + the φ8
+   fused Pow+squeeze sites (keep the AG arms structurally parallel from
+   Phase B so this is arm-deletion, not surgery).
+4. Profiles/grinding: the RS rows of the audit schedule retire;
+   `ZerocheckGrinding::skip_bits` / `LincheckGrinding::skip_bits` collapse
+   to the AG accounting; the ungrinded direct route decides whether it
+   gains the fused nonce or stays no-claim.
+5. Transcript/fixture retirement: every RS byte pin (m6 merged fixtures,
+   mixed-class pins, chain/Merkle/keccak3/sha2 relations — all currently
+   RS), proof-IO version bump, and the parallel `*Ag` structs/entries
+   renamed to primary as the RS structs are deleted.
+6. `SkipPoint::Phi8` and `phi8()` die; `SkipPoint` may collapse back to a
+   plain `EvaluationPoint` (claim types simplify).
+
 ## Open decisions (for Ron)
 
-1. Tier 0 vs Tier 1 to start — recommend Tier 0.
-2. TowerConfig shape for the flavor — variants vs field.
-3. Proof struct: separate `R1csProofCircuitMergedAg` (recommended — matches
-   the existing Ag pattern, keeps RS byte-compat) vs an enum field.
-4. Scope order leaf-first — recommend yes (Phase B is where the workload
-   payoff is; Phase C is optional-until-measured).
-5. PoW-convention alignment in Phase A — recommend yes.
+1. Tier 0 vs Tier 1 to start — recommend Tier 0 first, with Tier 1 (Phase D)
+   scheduled before RS removal (see endgame note).
+2. TowerConfig: under the endgame, do NOT grow the public config — keep
+   Chain100/Chain128 and flip the flavor in place per phase (a private
+   accessor / test-only knob during migration), so the eventual state has
+   no residual flavor API to delete.
+3. Proof struct: parallel `R1csProofCircuitMergedAg` during migration (no
+   RS wire churn now); renamed to primary when the RS structs are deleted
+   in Phase F. Structure all tower locator/region code as PARALLEL ARMS so
+   RS removal is arm-deletion.
+4. Scope order leaf-first — recommend yes; Phase C is on the deprecation
+   critical path (no longer optional-until-measured).
+5. PoW-convention alignment in Phase A — recommend yes (mandatory before
+   the AG transcript becomes the only one).
+6. Phase F sequencing: the x86 and CUDA AG round-1 kernels are the
+   long-lead items — start them as soon as AG-everywhere (Phase C) is
+   validated, independent of Phase D.

--- a/docs/ag-recursion-plan.md
+++ b/docs/ag-recursion-plan.md
@@ -72,10 +72,14 @@ runs (wide bands on one arm — box noise); the leaf bands are tight, so the
 leaf delta is the solid number. OPEN ATTRIBUTION: the recorded union-AG
 margin (466.0 → 367.3 at m32, −98.7 ms) predicted ~−100 ms; the leaf shows
 −48 on the prove. The RS arm matches its union twin (475.8 ≈ 466 + wiring),
-the AG arm runs ~50 ms above its (427.7 vs ~377) — the forced honest-zero
-witness mode inside the circuit-AG prove path is the prime suspect
-(the RS arm keeps pooled-dirty pages). Worth one attribution pass before
-Phase C multiplies it across the outers.
+the AG arm runs ~50 ms above its (427.7 vs ~377). The honest-zero forcing
+is NOT the cause: the chain leaf is identity-compacted, so BOTH flavors run
+PooledZeroed (verified with PCS_TRACE — the RS arm's PooledDirty election
+requires !identity), and the padding cost is identical across arms. The gap
+is unattributed; candidates: the AG round-1's dense full-region scan vs the
+RS run-list gating on this shape, or the recorded three-arm bench's arm not
+matching the leaf's exact profile/transport. Worth one attribution pass
+before Phase C multiplies it across the outers.
 
 NEXT — **Phase C (outers-AG)**: the same five items on
 `RealTape`/`RealRegion` (`zc_l` find at 6222, round-1 pins ~6300s, walk

--- a/docs/ag-recursion-plan.md
+++ b/docs/ag-recursion-plan.md
@@ -81,6 +81,34 @@ RS run-list gating on this shape, or the recorded three-arm bench's arm not
 matching the leaf's exact profile/transport. Worth one attribution pass
 before Phase C multiplies it across the outers.
 
+**AG/RS OPTIMIZATION PARITY (Ron's call, same day): CLOSED** — the AG
+zerocheck now has every RS-branch optimization (commits on this branch):
+- Run-list round 1: `PaddingSpec::block_coverage` classifies the 8192-bit
+  code-block grid Dead/Full/Partial; the SLP kernels needed NO surgery —
+  they are position-independent additive sums, so full runs go in as
+  (slice, eq-subrange) segments and Partial blocks are cleansed
+  (`cleanse_block`, bit-masked edges) into zeroed scratch. No
+  declared-dead bit is ever read.
+- The fused fold is gated on the same map (`fold_and_first_round_padded`),
+  and below the utilization gate emits LIVE-SPAN buffers
+  (`fold_and_first_round_sparse` + 128-aligned `LiveLayout`) feeding RS's
+  own support-proportional rounds (`fold_and_round_pair_sparse_into` —
+  the friendly constants ride as ordinary r_next weights), with ONE
+  expand-to-dense on exit resuming the AG lookahead tail mid-stream.
+- Consequence: the `PooledDirty` witness election dropped its RS-only
+  condition — the AG honest-zero forcing is GONE (the padding contract is
+  now enforced by read-exactness, not by memset).
+- Differential coverage: byte-identical proofs between dense-honest,
+  padded-honest, and padded-DIRTY witnesses (deliberately inconsistent
+  garbage in dead regions), both grinding schedules, at 62%/8-block and
+  3-of-64-block utilization; plus a 200/256-row union roundtrip re-proving
+  over pooled-dirty buffers byte-identically.
+The direction of remaining asymmetry is now AG-ahead-of-RS (lookahead +
+friendly-Horner tail), which is fine — RS is the deprecation target.
+This also pre-pays Phase C's cost profile: the envelope outers' dead
+boolean space (swap 12250/16384, spread 1060/16384, pow 4096/16384 at
+nu* = 14) is now skipped, not scanned, under AG.
+
 NEXT — **Phase C (outers-AG)**: the same five items on
 `RealTape`/`RealRegion` (`zc_l` find at 6222, round-1 pins ~6300s, walk
 ~6848s, `zskip_ch/zskip_fin` fields at 7422/8764, `emit_lagrange_lows`

--- a/docs/ag-recursion-plan.md
+++ b/docs/ag-recursion-plan.md
@@ -119,16 +119,48 @@ This also pre-pays Phase C's cost profile: the envelope outers' dead
 boolean space (swap 12250/16384, spread 1060/16384, pow 4096/16384 at
 nu* = 14) is now skipped, not scanned, under AG.
 
-NEXT — **Phase C (outers-AG)**: the same five items on
-`RealTape`/`RealRegion` (`zc_l` find at 6222, round-1 pins ~6300s, walk
-~6848s, `zskip_ch/zskip_fin` fields at 7422/8764, `emit_lagrange_lows`
-call in `build_node_outer_app` at ~17000s, the ghash constants at 8273) +
-mixed-class-with-element AG entries. The envelope moves: re-check nu* ≤ 14
-per b3 slot, m* = 29 content, the publics cap (now shared with the FL's AG
-blocks), internal/spine digest equality, `chain_spine_converges`. Note the
-mixed outers carry an ELEMENT class — the AG flavor forces honest-zero
-witness mode (already enforced in the shared prove body). Then Phase F's
-long-lead kernels (x86 AVX-512 + CUDA round-1) can start.
+**Phase C COMPLETE (same day, evening 4)** — the envelope outers (FL /
+internal / spine) prove under AG behind the private `outer_zc_ag()`
+switch (`TOWER_OUTER_ZC=rs` A/B override). `LeafOuter.proof` is the
+shared `MixedProof` (with `boolean_lincheck()` +
+`verify_circuit{,_deferred}` dispatch methods); `RealTape`/`RealRegion`
+carry the ChildTape/ChildRegion AG arms verbatim (anchor, 158/64 pins,
+seed/nonce locator, point-pin decode, `ZskipWires`, friendly c-constants,
+the exact `squeeze_word_wire` map — the RealRegion emitter had the same
+naive-4-per-row bug the child emitter had); `build_node_outer_app` takes
+the Tier-0 publish + `check_ag_skip_publics` per AG child, with the RS
+λ machinery conditional. Pipeline green under AG-everywhere incl.
+`chain_spine_converges` (one-digest property holds), all four flavor-knob
+combos, Chain100+Chain128.
+
+PERF LESSON EARNED EN ROUTE: the parity slice's segment-call round-1
+driver COLLAPSED at the envelope — its per-column run structure is
+19,920 full / 228 partial / 110,924 dead blocks at m30 (~15% live,
+~450 segments), and per-segment rayon bridges made round 1 cost 28–43 ms
+(2–3× the FULL dense scan). Fixed by
+`round1_slp_packed_banks_fused_padded` — ONE parallel pass over the
+live-block list (Full pairs keep the 2src c-transpose, Partials cleanse
+inline; char-2 addition makes visit order irrelevant) — now 2.4–4.7 ms,
+count-proportional parity. The segment driver survives only as the
+bench-only unfused arm. `FLOCK_ZC_TIMING` now prints the AG phases.
+
+m32 A/B (tower_online_bench, warm medians, same box): all-RS 721 ms/leaf
+amortised (364k c/s) → all-AG **660 ms (397k c/s, +9.1%)**: leaf
+494.6→442.1, FL 224.1→222.1, internal 224.7→214.2, spine 228.0→213.7.
+The node wins are capped by the PIOP∥wiring join (the wiring GKR no
+longer hides fully under the faster AG PIOP); the leaf carries the bulk.
+Proof sizes: node 252.8→254.3 KiB (+1.5, the AG round-1 message).
+
+NEXT (order per the endgame):
+1. **Phase F long-lead kernels, start now**: the x86 AVX-512 AG round-1
+   (RS removal otherwise kills x86 proving) and the CUDA AG round-1
+   (GPU runs full RS zerocheck on-device; mlv tail carries over).
+2. **Phase D — Tier-1 in-circuit AG lows** (`emit_ag_lows` + on-curve +
+   standalone-hash binding), replacing the Tier-0 72-publics blocks at
+   BOTH consumers (FL over leaves, nodes over outers) — scheduled before
+   RS removal.
+3. Phase E audit/docs; then Phase F removal (locator arm deletion,
+   fixture/proof-IO retirement, SkipPoint collapse).
 
 Memory track: `recursion-track.md` (machine-local) mirrors this and adds
 session gotchas. The two survey reports' full maps are summarized in the

--- a/docs/ag-recursion-plan.md
+++ b/docs/ag-recursion-plan.md
@@ -180,8 +180,11 @@ landed instead ((a)+(c), Ron's call):
   repaid by the all-explicit `R1_POW_BITS = 9` (was 4+5 credit; total
   unchanged; scan budget 2^24; the lincheck site keeps 3+5 — its decode
   stays canonical end-to-end).
-- `check_ag_skip_publics` slims to ONE item: `lows == bf(point)`. The
-  genus-95 sampler/DRBG/AS-solver leave the exit contract; `bf()` stays.
+- `check_ag_skip_publics` slims to TWO items: the NONCE RANGE (the
+  PowMask row pins only the nonce word's high half, and Chain100 emits no
+  row, so the range check stays native — the PR review caught its brief
+  removal) and `lows == bf(point)`. The genus-95 sampler/DRBG/AS-solver
+  leave the exit contract; `bf()` and the range check stay.
 Whole pipeline green under everything (all knobs, Chain100+128), 687
 workspace tests, x86 clean. m32 bench with the binding in place:
 amortised 637 ms/leaf = 412k c/s (leaf 429.6, FL 209.2, internal 196.6,


### PR DESCRIPTION
## Summary

- Adds the AG-skip zerocheck (genus-95 multiplication-code round 1) to the merged-transport union as a boolean flavor. The RS route stays byte-identical, with the full byte-pin suite green.
- Migrates the recursion tower to AG end to end. Chain leaves, first-level nodes, internal nodes, and the spine prove with the AG flavor on aarch64. Private flip-in-place switches (`TOWER_LEAF_ZC=rs`, `TOWER_OUTER_ZC=rs`) keep RS available for A/B runs, and every locator is a parallel arm so the eventual RS removal is arm deletion.
- Binds the AG r1 point in-circuit at both tower consumers: two BLAKE3 rows recompute `H(seed || nonce)` and its XOF block, a PowMask row enforces the fused grinding target, and fiber constraints hold the published point coordinates. The native checker keeps two items, the nonce range and `lows == bf(point)`; the genus-95 sampler leaves the root verifier's checker obligations. Canonicity is relaxed by design, and the fiber freedom is repaid by an all-explicit `R1_POW_BITS = 9` (total budget unchanged; guard tests pin the constants).
- Brings the AG zerocheck to RS parity on witness handling: run-list round 1 through a single-pass padded kernel, a coverage-gated fold, support-proportional tail rounds, and legal `PooledDirty` witnesses. The honest-zero witness forcing is retired; read-exactness now enforces the padding rules.
- Closes the 128-bit grinding accounting for the AG challenge sites with fused nonces (PoW and point decode on one hash).
- Fixes two latent bugs any AG recording would hit: `RecordingChallenger` now forwards `hash_kind()`, and the c-point wires use the exact squeeze-word map instead of a four-words-per-row guess.

## Motivation

The recorded endgame deprecates the RS/φ8 skip and makes AG the only skip basis (`docs/ag-recursion-plan.md` carries the plan, the survey, and the measurements). The union transport makes the two flavors commensurable, and the tower migration is the critical path. Measured at m32 on M4 Max: the union prove margin is 1.18x on a quiet box, the tower leaf gains 50 to 60 ms, and the amortised tower reaches ~400k compressions/sec. Node cost is flavor-neutral within box noise; the leaf carries the speed win, and the tower work buys uniformity for the removal.

## Validation

- 687 workspace tests green. The tower pipeline (leaf, FL, internal, spine convergence, e2e tamper matrix) passes under every flavor knob and under both Chain100 and Chain128.
- Differential tests pin byte-identical proofs across dense, padded, and dirty-padding witnesses on both grinding schedules, at three utilization shapes.
- x86 cross-checks compile clean. AG proving stays aarch64-only until the Phase F kernels land.

## Caveats

- `R1_POW_BITS` moves from 4 to 9: pre-branch AG proofs fail the strict verifier (values change, shape does not). No AG fixtures exist yet.
- In-circuit AG lows are measured-rejected at ~24.5k rows per child (`base_functional_circuit_census` records the numbers); the lows stay published with the one checker item above.
- The earlier three-arm benchmark comment predates the quiet-box re-measure; the plan doc holds the current numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

