### PR TITLE
Legacy-path hardening: C=I guard, statement-digest v2, walker const-pin overrides

### DIFF
--- a/crates/flock-core/src/r1cs.rs
+++ b/crates/flock-core/src/r1cs.rs
@@ -364,10 +364,20 @@ impl BlockR1cs {
     pub fn statement_digest(&self) -> [u8; 32] {
         *self.digest_cache.get_or_init(|| {
             let mut h = blake3::Hasher::new();
-            h.update(b"flock-r1cs-stmt-v1");
+            h.update(b"flock-r1cs-stmt-v2");
             h.update(&(self.m as u64).to_le_bytes());
             h.update(&(self.k_log as u64).to_le_bytes());
             h.update(&(self.k_skip as u64).to_le_bytes());
+            // useful_bits (the padding boundary — which rows carry witness)
+            // and const_pin (the constant-wire pin) both change protocol
+            // semantics, so they are part of the statement. const_pin
+            // absorbs as (present, value) so Some(0) differs from None.
+            // (v2, 2026-08-25: v1 lacked both — the union path was already
+            // covered via the registry digest, this is the legacy
+            // single-table binding catching up.)
+            h.update(&(self.useful_bits as u64).to_le_bytes());
+            h.update(&[self.const_pin.is_some() as u8]);
+            h.update(&(self.const_pin.unwrap_or(0) as u64).to_le_bytes());
             // The layout determines which polynomial a given witness commits
             // to — it is part of the statement.
             h.update(&[match self.layout {
@@ -888,5 +898,44 @@ mod tests {
         let mut z_nonzero = vec![false; 1 << m];
         z_nonzero[5] = true;
         assert!(!r1cs.satisfies(&z_nonzero));
+    }
+
+    /// `useful_bits` and `const_pin` both change protocol semantics (the
+    /// padding boundary; the constant-wire pin), so the statement digest must
+    /// be sensitive to each — including `Some(0)` vs `None`. Mirrors the
+    /// registry-digest sensitivity tests that already cover the union path.
+    #[test]
+    fn statement_digest_binds_useful_bits_and_const_pin() {
+        let k_log = 3;
+        let base = BlockR1cs {
+            m: 6,
+            k_log,
+            k_skip: 2,
+            useful_bits: 1 << k_log,
+            a_0: identity(1 << k_log),
+            b_0: identity(1 << k_log),
+            c_0: identity(1 << k_log),
+            layout: WitnessLayout::RowMajor,
+            const_pin: None,
+            digest_cache: std::sync::OnceLock::new(),
+            csc_cache: std::sync::OnceLock::new(),
+        };
+        let d0 = base.statement_digest();
+
+        let mut smaller_useful = base.clone();
+        smaller_useful.useful_bits = (1 << k_log) - 1;
+        assert_ne!(d0, smaller_useful.statement_digest(), "useful_bits");
+
+        let mut pin_zero = base.clone();
+        pin_zero.const_pin = Some(0);
+        assert_ne!(d0, pin_zero.statement_digest(), "const_pin Some(0) vs None");
+
+        let mut pin_five = base.clone();
+        pin_five.const_pin = Some(5);
+        assert_ne!(
+            pin_zero.statement_digest(),
+            pin_five.statement_digest(),
+            "const_pin value"
+        );
     }
 }

--- a/crates/flock-core/src/verifier.rs
+++ b/crates/flock-core/src/verifier.rs
@@ -34,6 +34,13 @@ pub enum VerifyError {
     /// different registry, or gate counts that are not the union's declared
     /// counts. A rejection, not a panic — both come from the caller.
     CircuitMismatch,
+    /// The single-table entries build the c-claim as a direct z-claim, which
+    /// is sound only for the circuit-R1CS shape `C = I` — an R1CS with any
+    /// other `c_0` must be rejected here, not silently misverified. (The
+    /// union path has no such check by design: registry table types carry
+    /// stub `c_0` matrices under the walker-encoder convention, and the
+    /// statement is bound through the registry digest instead.)
+    NonIdentityC,
 }
 
 /// Per-phase wall-clock timings (seconds) of a verify, for benchmark cost
@@ -1226,6 +1233,10 @@ fn verify_core_ag_inner<Ch: Challenger>(
         zerocheck::ag_skip::K_SKIP,
         "AG skip is k_skip=6"
     );
+    // The c-claim below is a direct z-claim (ĉ = ẑ) — sound only for C = I.
+    if !r1cs.c0_is_identity() {
+        return Err(VerifyError::NonIdentityC);
+    }
 
     // ---- Bind FS transcript to the statement (mirrors the AG prover).
     crate::proof::bind_statement(challenger, r1cs, commitment);
@@ -1384,6 +1395,10 @@ fn verify_core_inner<Ch: Challenger>(
     lincheck_grinding: lincheck::LincheckGrinding,
     challenger: &mut Ch,
 ) -> Result<(ZClaim, ZClaim), VerifyError> {
+    // The c-claim below is a direct z-claim (ĉ = ẑ) — sound only for C = I.
+    if !r1cs.c0_is_identity() {
+        return Err(VerifyError::NonIdentityC);
+    }
     let trace = std::env::var("VERIFY_TRACE").is_ok();
     let fmt = |s: f64| -> String {
         let ms = s * 1000.0;
@@ -1506,6 +1521,92 @@ mod tests {
         assert!(!super::commitment_params_match_expected(
             &commitment,
             &expected
+        ));
+    }
+
+    /// Both single-table entries build the c-claim as a direct z-claim, which
+    /// assumes `C = I`; an R1CS with any other `c_0` must be REJECTED (a
+    /// structured error), not silently misverified. The guard fires before
+    /// any proof inspection, so empty proofs suffice.
+    #[test]
+    fn non_identity_c_is_rejected_by_both_single_table_entries() {
+        use crate::challenger::FsChallenger;
+        use crate::r1cs::{BlockR1cs, SparseBinaryMatrix, WitnessLayout};
+
+        let k_log = 6;
+        let k = 1usize << k_log;
+        let identity = SparseBinaryMatrix {
+            num_rows: k,
+            num_cols: k,
+            rows: (0..k).map(|i| vec![i]).collect(),
+        };
+        // c_0 = a shift-by-one permutation: a valid matrix, not the identity.
+        let shifted = SparseBinaryMatrix {
+            num_rows: k,
+            num_cols: k,
+            rows: (0..k).map(|i| vec![(i + 1) % k]).collect(),
+        };
+        let r1cs = BlockR1cs {
+            m: 12,
+            k_log,
+            k_skip: crate::zerocheck::ag_skip::K_SKIP,
+            useful_bits: k,
+            a_0: identity.clone(),
+            b_0: identity.clone(),
+            c_0: shifted,
+            layout: WitnessLayout::RowMajor,
+            const_pin: None,
+            digest_cache: std::sync::OnceLock::new(),
+            csc_cache: std::sync::OnceLock::new(),
+        };
+        let commitment = Commitment {
+            cap: Vec::new(),
+            params: PcsParams {
+                m: 12,
+                log_inv_rate: 1,
+                log_batch_size: 6,
+                profile: LigeritoProfile::Fast,
+                num_lanes: None,
+                merkle_hash: HashKind::Sha256,
+            },
+        };
+        let circuit = r1cs.csc_lincheck_circuit();
+
+        let zc = crate::zerocheck::ZerocheckProof {
+            round1_ab: Vec::new(),
+            round1_c: Vec::new(),
+            multilinear_rounds: Vec::new(),
+            final_a_eval: crate::field::F128::ZERO,
+            final_b_eval: crate::field::F128::ZERO,
+            final_c_eval: crate::field::F128::ZERO,
+            grinding_nonces: Vec::new(),
+        };
+        let lc = crate::lincheck::LincheckProof {
+            rounds: Vec::new(),
+            z_partial: Vec::new(),
+            matrix_evals: Vec::new(),
+            grinding_nonces: Vec::new(),
+        };
+        let mut ch = FsChallenger::new(b"non-identity-c-test");
+        assert!(matches!(
+            super::verify_core(&r1cs, &zc, &lc, &commitment, circuit, &mut ch),
+            Err(super::VerifyError::NonIdentityC)
+        ));
+
+        let ag = crate::zerocheck::ag_skip::AgProof {
+            round1_ab: Vec::new(),
+            round1_c: Vec::new(),
+            r1_nonce: 0,
+            multilinear_rounds: Vec::new(),
+            final_a_eval: crate::field::F128::ZERO,
+            final_b_eval: crate::field::F128::ZERO,
+            final_c_eval: crate::field::F128::ZERO,
+            grinding_nonces: Vec::new(),
+        };
+        let mut ch = FsChallenger::new(b"non-identity-c-test");
+        assert!(matches!(
+            super::verify_core_ag(&r1cs, &ag, &lc, &commitment, circuit, &mut ch),
+            Err(super::VerifyError::NonIdentityC)
         ));
     }
 }

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -943,6 +943,14 @@ impl flock_core::lincheck::LincheckCircuit for Blake3LincheckCircuit {
         K
     }
 
+    // Without this override the trait default (`None`) silently drops the
+    // constant-wire pin the R1CS declares, reopening the all-zero-witness
+    // gap for any caller pairing this walker with a pinned setup — the
+    // keccak/merkle walkers all override; this one had inherited the default.
+    fn const_pin_col(&self) -> Option<usize> {
+        Some(Z_CONST_POS)
+    }
+
     fn fold_alpha_batched(&self, alpha: F128, eq_inner: &[F128]) -> Vec<F128> {
         assert_eq!(eq_inner.len(), K, "eq_inner length must equal n_cols = K");
         let mut comb = vec![F128::ZERO; K];
@@ -2202,6 +2210,17 @@ pub fn generate_witness_batch_major_partial_into(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The walker's constant-wire pin must equal the pin the R1CS itself
+    /// declares — a walker inheriting the trait's `None` default silently
+    /// drops the pin and reopens the all-zero-witness gap.
+    #[test]
+    fn walker_const_pin_matches_r1cs() {
+        use flock_core::lincheck::LincheckCircuit as _;
+        let r1cs = build_block_r1cs(3);
+        assert_eq!(Blake3LincheckCircuit.const_pin_col(), r1cs.const_pin);
+        assert_eq!(r1cs.const_pin, Some(Z_CONST_POS));
+    }
 
     /// The IO schema must cover **every free-witness input region**: a word
     /// the relation does not pin and the schema does not expose is a value the

--- a/crates/flock-prover/src/r1cs_hashes/sha2.rs
+++ b/crates/flock-prover/src/r1cs_hashes/sha2.rs
@@ -840,6 +840,12 @@ impl flock_core::lincheck::LincheckCircuit for Sha2LincheckCircuit {
         K
     }
 
+    // See Blake3LincheckCircuit::const_pin_col — same latent trait-default
+    // gap, same fix.
+    fn const_pin_col(&self) -> Option<usize> {
+        Some(Z_CONST_POS)
+    }
+
     fn fold_alpha_batched(&self, alpha: F128, eq_inner: &[F128]) -> Vec<F128> {
         assert_eq!(eq_inner.len(), K, "eq_inner length must equal n_cols = K");
         let mut comb = vec![F128::ZERO; K];
@@ -1968,6 +1974,16 @@ pub fn generate_witness_batch_major_partial_into(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The walker's constant-wire pin must equal the pin the R1CS itself
+    /// declares — see the blake3 twin of this test.
+    #[test]
+    fn walker_const_pin_matches_r1cs() {
+        use flock_core::lincheck::LincheckCircuit as _;
+        let r1cs = build_block_r1cs(3);
+        assert_eq!(Sha2LincheckCircuit.const_pin_col(), r1cs.const_pin);
+        assert_eq!(r1cs.const_pin, Some(Z_CONST_POS));
+    }
 
     /// SplitMix64 PRNG, deterministic.
     struct Rng(u64);


### PR DESCRIPTION
The remnants of #4 and #2 after triage against the union-era main — each item confined to the legacy single-table path, where the union-era protections don't reach.

## Summary

- **C=I guard** (#4's surviving half): `verify_core` and `verify_core_ag` build the c-claim as a direct z-claim, which is sound only for the circuit-R1CS shape `C = I` — both said so in comments, neither checked. They now reject a non-identity `c_0` with a structured `VerifyError::NonIdentityC` instead of silently misverifying. No guard on the union path by design: registry table types legitimately carry stub `c_0` matrices under the walker-encoder convention.
- **Statement-digest v2** (#2's surviving half): `BlockR1cs::statement_digest()` now absorbs `useful_bits` (the padding boundary) and `const_pin` (as present+value, so `Some(0)` ≠ `None`) — both change protocol semantics and were unbound on this path. Domain tag `flock-r1cs-stmt-v1` → `v2`. **Deliberate transcript change on the legacy single-table path only**; the union transcript is untouched (it binds through the registry digest, which already covers both fields with sensitivity tests). The CUDA prover receives the digest opaquely from Rust, so it follows with no C++ change.
- **Walker const-pin overrides** (#2's other half): `Blake3LincheckCircuit` and `Sha2LincheckCircuit` inherited the trait's `None` default while every other walker overrides `const_pin_col` — a latent public-API trap that would drop the constant-wire pin. Each now returns the R1CS's own pin, with tests locking the equality.

## Motivation

Closes out the June security-audit items that five months of protocol rework didn't subsume: the union path got these protections structurally, the still-shipped single-table API (keccak3, verifier_roundtrip, gpu_roundtrip) did not.

## Validation

Full workspace suite green — no default-run byte pins moved (the m6 pins are union-path). The ignored single-table RS and AG roundtrips pass under the v2 digest. New tests: non-identity-C rejection on both entries, digest sensitivity (useful_bits, `Some(0)` vs `None`, pin value), walker-pin equality. Clippy + fmt clean on 1.98; x86_64 cross-check clean. The element transcript-shape pin fails identically on clean main (pre-existing fixture rot).

Closes #4. Closes #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)