### PR TITLE
tower: fold the mechanical duplication clusters (stacked on #41)

### DIFF
--- a/crates/flock-core/src/circuit/builder.rs
+++ b/crates/flock-core/src/circuit/builder.rs
@@ -77,6 +77,21 @@ pub enum SlotWitness {
     DeferredToRows,
 }
 
+impl SlotWitness {
+    /// The element-slot witness of per-row words: `word[(col << nu) + row]`
+    /// over a `width << nu` buffer, rows in declaration order. Every
+    /// element gate's `witness()` is this call.
+    pub fn element_from_rows<R: AsRef<[F128]>>(width: usize, nu: usize, rows: &[R]) -> Self {
+        let mut z = crate::alloc_zeroed_vec::<F128>(width << nu);
+        for (j, row) in rows.iter().enumerate() {
+            for (col, &v) in row.as_ref().iter().enumerate() {
+                z[(col << nu) + j] = v;
+            }
+        }
+        SlotWitness::Element(z)
+    }
+}
+
 /// A gate type: its constraint system and its native evaluation, together.
 ///
 /// The pairing is the whole point. A type that could describe its constraints

--- a/crates/flock-core/src/pcs/jagged.rs
+++ b/crates/flock-core/src/pcs/jagged.rs
@@ -2282,8 +2282,11 @@ fn sqrt_basis() -> &'static [F128; 128] {
     })
 }
 
-/// `x^{2^{-1}}` via the basis-image table.
-fn frob_inv(x: F128) -> F128 {
+/// The inverse Frobenius `x ↦ x^{2^{-1}} = x^{2^127}` (the square root in
+/// F₂₁₂₈), via the basis-image table: 128 table adds instead of 127
+/// squarings. The recursion tower's walkers use it too; `frob_inv_matches_127_squarings`
+/// pins the two derivations equal.
+pub fn frob_inv(x: F128) -> F128 {
     let t = sqrt_basis();
     let mut acc = F128::ZERO;
     let mut lo = x.lo;
@@ -6451,5 +6454,21 @@ mod tests {
             verify(&params, &z_row, &z_col, v, &proof, &mut vch).is_none(),
             "verifier must reject a tampered q_eval"
         );
+    }
+
+    /// The table-based square root equals 127 squarings on random inputs —
+    /// the tower's walkers used the squaring form until 2026-08-29.
+    #[test]
+    fn frob_inv_matches_127_squarings() {
+        let mut rng = crate::test_rng::Rng::new(0xF0B_1A5);
+        for _ in 0..256 {
+            let x = rng.f128();
+            let mut y = x;
+            for _ in 0..127 {
+                y = y * y;
+            }
+            assert_eq!(frob_inv(x), y);
+            assert_eq!(frob_inv(x) * frob_inv(x), x, "sqrt squares back");
+        }
     }
 }

--- a/crates/flock-core/src/transcript_record.rs
+++ b/crates/flock-core/src/transcript_record.rs
@@ -152,6 +152,19 @@ impl TranscriptOp {
         }
     }
 
+    /// Whether this op owns a byte-payload ordinal: `ObserveBytes` (public
+    /// bytes) and both PoW forms (the private 16-byte nonce) share the
+    /// payload counter — the tower's tape walkers, fold/query regions and
+    /// `bytes_payload_mask` all index payloads this way.
+    pub fn carries_payload(&self) -> bool {
+        matches!(
+            self,
+            TranscriptOp::ObserveBytes(_)
+                | TranscriptOp::Pow { .. }
+                | TranscriptOp::LegacyPow { .. }
+        )
+    }
+
     /// Whether this op finalizes the pending state. Finalizations are the
     /// transcript's serial depth: a squeeze finalizes the running state, and
     /// everything after it depends on that state, so nothing downstream can

--- a/crates/flock-prover/src/tower/child_walker.rs
+++ b/crates/flock-prover/src/tower/child_walker.rs
@@ -1022,17 +1022,8 @@ impl<'p> ChildTape<'p> {
         // map onto the same walk — the merge node's connects consume them.
         // Byte-payload ordinal of the op at `end` (ObserveBytes and Pow
         // share the payload counter — see [`bytes_payload_mask`]).
-        let payload_at = |end: usize| -> usize {
-            ops[..end]
-                .iter()
-                .filter(|o| {
-                    matches!(
-                        o,
-                        Op::ObserveBytes(_) | Op::Pow { .. } | Op::LegacyPow { .. }
-                    )
-                })
-                .count()
-        };
+        let payload_at =
+            |end: usize| -> usize { ops[..end].iter().filter(|o| o.carries_payload()).count() };
         let (
             zc_rounds_b,
             zskip,
@@ -1368,7 +1359,7 @@ impl<'p> ChildTape<'p> {
                 for (j, &gp) in gpow_n.iter().enumerate().take(128) {
                     if j > 0 {
                         for x in rinv.iter_mut() {
-                            *x = frob_inv_native(*x);
+                            *x = flock_core::pcs::jagged::frob_inv(*x);
                         }
                     }
                     let mut prod = gp;
@@ -2457,7 +2448,7 @@ pub(super) fn emit_child_region(
         if j > 0 {
             let mut lvl_w = Vec::with_capacity(m_mp2);
             for t2 in 0..m_mp2 {
-                let y = frob_inv_native(rinv_n2[t2]);
+                let y = flock_core::pcs::jagged::frob_inv(rinv_n2[t2]);
                 rinv_n2[t2] = y;
                 vals.push(y);
                 let yw = sb.input();

--- a/crates/flock-prover/src/tower/fold_region.rs
+++ b/crates/flock-prover/src/tower/fold_region.rs
@@ -855,10 +855,7 @@ pub(super) fn labeled_bytes_payloads(
         {
             out.push(payload);
         }
-        if matches!(
-            op,
-            Op::ObserveBytes(_) | Op::Pow { .. } | Op::LegacyPow { .. }
-        ) {
+        if op.carries_payload() {
             payload += 1;
         }
     }

--- a/crates/flock-prover/src/tower/gates_leaf.rs
+++ b/crates/flock-prover/src/tower/gates_leaf.rs
@@ -172,13 +172,7 @@ impl GateType for LeafEvalGate {
     }
 
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (c, &v) in row.iter().enumerate() {
-                z[(c << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }
 
@@ -398,12 +392,6 @@ impl GateType for LeafEvalGate256 {
     }
 
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (c, &v) in row.iter().enumerate() {
-                z[(c << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }

--- a/crates/flock-prover/src/tower/gates_spine.rs
+++ b/crates/flock-prover/src/tower/gates_spine.rs
@@ -82,13 +82,7 @@ impl GateType for SpineGate {
     }
 
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (col, &v) in row.iter().enumerate() {
-                z[(col << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }
 
@@ -216,13 +210,7 @@ impl GateType for SpineGate256 {
     }
 
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (col, &v) in row.iter().enumerate() {
-                z[(col << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }
 
@@ -299,7 +287,9 @@ impl ResidualWeightsGate256 {
     pub(super) fn new() -> Self {
         use flock_core::element_r1cs::ElementTableBuilder;
         let o = F128::ONE;
-        let sks = sk_at_vks(Self::N_WEIGHTS);
+        // The subspace-polynomial chain constants `s_k(v_k)`, straight from
+        // ligerito (the residual boundary check pins the spine against them).
+        let sks = flock_core::pcs::ligerito::eval_sk_at_vks(Self::N_WEIGHTS);
         let coeffs: Vec<F128> = (0..Self::N_WEIGHTS - 1)
             .map(|k| {
                 assert_ne!(sks[k + 1], F128::ZERO, "novel-basis normalizer is nonzero");
@@ -347,13 +337,7 @@ impl GateType for ResidualWeightsGate256 {
     }
 
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (col, &v) in row.iter().enumerate() {
-                z[(col << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }
 
@@ -445,13 +429,7 @@ impl GateType for ResidualPrefix3Gate256 {
     }
 
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (col, &v) in row.iter().enumerate() {
-                z[(col << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }
 
@@ -566,13 +544,7 @@ impl GateType for ResidualAccGate256 {
     }
 
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (col, &v) in row.iter().enumerate() {
-                z[(col << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }
 
@@ -594,32 +566,6 @@ pub(super) fn live_element_input_from_rows(
             }
         }
     })
-}
-
-/// `s_{k+1}(x) = s_k(x)^2 + s_k(v_k) s_k(x)` — the subspace-polynomial chain,
-/// and its `s_k(v_k)` constants (a replica of ligerito's pub(crate)
-/// `eval_sk_at_vks`, pinned by the residual boundary check below).
-pub(super) fn sk_at_vks(log_n: usize) -> Vec<F128> {
-    let next = |s: F128, c: F128| s * s + c * s;
-    let mut sks = vec![F128::ZERO; log_n + 1];
-    sks[0] = F128::ONE;
-    if log_n == 0 {
-        return sks;
-    }
-    let mut layer: Vec<F128> = (1..=log_n).map(|i| F128::new(1u64 << i, 0)).collect();
-    let mut cur = log_n;
-    for i in 0..log_n {
-        for j in 0..cur {
-            let v = next(layer[j], sks[i]);
-            if j == 0 {
-                sks[i + 1] = v;
-            } else {
-                layer[j - 1] = v;
-            }
-        }
-        cur -= 1;
-    }
-    sks
 }
 
 /// 2b stage 2: PrefixGate computes `seed * prod_j (1 + a_j + b_j)` — the
@@ -692,13 +638,7 @@ impl GateType for PrefixGate {
         z
     }
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (col, &v) in row.iter().enumerate() {
-                z[(col << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }
 
@@ -799,13 +739,7 @@ impl GateType for PrefixGate256 {
     }
 
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (col, &v) in row.iter().enumerate() {
-                z[(col << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }
 
@@ -856,13 +790,7 @@ impl GateType for MergedRoundGate {
         z
     }
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (col, &v) in row.iter().enumerate() {
-                z[(col << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }
 
@@ -908,13 +836,7 @@ impl GateType for MacGate {
         z
     }
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (col, &v) in row.iter().enumerate() {
-                z[(col << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }
 
@@ -967,13 +889,7 @@ impl GateType for MacGate256 {
     }
 
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (col, &v) in row.iter().enumerate() {
-                z[(col << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }
 
@@ -1093,13 +1009,7 @@ impl GateType for AssistLayerGate {
         z
     }
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (col, &v) in row.iter().enumerate() {
-                z[(col << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }
 
@@ -1161,12 +1071,6 @@ impl GateType for ZcRoundGate {
         z
     }
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
-        let mut z = flock_core::alloc_zeroed_vec::<F128>(self.ty.width() << nu);
-        for (j, row) in rows.iter().enumerate() {
-            for (col, &v) in row.iter().enumerate() {
-                z[(col << nu) + j] = v;
-            }
-        }
-        SlotWitness::Element(z)
+        SlotWitness::element_from_rows(self.ty.width(), nu, rows)
     }
 }

--- a/crates/flock-prover/src/tower/gkr.rs
+++ b/crates/flock-prover/src/tower/gkr.rs
@@ -755,11 +755,3 @@ pub(super) struct ElPiopRec {
     pub(super) alpha_ch: usize,
     pub(super) lc_rounds: Vec<(usize, usize, usize)>,
 }
-
-pub(super) fn frob_inv_native(x: F128) -> F128 {
-    let mut y = x;
-    for _ in 0..127 {
-        y = y * y;
-    }
-    y
-}

--- a/crates/flock-prover/src/tower/query.rs
+++ b/crates/flock-prover/src/tower/query.rs
@@ -580,7 +580,7 @@ pub(super) fn emit_residual_region(
 
 /// Check the residual region's published wires against a NATIVE replica:
 /// `induce_sumcheck_evaluate_at_residual` per level (sks replicated via
-/// `sk_at_vks` — the mvp7 discipline), then the close-out's gamma-weighted
+/// `eval_sk_at_vks` — the mvp7 discipline), then the close-out's gamma-weighted
 /// char-2 eq products and the yr dot. Walks `public` from `at` (the first
 /// accumulator, `levels × 2^yr` entries, then the inner), asserting each.
 /// Returns the native inner — the residual-side t_r — so the caller asserts
@@ -605,7 +605,7 @@ pub(super) fn check_residual_publics(
     for (li, lvl) in levels.iter().enumerate() {
         let pl: usize = levels[li + 1..].iter().map(|l| l.fold_fins.len() - 1).sum();
         let lmc = pl + yr_log;
-        let sks = sk_at_vks(lmc);
+        let sks = flock_core::pcs::ligerito::eval_sk_at_vks(lmc);
         let inv = |v: F128| if v == F128::ZERO { F128::ZERO } else { v.inv() };
         let ris: Vec<F256> = levels[li + 1..]
             .iter()
@@ -845,10 +845,7 @@ pub(super) fn emit_recorded_pow_checks(
         if op.finalizes() {
             fin += 1;
         }
-        if matches!(
-            op,
-            Op::ObserveBytes(_) | Op::Pow { .. } | Op::LegacyPow { .. }
-        ) {
+        if op.carries_payload() {
             pay += 1;
         }
     }

--- a/crates/flock-prover/src/tower/real_walker.rs
+++ b/crates/flock-prover/src/tower/real_walker.rs
@@ -582,9 +582,8 @@ impl<'p> RealTape<'p> {
                 if op.finalizes() {
                     fin += 1;
                 }
-                match op {
-                    Op::ObserveBytes(_) | Op::Pow { .. } | Op::LegacyPow { .. } => pay += 1,
-                    _ => {}
+                if op.carries_payload() {
+                    pay += 1;
                 }
             }
             out
@@ -859,17 +858,8 @@ impl<'p> RealTape<'p> {
         // squeeze, z_partial's slice).
         // Byte-payload ordinal of the op at `end` (ObserveBytes and Pow
         // share the payload counter — see [`bytes_payload_mask`]).
-        let payload_at = |end: usize| -> usize {
-            ops[..end]
-                .iter()
-                .filter(|o| {
-                    matches!(
-                        o,
-                        Op::ObserveBytes(_) | Op::Pow { .. } | Op::LegacyPow { .. }
-                    )
-                })
-                .count()
-        };
+        let payload_at =
+            |end: usize| -> usize { ops[..end].iter().filter(|o| o.carries_payload()).count() };
         let (
             zc_rounds_b,
             zskip,
@@ -1237,7 +1227,7 @@ impl<'p> RealTape<'p> {
                 for (j, &gp) in gpow_n.iter().enumerate().take(128) {
                     if j > 0 {
                         for x in rinv.iter_mut() {
-                            *x = frob_inv_native(*x);
+                            *x = flock_core::pcs::jagged::frob_inv(*x);
                         }
                     }
                     let mut prod = gp;
@@ -2411,7 +2401,7 @@ pub(super) fn emit_real_child_region(
         if j > 0 {
             let mut lvl_w = Vec::with_capacity(m_mp2);
             for t3 in 0..m_mp2 {
-                let y = frob_inv_native(rinv_n2[t3]);
+                let y = flock_core::pcs::jagged::frob_inv(rinv_n2[t3]);
                 rinv_n2[t3] = y;
                 vals.push(y);
                 let yw = sb.input();

--- a/docs/bloat-ledger.md
+++ b/docs/bloat-ledger.md
@@ -465,19 +465,19 @@ alone: 23% clone-covered, ~2,970 of the recommended total.
 | # | Cluster | Dup lines | Consol. | Risk |
 | --- | --- | --- | --- | --- |
 | 1 | tower.rs Real/Child tape+region+node family (walkers share 76%, emitters 78%) | 2,488 | ~2,000 | **high** — transcript + byte pins; unify field-by-field, re-run pins |
-| 2 | LegacyPow payload-ordinal walkers ×4 (2 of 4 had the bug) | 40 | 40 | high value, mechanical: one `payload_ordinals()` iterator |
-| 3 | `GateType::witness()` 12-line body ×18 + `*256` twin gates | 420 | ~330 | low (witness) / medium (`*256` column order) |
-| 4 | tower native replicas (`sk_at_vks` ≡ `eval_sk_at_vks`, `frob_inv_native` ≡ jagged's) — export core fns instead | 700 | ~250 | low for replicas; do NOT merge the `check_*` validators (soundness backstop) |
+| 2 | LegacyPow payload-ordinal walkers ×4 (2 of 4 had the bug) | 40 | 40 | high value, mechanical: one `payload_ordinals()` iterator — **DONE 2026-08-29**: `TranscriptOp::carries_payload()` replaces the 5 inline `ObserveBytes|Pow|LegacyPow` patterns (child/real walkers, fold_region, query) |
+| 3 | `GateType::witness()` 12-line body ×18 + `*256` twin gates | 420 | ~330 | low (witness) / medium (`*256` column order) — **DONE 2026-08-29** (witness half): `SlotWitness::element_from_rows` replaces the 14 identical bodies; the `*256` twin gates are left as they are (column order is protocol) |
+| 4 | tower native replicas (`sk_at_vks` ≡ `eval_sk_at_vks`, `frob_inv_native` ≡ jagged's) — export core fns instead | 700 | ~250 | low for replicas; do NOT merge the `check_*` validators (soundness backstop) — **DONE 2026-08-29** for the replicas: `sk_at_vks` → `ligerito::eval_sk_at_vks`, `frob_inv_native` → `jagged::frob_inv` (now pub; `frob_inv_matches_127_squarings` pins the two derivations); the `check_*` validators untouched as recommended |
 | 5 | fold ↔ jagged-fold twin family ×5 | 251 | ~200 | high — transcript |
-| 6 | tower gates duplicated into test files (Blake3Gate, AssistLayerGate, MultGate; circuit_wiring↔kappa7 harness 219 exact) | 371 | ~150 | low — export as `pub(crate)` |
+| 6 | tower gates duplicated into test files (Blake3Gate, AssistLayerGate, MultGate; circuit_wiring↔kappa7 harness 219 exact) | 371 | ~150 | low — export as `pub(crate)` — **REJECTED 2026-08-29**: re-measured, the test copies of `Blake3Gate`/`AssistLayerGate` differ from the tower's (0.66/0.73 similarity, different unpack helpers) and the circuit_wiring↔kappa7 clone is 24 lines today, not 219; not worth exporting |
 | 7 | r1cs_hashes four-encoder family (Setup ctors byte-identical keccak↔keccak3; `accumulate_subkeccak` ≡ `fold_alpha_batched` 94 shared; keccak.rs:1234 re-implements the common driver) | 840 | ~640 | medium; leave the hot `bm_*`/`build_group_batch_major` loops |
 | 8 | **SplitMix64 RNG: 117 sites, 52 variant bodies, byte-identical groups mapped** | 2,072 | ~1,950 | low but byte-pinned — one `test_rng::Rng` (~45 lines); preserve per-site draw order verbatim (`f128()` order is load-bearing) — **DONE 2026-08-27** (`flock_core::test_rng::Rng`, 78 sites replaced; per-method equivalence classes verified before replacing; site-specific draws kept as local `RngExt` traits; 4 custom generators left alone: assist_blocked, virtual_b, jagged_fold, matrix_fold; all byte pins + tower tape pins held) |
 | 9 | Ligerito F256 transcript walk ×4 semantic copies (Rust prover/verifier + `.cuh` + host `.cpp`; `700cace` fixed 3, `ffabc07` the 4th) | ~1,500 sem. | ~180 | **maximum** — only unifiable artifact is a declarative op schedule + conformance vector; needs Blackwell CI |
-| 10 | bench boilerplate (keccak3 3-way ~90% clone-covered; native-chain pair has a 134-line exact clone) | 1,270 | ~1,270 | low |
+| 10 | bench boilerplate (keccak3 3-way ~90% clone-covered; native-chain pair has a 134-line exact clone) | 1,270 | ~1,270 | low — mostly RESOLVED by 2.1 (the keccak3 3-way and the native-chain pair were deleted) |
 | 11 | dump-bin frame | 270 | ~270 | byte-pinned draw order |
-| 12 | verifier/prover `_ag`/`_deferred`/`_timed`/`_jagged` twins | 425 | ~425 | `_timed` safe (timer sink); `_ag`/`_deferred` are protocol variants |
+| 12 | verifier/prover `_ag`/`_deferred`/`_timed`/`_jagged` twins | 425 | ~425 | `_timed` safe (timer sink); `_ag`/`_deferred` are protocol variants — `_timed` DONE (deleted with 2.1); `_ag`/`_deferred` stay (protocol variants) |
 | 13 | merkle_r1cs `*_chunk` twins | 180 | ~180 | follows Phase 2.2 — DONE 2026-08-27 (deleted with 2.2) |
-| 14 | merkle_glue gate-table boilerplate ×4 | 131 | ~130 | low — macro/blanket trait |
+| 14 | merkle_glue gate-table boilerplate ×4 | 131 | ~130 | low — macro/blanket trait — **REJECTED 2026-08-29**: the shared shape is ~10 lines per table split between associated fns and methods; a macro would cost more than it saves |
 | 15 | ligerito.rs test roundtrip boilerplate | 883 | ~440 | low — `roundtrip_case` helper |
 
 Also mapped for the Phase 3 tower.rs module split: the full region map


### PR DESCRIPTION
## Summary

Stacked on #41 (base `bloat-phase3-rng`). Phase 3 slice 3: the mechanical duplication clusters in the tower (ledger §G rows 2, 3, 4). One commit, 11 files, +87 / −181. Byte-preserving: the tower tape pins and every fixture digest reproduce.

- `SlotWitness::element_from_rows` replaces the 14 identical `witness()` bodies in the spine and leaf gates.
- `TranscriptOp::carries_payload()` replaces the five inline `ObserveBytes | Pow | LegacyPow` patterns that count byte-payload ordinals in the two walkers, `fold_region` and `query`. Two of the four walkers once had this predicate wrong; it now has one definition.
- The spine's `sk_at_vks` replica is gone; the tower calls `ligerito::eval_sk_at_vks`, and the residual boundary check that pinned the replica now pins the original.
- `frob_inv_native` (127 squarings) is gone; the walkers call jagged's table-based `frob_inv`, now `pub`. It is the same field element by construction (the unique square root), and a new unit test pins the two derivations equal on 256 random inputs.

Rejected after re-measuring: §G 6 (the test copies of `Blake3Gate`/`AssistLayerGate` are not clones of the tower's, and the `circuit_wiring`↔`kappa7_probe` clone is 24 lines today, not 219) and §G 14 (a glue-table macro would cost more than the ~10 lines per table it saves). The ledger rows record both.

## Motivation

These were the low-risk entries of the Phase 3 map; the remaining large one (the Child/Real tape-walker pair, ~2,000 lines) is high risk and gets its own plan.

## Validation

Full workspace suite (release, `--no-fail-fast`) green; ignored tower suite 12/12 (tape pins, spine convergence, m32 headline); clippy `-D warnings` clean on aarch64 and on the exact CI x86_64 lint leg; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
