### PR TITLE
tower: the driver — one call from chain statement to converged root (productionization M1)

### DIFF
--- a/crates/flock-prover/examples/tower.rs
+++ b/crates/flock-prover/examples/tower.rs
@@ -20,9 +20,9 @@ fn main() {
     let n_leaves: usize = args
         .next()
         .map_or(8, |v| v.parse().expect("n_leaves: an even integer >= 4"));
-    let blocks_per_leaf: usize = args
-        .next()
-        .map_or(256, |v| v.parse().expect("blocks_per_leaf: a positive integer"));
+    let blocks_per_leaf: usize = args.next().map_or(256, |v| {
+        v.parse().expect("blocks_per_leaf: a positive integer")
+    });
     let cfg = match args.next().as_deref() {
         None | Some("chain128") => TowerConfig::Chain128,
         Some("chain100") => TowerConfig::Chain100,

--- a/crates/flock-prover/examples/tower.rs
+++ b/crates/flock-prover/examples/tower.rs
@@ -1,0 +1,58 @@
+//! The recursion tower, end to end: prove a BLAKE3 compression chain and
+//! fold it to ONE recursable root proof, then discharge the root-side
+//! residue.
+//!
+//! ```sh
+//! cargo run --release --example tower -- [n_leaves] [blocks_per_leaf] [chain128|chain100]
+//! ```
+//!
+//! Defaults: 8 leaves x 256 compressions under the 128-bit tower — the
+//! smallest run that reaches the STEADY spine shape (a base plus two
+//! spine folds) and boards the passenger. The production leaf is 2^18
+//! compressions (`blocks_per_leaf = 262144`); expect minutes there.
+
+use std::{env, time::Instant};
+
+use flock_prover::tower::{Tower, TowerConfig};
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let n_leaves: usize = args
+        .next()
+        .map_or(8, |v| v.parse().expect("n_leaves: an even integer >= 4"));
+    let blocks_per_leaf: usize = args
+        .next()
+        .map_or(256, |v| v.parse().expect("blocks_per_leaf: a positive integer"));
+    let cfg = match args.next().as_deref() {
+        None | Some("chain128") => TowerConfig::Chain128,
+        Some("chain100") => TowerConfig::Chain100,
+        Some(other) => panic!("unknown tower config {other:?}: chain128 or chain100"),
+    };
+
+    // The demo chain starts at the zero state; a deployment starts at its
+    // application's own h_start.
+    let h_start = [0u32; 16];
+
+    let t0 = Instant::now();
+    let tower = Tower::prove(cfg, h_start, blocks_per_leaf, n_leaves);
+    let prove_s = t0.elapsed().as_secs_f64();
+
+    let t1 = Instant::now();
+    tower
+        .discharge_root()
+        .expect("the root-side residue discharges");
+    let discharge_s = t1.elapsed().as_secs_f64();
+
+    let s = tower.statement();
+    println!(
+        "\nTOWER {:?}: {n_leaves} leaves x {blocks_per_leaf} compressions = {} total\n  \
+         h_end = {:08x}{:08x}.. (== H^{}(h_start))\n  \
+         ONE root proof: {:.1} KiB | prove {prove_s:.1}s | root discharge {discharge_s:.3}s",
+        cfg,
+        s.n_blocks,
+        s.h_end[0],
+        s.h_end[1],
+        s.n_blocks,
+        tower.root_proof_kib(),
+    );
+}

--- a/crates/flock-prover/src/tower/driver.rs
+++ b/crates/flock-prover/src/tower/driver.rs
@@ -1,0 +1,353 @@
+//! **THE DRIVER**: one call from a chain statement to the tower's
+//! converged root — the production caller for the pipeline the e2e tests
+//! used to hand-assemble.
+//!
+//! [`Tower::prove`] runs the whole tower over a BLAKE3 compression chain:
+//! sequential LEAVES (each segment starts at the previous one's `h_end`),
+//! adjacent pairs into FIRST-LEVEL nodes, then the SPINE — the BASE folds
+//! the LAST two FLs and every level above prepends the next-earlier FL as
+//! its fresh child, the chain LANE riding every level. From the second
+//! spine fold on the circuit digest must not move (ONE steady shape —
+//! asserted in the loop).
+//!
+//! [`Tower::discharge_root`] settles the ROOT-SIDE RESIDUE: the carried
+//! accumulators against the native tables, the passenger against the
+//! base's own tables, the statement against the root's publics. It does
+//! NOT verify the root's own proof — that is the consuming verifier's
+//! call (`verify_circuit` over the root outer, the statement-tier helper
+//! the e2e tamper legs assemble); the driver's job ends at handing back
+//! the root artifacts whole.
+
+use flock_core::{
+    aggregate::Accumulator, circuit::Circuit, lincheck::LincheckCircuit,
+    pcs::jagged::JaggedParams,
+};
+
+use crate::tower::{
+    chain::{ChainProof, build_chain_proof},
+    config::TowerConfig,
+    fl_node::{FlNode, build_fl_node, chain_blake_r1cs, chain_jagged_params},
+    gates_blake3::pack4,
+    node::{
+        ChainLane, NodeOut, SpineIn, build_node_outer_app, digest_f128, entry_live,
+        node_jagged_params,
+    },
+    online::census_kib,
+    query::leaf_boolean_mats,
+};
+
+/// What a tower run attests: `h_end == H^{n_blocks}(h_start)` over the
+/// BLAKE3 compression chain.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ChainStatement {
+    pub h_start: [u32; 16],
+    pub h_end: [u32; 16],
+    /// TOTAL compressions across the span: `n_leaves * blocks_per_leaf`.
+    pub n_blocks: usize,
+}
+
+/// Which root-side discharge refused — see [`Tower::discharge_root`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RootDischargeFailure {
+    /// The root's app block does not carry the statement's span.
+    Statement,
+    /// The chain lane's boolean claims vs the chain BLAKE3 matrices.
+    ChainLaneBoolean,
+    /// The chain lane grew an element group it cannot have.
+    ChainLaneElement,
+    /// The chain lane's sigma claims vs the chain circuit's wiring.
+    ChainLaneSigma,
+    /// The chain lane's jagged claims vs the chain layout.
+    ChainLaneJagged,
+    /// The main fold's boolean claims vs the outer registry's matrices.
+    Boolean,
+    /// The main fold's element claims vs the outer element types.
+    Element,
+    /// The main fold's sigma claims vs the outer circuits' wiring.
+    Sigma,
+    /// The main fold's jagged claims vs the outer layouts.
+    Jagged,
+    /// The passenger: missing when owed, riding when not, or refusing the
+    /// base's tables.
+    Passenger,
+}
+
+/// A completed tower run: the ROOT (one recursable proof over the whole
+/// chain) plus the material owners the root-side discharge needs — leaf 0
+/// for the chain tables, FL 0 for the outer tables, the base for the
+/// passenger's.
+pub struct Tower {
+    pub(super) cfg: TowerConfig,
+    pub(super) statement: ChainStatement,
+    /// The app block's offset in every outer's public segment.
+    pub(super) app_base: usize,
+    /// Leaf 0 — the chain lane's material owner (one shape for every
+    /// leaf).
+    pub(super) chain: ChainProof,
+    /// FL 0 (the root's own fresh child) — the outer tables' owner (one
+    /// shape for every FL).
+    pub(super) fl: FlNode,
+    /// The spine's BASE, kept whenever it is not the root itself: its
+    /// circuit key survives at the root — as the k = 3 root's node-slot
+    /// sigma key, or as the steady passenger's — so the discharge needs
+    /// its tables.
+    pub(super) base: Option<NodeOut>,
+    pub(super) root: NodeOut,
+    /// A STEADY root (two spine folds or more) owes the single orphan its
+    /// transition made; a shallower root owes none.
+    pub(super) expect_passenger: bool,
+}
+
+impl Tower {
+    /// PROVE THE CHAIN: `n_leaves` sequential segments of
+    /// `blocks_per_leaf` compressions each, folded to one root.
+    ///
+    /// `n_leaves` must be even and at least 4 (leaves pair into 2-ary FLs
+    /// and the tower roots at a node; the k-ary FL door stays open but is
+    /// not driven here). Leaves build sequentially — each segment's walk
+    /// IS the chain compute — and each level's inputs drop once folded;
+    /// what stays resident is the FL row (built forward, folded backward
+    /// from the tail) plus the current spine node.
+    pub fn prove(
+        cfg: TowerConfig,
+        h_start: [u32; 16],
+        blocks_per_leaf: usize,
+        n_leaves: usize,
+    ) -> Tower {
+        assert!(
+            n_leaves >= 4 && n_leaves.is_multiple_of(2),
+            "the tower pairs leaves into 2-ary FLs and roots at a node: \
+             n_leaves must be even and >= 4, got {n_leaves}"
+        );
+        // ---- LEAVES, sequential: each segment starts at the last h_end ----
+        let mut cps: Vec<ChainProof> = Vec::with_capacity(n_leaves);
+        let mut h = h_start;
+        for _ in 0..n_leaves {
+            let cp = build_chain_proof(cfg, h, blocks_per_leaf);
+            h = cp.h_end;
+            cps.push(cp);
+        }
+        let statement = ChainStatement {
+            h_start,
+            h_end: h,
+            n_blocks: n_leaves * blocks_per_leaf,
+        };
+
+        // ---- FIRST LEVEL: adjacent pairs ----
+        let fls: Vec<FlNode> = (0..n_leaves / 2)
+            .map(|i| build_fl_node(cfg, &cps[2 * i], &cps[2 * i + 1]))
+            .collect();
+        let app_base = fls[0].stmt_base;
+        let claims_base = fls[0].fold_pub_base;
+
+        // Leaf 0 owns the lane's chain-side materials (one shape for
+        // every leaf); the other leaves fold and drop here.
+        let chain = cps.into_iter().next().expect("leaf 0");
+        let registry = &chain.inner.built.shape.registry;
+        let blake = chain_blake_r1cs(chain.inner.nu);
+        let blake_lc = blake.csc_lincheck_circuit();
+        let chain_mats = [(&blake.a_0, &blake.b_0)];
+        let chain_circs: Vec<&dyn LincheckCircuit> = vec![blake_lc];
+        let chain_circuit = &chain.inner.built.shape.circuit;
+        let chain_jp = chain_jagged_params(&chain);
+
+        // ---- THE BASE: fresh-only over the LAST two FLs (the spine
+        // grows by prepending, so the base covers the chain's tail) ----
+        let k = fls.len();
+        let base = build_node_outer_app(
+            cfg,
+            &[&fls[k - 2].lo, &fls[k - 1].lo],
+            Some(app_base),
+            Some(ChainLane {
+                registry,
+                mats: &chain_mats,
+                circs: &chain_circs,
+                circuit: chain_circuit,
+                params: &chain_jp,
+                priors: &[&fls[k - 2].acc, &fls[k - 1].acc],
+                claims_base,
+            }),
+            None,
+        );
+
+        // ---- THE SPINE: prepend the next-earlier FL, level by level ----
+        let (base, root) = if k == 2 {
+            (None, base)
+        } else {
+            let mut cur: Option<NodeOut> = None;
+            for i in (0..k - 2).rev() {
+                let prev = cur.as_ref().unwrap_or(&base);
+                let prev_lane = prev.lane_acc.clone().expect("the lane rides every level");
+                let n = build_node_outer_app(
+                    cfg,
+                    &[&fls[i].lo, &prev.lo],
+                    Some(app_base),
+                    Some(ChainLane {
+                        registry,
+                        mats: &chain_mats,
+                        circs: &chain_circs,
+                        circuit: chain_circuit,
+                        params: &chain_jp,
+                        priors: &[&fls[i].acc, &prev_lane],
+                        claims_base,
+                    }),
+                    Some(SpineIn {
+                        node_child: 1,
+                        prior: &prev.block,
+                        forge: false,
+                    }),
+                );
+                // ONE steady shape: from the second spine fold on, the
+                // digest must not move (wall 3's convergence).
+                if let Some(c) = &cur {
+                    assert_eq!(
+                        n.lo.shape.circuit.digest(),
+                        c.lo.shape.circuit.digest(),
+                        "the spine converged and must stay converged"
+                    );
+                }
+                cur = Some(n); // the folded spine node drops here
+            }
+            (Some(base), cur.expect("k > 2 built at least one spine node"))
+        };
+
+        let fl = fls.into_iter().next().expect("FL 0");
+        Tower {
+            cfg,
+            statement,
+            app_base,
+            chain,
+            fl,
+            base,
+            root,
+            expect_passenger: k >= 4,
+        }
+    }
+
+    pub fn config(&self) -> TowerConfig {
+        self.cfg
+    }
+
+    pub fn statement(&self) -> &ChainStatement {
+        &self.statement
+    }
+
+    /// The root proof's serialized size in KiB — the recursable artifact.
+    pub fn root_proof_kib(&self) -> f64 {
+        census_kib(&self.root.lo.proof)
+    }
+
+    /// **THE ROOT-SIDE RESIDUE.** Everything the tower defers lands here
+    /// and discharges against the native tables:
+    ///
+    /// 1. the STATEMENT rides the root's app block (packed `h_start` then
+    ///    `h_end`);
+    /// 2. the CHAIN LANE — every leaf's claims — against the chain BLAKE3
+    ///    matrices, the chain circuit's sigma table, and the chain layout;
+    /// 3. the MAIN FOLD against the outer registry's matrices and element
+    ///    types, and against the sigma/jagged tables of every circuit a
+    ///    keyed slot can name — the FL's, the root's own, and the base's;
+    /// 4. the PASSENGER — the spine's single orphan — against the base's
+    ///    own tables, owed exactly when the root is steady.
+    pub fn discharge_root(&self) -> Result<(), RootDischargeFailure> {
+        use RootDischargeFailure::*;
+        let root = &self.root;
+        // (1) the statement.
+        let words =
+            |h: &[u32; 16], j: usize| pack4(h[4 * j..4 * j + 4].try_into().expect("4 words"));
+        for j in 0..4 {
+            if root.lo.public[self.app_base + j] != words(&self.statement.h_start, j)
+                || root.lo.public[self.app_base + 4 + j] != words(&self.statement.h_end, j)
+            {
+                return Err(Statement);
+            }
+        }
+        // (2) the chain lane vs the chain tables (leaf 0's shape).
+        let lane = root.lane_acc.as_ref().expect("the lane rides every level");
+        let blake = chain_blake_r1cs(self.chain.inner.nu);
+        let chain_mats = [(&blake.a_0, &blake.b_0)];
+        let chain_circuit = &self.chain.inner.built.shape.circuit;
+        if !lane.discharge(&chain_mats) {
+            return Err(ChainLaneBoolean);
+        }
+        if !lane.per_element.is_empty() {
+            return Err(ChainLaneElement);
+        }
+        if !lane.discharge_sigma(&[chain_circuit]) {
+            return Err(ChainLaneSigma);
+        }
+        let chain_jp = chain_jagged_params(&self.chain);
+        if !lane.discharge_jagged(&[(chain_circuit.digest(), &chain_jp)]) {
+            return Err(ChainLaneJagged);
+        }
+        // (3) the main fold vs the outer tables.
+        let fl_lo = &self.fl.lo;
+        if !root.acc.discharge(&leaf_boolean_mats(fl_lo)) {
+            return Err(Boolean);
+        }
+        let el_mats: Vec<_> = fl_lo
+            .shape
+            .registry
+            .element_types()
+            .iter()
+            .map(|t| {
+                let e = t.element_type().expect("element table");
+                (e.a_0(), e.b_0())
+            })
+            .collect();
+        if !root.acc.discharge_element(&el_mats) {
+            return Err(Element);
+        }
+        let fl_jp = node_jagged_params(fl_lo);
+        let root_jp = node_jagged_params(&root.lo);
+        let base_jp = self.base.as_ref().map(|b| node_jagged_params(&b.lo));
+        let mut circuits: Vec<&Circuit> = vec![&fl_lo.shape.circuit, &root.lo.shape.circuit];
+        let mut layouts: Vec<([u8; 32], &JaggedParams)> = vec![
+            (fl_lo.shape.circuit.digest(), &fl_jp),
+            (root.lo.shape.circuit.digest(), &root_jp),
+        ];
+        if let (Some(b), Some(jp)) = (&self.base, &base_jp) {
+            circuits.push(&b.lo.shape.circuit);
+            layouts.push((b.lo.shape.circuit.digest(), jp));
+        }
+        if !root.acc.discharge_sigma(&circuits) {
+            return Err(Sigma);
+        }
+        if !root.acc.discharge_jagged(&layouts) {
+            return Err(Jagged);
+        }
+        // (4) the passenger: (sigma-shaped, jagged-shaped), keyed by the
+        // base — the only orphan a spine ever makes.
+        let pass = &root.block.passenger;
+        let live = pass.iter().any(|(_, c)| entry_live(c));
+        if live != self.expect_passenger {
+            return Err(Passenger);
+        }
+        if live {
+            let base = self.base.as_ref().expect("a steady root keeps its base");
+            let base_d = base.lo.shape.circuit.digest();
+            if pass.len() != 2
+                || pass[0].0 != digest_f128(&base_d)
+                || pass[1].0 != digest_f128(&base_d)
+                || !entry_live(&pass[0].1)
+                || !entry_live(&pass[1].1)
+            {
+                return Err(Passenger);
+            }
+            let pacc = Accumulator {
+                registry_digest: root.acc.registry_digest,
+                per_type: Vec::new(),
+                per_element: Vec::new(),
+                sigma: vec![(base_d, pass[0].1.clone())],
+                jagged: vec![(base_d, pass[1].1.clone())],
+            };
+            let jp = base_jp.as_ref().expect("computed with the base");
+            if !pacc.discharge_sigma(&[&base.lo.shape.circuit])
+                || !pacc.discharge_jagged(&[(base_d, jp)])
+            {
+                return Err(Passenger);
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/flock-prover/src/tower/driver.rs
+++ b/crates/flock-prover/src/tower/driver.rs
@@ -19,8 +19,7 @@
 //! the root artifacts whole.
 
 use flock_core::{
-    aggregate::Accumulator, circuit::Circuit, lincheck::LincheckCircuit,
-    pcs::jagged::JaggedParams,
+    aggregate::Accumulator, circuit::Circuit, lincheck::LincheckCircuit, pcs::jagged::JaggedParams,
 };
 
 use crate::tower::{
@@ -208,7 +207,10 @@ impl Tower {
                 }
                 cur = Some(n); // the folded spine node drops here
             }
-            (Some(base), cur.expect("k > 2 built at least one spine node"))
+            (
+                Some(base),
+                cur.expect("k > 2 built at least one spine node"),
+            )
         };
 
         let fl = fls.into_iter().next().expect("FL 0");

--- a/crates/flock-prover/src/tower/driver.rs
+++ b/crates/flock-prover/src/tower/driver.rs
@@ -15,8 +15,8 @@
 //! base's own tables, the statement against the root's publics. It does
 //! NOT verify the root's own proof — that is the consuming verifier's
 //! call (`verify_circuit` over the root outer, the statement-tier helper
-//! the e2e tamper legs assemble); the driver's job ends at handing back
-//! the root artifacts whole.
+//! the e2e tamper legs assemble). The root artifacts stay crate-internal
+//! until the standalone-verifier milestone decides what a consumer sees.
 
 use flock_core::{
     aggregate::Accumulator, circuit::Circuit, lincheck::LincheckCircuit, pcs::jagged::JaggedParams,
@@ -104,9 +104,11 @@ impl Tower {
     /// `n_leaves` must be even and at least 4 (leaves pair into 2-ary FLs
     /// and the tower roots at a node; the k-ary FL door stays open but is
     /// not driven here). Leaves build sequentially — each segment's walk
-    /// IS the chain compute — and each level's inputs drop once folded;
-    /// what stays resident is the FL row (built forward, folded backward
-    /// from the tail) plus the current spine node.
+    /// IS the chain compute — and every input drops once folded: a
+    /// segment pair drops when its FL takes it (leaf 0 stays as the
+    /// lane's material owner), so what stays resident is one leaf pair,
+    /// the FL row (built forward, folded backward from the tail), and the
+    /// current spine node.
     pub fn prove(
         cfg: TowerConfig,
         h_start: [u32; 16],
@@ -118,30 +120,30 @@ impl Tower {
             "the tower pairs leaves into 2-ary FLs and roots at a node: \
              n_leaves must be even and >= 4, got {n_leaves}"
         );
-        // ---- LEAVES, sequential: each segment starts at the last h_end ----
-        let mut cps: Vec<ChainProof> = Vec::with_capacity(n_leaves);
+        // ---- LEAVES + FIRST LEVEL, interleaved: prove a segment pair
+        // (each segment starts at the last h_end), fold it into its FL,
+        // drop the pair ----
+        let mut chain: Option<ChainProof> = None;
+        let mut fls: Vec<FlNode> = Vec::with_capacity(n_leaves / 2);
         let mut h = h_start;
-        for _ in 0..n_leaves {
-            let cp = build_chain_proof(cfg, h, blocks_per_leaf);
-            h = cp.h_end;
-            cps.push(cp);
+        for _ in 0..n_leaves / 2 {
+            let cp0 = build_chain_proof(cfg, h, blocks_per_leaf);
+            let cp1 = build_chain_proof(cfg, cp0.h_end, blocks_per_leaf);
+            h = cp1.h_end;
+            fls.push(build_fl_node(cfg, &cp0, &cp1));
+            // Leaf 0 survives as the lane's chain-side material owner
+            // (one shape for every leaf); every other leaf drops here.
+            chain.get_or_insert(cp0);
         }
         let statement = ChainStatement {
             h_start,
             h_end: h,
             n_blocks: n_leaves * blocks_per_leaf,
         };
-
-        // ---- FIRST LEVEL: adjacent pairs ----
-        let fls: Vec<FlNode> = (0..n_leaves / 2)
-            .map(|i| build_fl_node(cfg, &cps[2 * i], &cps[2 * i + 1]))
-            .collect();
         let app_base = fls[0].stmt_base;
         let claims_base = fls[0].fold_pub_base;
 
-        // Leaf 0 owns the lane's chain-side materials (one shape for
-        // every leaf); the other leaves fold and drop here.
-        let chain = cps.into_iter().next().expect("leaf 0");
+        let chain = chain.expect("leaf 0");
         let registry = &chain.inner.built.shape.registry;
         let blake = chain_blake_r1cs(chain.inner.nu);
         let blake_lc = blake.csc_lincheck_circuit();

--- a/crates/flock-prover/src/tower/e2e_tests.rs
+++ b/crates/flock-prover/src/tower/e2e_tests.rs
@@ -1028,7 +1028,12 @@ pub(super) fn tower_driver_e2e() {
         Err(RootDischargeFailure::ChainLaneBoolean),
         "a doctored lane claim must be refused"
     );
-    tower.root.lane_acc.as_mut().expect("the lane rides").per_type[0]
+    tower
+        .root
+        .lane_acc
+        .as_mut()
+        .expect("the lane rides")
+        .per_type[0]
         .0
         .value = saved;
 

--- a/crates/flock-prover/src/tower/e2e_tests.rs
+++ b/crates/flock-prover/src/tower/e2e_tests.rs
@@ -984,8 +984,9 @@ pub(super) fn tower_online_bench() {
 /// leaves, four FLs, the base plus two spine folds, the lane threaded,
 /// convergence asserted inside the loop — and the root-side residue
 /// discharges. Then the falsifiability legs: a doctored statement word, a
-/// doctored lane claim, and a killed passenger must each turn
-/// [`Tower::discharge_root`] away.
+/// doctored lane claim, a killed passenger, a doctored sigma claim, and a
+/// doctored lane jagged claim must each turn [`Tower::discharge_root`]
+/// away.
 #[test]
 #[ignore] // Heavy — eight chain proofs and seven outers via the driver.
 pub(super) fn tower_driver_e2e() {
@@ -1046,6 +1047,31 @@ pub(super) fn tower_driver_e2e() {
         "a steady root without its orphan must be refused"
     );
     tower.root.block.passenger[0].1.row.low[0] = saved;
+
+    // (d) a doctored main-fold sigma claim.
+    let saved = tower.root.acc.sigma[0].1.value;
+    tower.root.acc.sigma[0].1.value += F128::ONE;
+    assert_eq!(
+        tower.discharge_root(),
+        Err(RootDischargeFailure::Sigma),
+        "a doctored sigma claim must be refused"
+    );
+    tower.root.acc.sigma[0].1.value = saved;
+
+    // (e) a doctored lane JAGGED claim — the discharge leg the
+    // hand-built root sections never ran; prove it can refuse.
+    let lane = tower.root.lane_acc.as_mut().expect("the lane rides");
+    assert!(!lane.jagged.is_empty(), "the lane carries jagged claims");
+    let saved = lane.jagged[0].1.value;
+    lane.jagged[0].1.value += F128::ONE;
+    assert_eq!(
+        tower.discharge_root(),
+        Err(RootDischargeFailure::ChainLaneJagged),
+        "a doctored lane jagged claim must be refused"
+    );
+    tower.root.lane_acc.as_mut().expect("the lane rides").jagged[0]
+        .1
+        .value = saved;
 
     tower
         .discharge_root()

--- a/crates/flock-prover/src/tower/e2e_tests.rs
+++ b/crates/flock-prover/src/tower/e2e_tests.rs
@@ -13,9 +13,10 @@ use flock_core::{
 use crate::{
     r1cs_hashes::blake3::build_block_r1cs,
     tower::{
-        ChainLane, ChainProof, DOMAIN, F128, FlNode, FsChallenger, LeafOuter, Online, SpineIn,
-        UnionInstance, build_chain_proof, build_fl_node, build_node_outer_app, chain_blake_r1cs,
-        chain_jagged_params, env_acc_chain_base, env_acc_main_base, env_app_base, env_pass_base,
+        ChainLane, ChainProof, DOMAIN, F128, FlNode, FsChallenger, LeafOuter, Online,
+        RootDischargeFailure, SpineIn, Tower, UnionInstance, build_chain_proof, build_fl_node,
+        build_node_outer_app, chain_blake_r1cs, chain_jagged_params, env_acc_chain_base,
+        env_acc_main_base, env_app_base, env_pass_base,
         envelope::STEADY_OVERRIDE,
         envelope_shape,
         gates_blake3::Rng,
@@ -976,4 +977,72 @@ pub(super) fn tower_online_bench() {
         per_leaf,
         n_blocks as f64 / per_leaf,
     );
+}
+
+/// **THE DRIVER, END TO END.** [`Tower::prove`] runs the same 8-leaf
+/// steady tower `chain_spine_converges` hand-assembles — sequential
+/// leaves, four FLs, the base plus two spine folds, the lane threaded,
+/// convergence asserted inside the loop — and the root-side residue
+/// discharges. Then the falsifiability legs: a doctored statement word, a
+/// doctored lane claim, and a killed passenger must each turn
+/// [`Tower::discharge_root`] away.
+#[test]
+#[ignore] // Heavy — eight chain proofs and seven outers via the driver.
+pub(super) fn tower_driver_e2e() {
+    let cfg = test_config();
+    let n_blocks = 256usize;
+    let mut rng = Rng(0xD41_4E12);
+    let h0: [u32; 16] = from_fn(|_| rng.next_u32());
+
+    let mut tower = Tower::prove(cfg, h0, n_blocks, 8);
+    assert_eq!(
+        tower.statement().h_start,
+        h0,
+        "the statement starts where the caller did"
+    );
+    assert_eq!(
+        tower.statement().h_end,
+        native_chain(&h0, 8 * n_blocks),
+        "the driver's statement IS the chain"
+    );
+    assert_eq!(tower.statement().n_blocks, 8 * n_blocks);
+    tower.discharge_root().expect("the honest root discharges");
+
+    // (a) a doctored statement word (the root's published h_end).
+    let at = tower.app_base + 4;
+    let saved = tower.root.lo.public[at];
+    tower.root.lo.public[at] += F128::ONE;
+    assert_eq!(
+        tower.discharge_root(),
+        Err(RootDischargeFailure::Statement),
+        "a doctored statement word must be refused"
+    );
+    tower.root.lo.public[at] = saved;
+
+    // (b) a doctored lane claim.
+    let lane = tower.root.lane_acc.as_mut().expect("the lane rides");
+    let saved = lane.per_type[0].0.value;
+    lane.per_type[0].0.value += F128::ONE;
+    assert_eq!(
+        tower.discharge_root(),
+        Err(RootDischargeFailure::ChainLaneBoolean),
+        "a doctored lane claim must be refused"
+    );
+    tower.root.lane_acc.as_mut().expect("the lane rides").per_type[0]
+        .0
+        .value = saved;
+
+    // (c) a killed passenger: a steady root OWES its orphan.
+    let saved = tower.root.block.passenger[0].1.row.low[0];
+    tower.root.block.passenger[0].1.row.low[0] = F128::ZERO;
+    assert_eq!(
+        tower.discharge_root(),
+        Err(RootDischargeFailure::Passenger),
+        "a steady root without its orphan must be refused"
+    );
+    tower.root.block.passenger[0].1.row.low[0] = saved;
+
+    tower
+        .discharge_root()
+        .expect("restored, the root discharges again");
 }

--- a/crates/flock-prover/src/tower/fl_node.rs
+++ b/crates/flock-prover/src/tower/fl_node.rs
@@ -97,7 +97,6 @@ pub struct FlNode {
 /// discharges both groups.
 /// The chain layout's jagged params — the count win's per-digest table
 /// owner for the lane, rebuilt exactly as the opening verifier reads it.
-#[cfg(test)]
 pub(super) fn chain_jagged_params(cp: &ChainProof) -> JaggedParams {
     let u = UnionInstance::new(
         &cp.inner.built.shape.registry,

--- a/crates/flock-prover/src/tower/mod.rs
+++ b/crates/flock-prover/src/tower/mod.rs
@@ -17,6 +17,9 @@
 //!   and the spine inheriting its base's accumulator toward the converged
 //!   fixed point (`chain_spine_converges` gates the ONE-digest property).
 //!
+//! [`Tower::prove`] drives the three end to end — the production caller —
+//! and [`Tower::discharge_root`] settles the root-side residue.
+//!
 //! Bench knobs (`CHAIN_BLOCKS`, `BENCH_RUNS`, `TOWER_STEADY`, and the
 //! test-only `TOWER_CONFIG=chain100`) live in the `#[test]` harness; the
 //! production geometry is typed, never env-var-driven.
@@ -37,6 +40,7 @@ use {
 pub use crate::tower::{
     chain::{ChainProof, build_chain_proof},
     config::TowerConfig,
+    driver::{ChainStatement, RootDischargeFailure, Tower},
     fl_node::{FlNode, build_fl_node, build_fl_node_k},
     node::{ChainLane, MainBlock, NodeOut, SpineIn, build_node_outer_app},
     query::LeafOuter,
@@ -113,6 +117,7 @@ use crate::{
 mod chain;
 mod child_walker;
 mod config;
+mod driver;
 #[cfg(test)]
 mod e2e_tests;
 mod envelope;

--- a/crates/flock-prover/src/tower/node.rs
+++ b/crates/flock-prover/src/tower/node.rs
@@ -3024,7 +3024,6 @@ pub(super) fn internal_node_over_two_fl_nodes() {
 /// One node's own JAGGED LAYOUT — the table its published claims are
 /// about, keyed by its circuit digest. Heights are a shape constant of
 /// that circuit, which is why the key names the table.
-#[cfg(test)]
 pub(super) fn node_jagged_params(lo: &LeafOuter) -> JaggedParams {
     let u = outer_union(&lo.shape.registry, lo.shape.counts.clone());
     JaggedParams::from_heights(

--- a/crates/flock-prover/src/tower/online.rs
+++ b/crates/flock-prover/src/tower/online.rs
@@ -1,11 +1,9 @@
+use {bincode::serialize, serde::Serialize};
+
 #[cfg(test)]
-use {
-    bincode::serialize,
-    flock_core::{
-        pcs::{MergedOpenProof, ligerito::RecursiveProof},
-        proof::R1csProofCircuitMerged,
-    },
-    serde::Serialize,
+use flock_core::{
+    pcs::{MergedOpenProof, ligerito::RecursiveProof},
+    proof::R1csProofCircuitMerged,
 };
 
 #[allow(unused_imports)] // used only under cfg(test)
@@ -92,7 +90,6 @@ pub(super) fn median_total(runs: &[Online]) -> f64 {
 /// parent replays the child's transcript through its b3 slot at one
 /// compression per 64 bytes, so at the measured ~6.1 µs per b3 row a KiB of
 /// child proof is ~0.1 ms of parent per child.
-#[cfg(test)]
 pub(super) fn census_kib<T: Serialize + ?Sized>(v: &T) -> f64 {
     serialize(v).map(|b| b.len()).unwrap_or(0) as f64 / 1024.0
 }

--- a/crates/flock-prover/src/tower/online.rs
+++ b/crates/flock-prover/src/tower/online.rs
@@ -91,7 +91,7 @@ pub(super) fn median_total(runs: &[Online]) -> f64 {
 /// compression per 64 bytes, so at the measured ~6.1 µs per b3 row a KiB of
 /// child proof is ~0.1 ms of parent per child.
 pub(super) fn census_kib<T: Serialize + ?Sized>(v: &T) -> f64 {
-    serialize(v).map(|b| b.len()).unwrap_or(0) as f64 / 1024.0
+    serialize(v).expect("proof component serializes").len() as f64 / 1024.0
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Tower productionization, milestone 1: the tower gets its first non-test caller.

## What this adds

**`Tower::prove(cfg, h_start, blocks_per_leaf, n_leaves)`** (`tower/driver.rs`) — one call from a chain statement to the converged root. It runs the pipeline the e2e tests hand-assemble: sequential leaves, adjacent pairs into FLs, the base over the last two FLs, then the spine prepending earlier FLs level by level, with the chain lane threaded once instead of rebuilt at every call site. The steady-shape convergence (`D(node_i) == D(node_{i-1})` from the second spine fold on) is asserted inside the loop, and each folded input drops when production would drop it.

**`Tower::discharge_root()`** — the root-side residue as one composition: the statement against the root's app publics, the chain lane against the chain tables, the main fold against the outer registry/element/sigma/jagged tables, and the passenger against the base's own tables (owed exactly when the root is steady, refused when missing). This is deliberately **not** proof verification — `verify_circuit` over the root outer stays the consuming verifier's call (milestone 2).

**`examples/tower.rs`** — the non-test caller: `cargo run --release --example tower -- [n_leaves] [blocks_per_leaf] [chain128|chain100]`.

**`tower_driver_e2e`** (ignored suite) — the 8-leaf steady tower via the driver, honest discharge plus five falsifiability legs (doctored statement word, doctored lane claim, killed passenger, doctored sigma claim, doctored lane jagged claim — each refused with the right error).

## Notes for review

- The driver strengthens the root check beyond what the hand-built tests exercised: the lane's **jagged** discharge and the main fold's **jagged** discharge (keyed by FL / steady / base layouts) are now checked; both hold.
- `chain_jagged_params`, `node_jagged_params`, `census_kib` lose their `#[cfg(test)]` gates — the driver is the promotion of exactly that logic into product code. No behavior change; no transcript movement, so no re-pins.
- All three depth classes ran: k=2 (base root, no passenger), k=3 (root's node slot keyed by the base), k=4 (steady root, passenger boarded).

## Validation

- driver e2e green; example runs at 4 and 6 leaves green (root discharge 0.4–0.8s, root proof 254.3 KiB)
- two-axis self-review (standards + spec vs the hand-assembled reference): no blockers; its four non-blocking items applied in the third commit (leaf-pair/FL interleave — peak leaf residency 2, byte-identical statement; census_kib expect; doc accuracy; two extra falsifiability legs)
- full workspace suite, full ignored tower suite (14 tests incl. both tape pins), release clippy native + x86_64 znver4 cross-clippy: all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XU432JiGGjEiAybuTbmST3

