### PR TITLE
tower: the standalone root verifier (productionization M2)

### DIFF
--- a/crates/flock-prover/examples/tower.rs
+++ b/crates/flock-prover/examples/tower.rs
@@ -3,17 +3,21 @@
 //! residue.
 //!
 //! ```sh
-//! cargo run --release --example tower -- [n_leaves] [blocks_per_leaf] [chain128|chain100]
+//! cargo run --release --example tower -- [n_leaves] [blocks_per_leaf] [chain128|chain100] [verify]
 //! ```
 //!
 //! Defaults: 8 leaves x 256 compressions under the 128-bit tower — the
 //! smallest run that reaches the STEADY spine shape (a base plus two
 //! spine folds) and boards the passenger. The production leaf is 2^18
 //! compressions (`blocks_per_leaf = 262144`); expect minutes there.
+//!
+//! With `verify`, the run also generates a verification key (a one-time
+//! six-leaf reference tower) and checks the root STANDALONE through
+//! `verify_root` — the consumer path, nothing prover-side trusted.
 
 use std::{env, time::Instant};
 
-use flock_prover::tower::{Tower, TowerConfig};
+use flock_prover::tower::{Tower, TowerConfig, TowerVk, verify_root};
 
 fn main() {
     let mut args = env::args().skip(1);
@@ -27,6 +31,11 @@ fn main() {
         None | Some("chain128") => TowerConfig::Chain128,
         Some("chain100") => TowerConfig::Chain100,
         Some(other) => panic!("unknown tower config {other:?}: chain128 or chain100"),
+    };
+    let do_verify = match args.next().as_deref() {
+        None => false,
+        Some("verify") => true,
+        Some(other) => panic!("unknown flag {other:?}: only `verify`"),
     };
 
     // The demo chain starts at the zero state; a deployment starts at its
@@ -55,4 +64,17 @@ fn main() {
         s.n_blocks,
         tower.root_proof_kib(),
     );
+
+    if do_verify {
+        let t2 = Instant::now();
+        let vk = TowerVk::generate(cfg, blocks_per_leaf);
+        let gen_s = t2.elapsed().as_secs_f64();
+        let t3 = Instant::now();
+        verify_root(&vk, s, &tower.root_bundle()).expect("the root verifies standalone");
+        let verify_s = t3.elapsed().as_secs_f64();
+        println!(
+            "  VERIFIED STANDALONE (consumer path): vk generate {gen_s:.1}s (one-time) \
+             | verify_root {verify_s:.3}s"
+        );
+    }
 }

--- a/crates/flock-prover/examples/tower.rs
+++ b/crates/flock-prover/examples/tower.rs
@@ -70,11 +70,12 @@ fn main() {
         let vk = TowerVk::generate(cfg, blocks_per_leaf);
         let gen_s = t2.elapsed().as_secs_f64();
         let t3 = Instant::now();
-        verify_root(&vk, s, &tower.root_bundle()).expect("the root verifies standalone");
+        let bound =
+            verify_root(&vk, s, &tower.root_bundle()).expect("the root verifies standalone");
         let verify_s = t3.elapsed().as_secs_f64();
         println!(
             "  VERIFIED STANDALONE (consumer path): vk generate {gen_s:.1}s (one-time) \
-             | verify_root {verify_s:.3}s"
+             | verify_root {verify_s:.3}s | span bound: {bound:?}"
         );
     }
 }

--- a/crates/flock-prover/src/tower/driver.rs
+++ b/crates/flock-prover/src/tower/driver.rs
@@ -12,11 +12,12 @@
 //!
 //! [`Tower::discharge_root`] settles the ROOT-SIDE RESIDUE: the carried
 //! accumulators against the native tables, the passenger against the
-//! base's own tables, the statement against the root's publics. It does
-//! NOT verify the root's own proof — that is the consuming verifier's
-//! call (`verify_circuit` over the root outer, the statement-tier helper
-//! the e2e tamper legs assemble). The root artifacts stay crate-internal
-//! until the standalone-verifier milestone decides what a consumer sees.
+//! base's own tables, the statement against the root's publics. It is
+//! the PROVER'S SELF-CHECK over its own in-memory objects — the
+//! consumer's check is `verify_root` over [`Tower::root_bundle`]'s
+//! artifacts, which re-runs these same legs over accumulators
+//! REASSEMBLED from the bundle's publics, after the native circuit
+//! verify.
 
 use flock_core::{
     aggregate::Accumulator, circuit::Circuit, lincheck::LincheckCircuit, matrix_fold::MatrixClaim,
@@ -40,6 +41,12 @@ use crate::tower::{
 
 /// What a tower run attests: `h_end == H^{n_blocks}(h_start)` over the
 /// BLAKE3 compression chain.
+///
+/// A standalone verifier pins the ENDPOINTS unconditionally but the
+/// COUNT only up to the root's depth class — the steady shape is
+/// depth-independent by design and the app block carries no count word.
+/// See `SpanBound` in the verify module before treating a verified
+/// `n_blocks` as exact.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct ChainStatement {
     pub h_start: [u32; 16],

--- a/crates/flock-prover/src/tower/driver.rs
+++ b/crates/flock-prover/src/tower/driver.rs
@@ -19,10 +19,12 @@
 //! until the standalone-verifier milestone decides what a consumer sees.
 
 use flock_core::{
-    aggregate::Accumulator, circuit::Circuit, lincheck::LincheckCircuit, pcs::jagged::JaggedParams,
+    aggregate::Accumulator, circuit::Circuit, lincheck::LincheckCircuit, matrix_fold::MatrixClaim,
+    pcs::jagged::JaggedParams,
 };
 
 use crate::tower::{
+    F128,
     chain::{ChainProof, build_chain_proof},
     config::TowerConfig,
     fl_node::{FlNode, build_fl_node, chain_blake_r1cs, chain_jagged_params},
@@ -33,6 +35,7 @@ use crate::tower::{
     },
     online::census_kib,
     query::leaf_boolean_mats,
+    verify::RootBundle,
 };
 
 /// What a tower run attests: `h_end == H^{n_blocks}(h_start)` over the
@@ -254,20 +257,60 @@ impl Tower {
     /// 4. the PASSENGER — the spine's single orphan — against the base's
     ///    own tables, owed exactly when the root is steady.
     pub fn discharge_root(&self) -> Result<(), RootDischargeFailure> {
+        self.discharge_with(
+            &self.root.lo.public,
+            self.root
+                .lane_acc
+                .as_ref()
+                .expect("the lane rides every level"),
+            &self.root.acc,
+            &self.root.block.passenger,
+            &self.statement,
+            self.expect_passenger,
+        )
+    }
+
+    /// The ROOT'S TRANSPORTABLE PART: what a consumer holds beside the
+    /// statement — publics, proof, commitment. Everything else the
+    /// standalone verifier derives from config via [`TowerVk`]; the
+    /// wire-format milestone gives this a byte form.
+    ///
+    /// [`TowerVk`]: crate::tower::TowerVk
+    pub fn root_bundle(&self) -> RootBundle<'_> {
+        RootBundle {
+            public: &self.root.lo.public,
+            proof: &self.root.lo.proof,
+            commitment: &self.root.lo.commitment,
+        }
+    }
+
+    /// The discharge legs over CALLER-SUPPLIED artifacts: the prover's
+    /// self-check hands in its own objects; the standalone verifier hands
+    /// in what it REASSEMBLED from a bundle's public segment. `self`
+    /// supplies only the native tables (leaf 0, FL 0, base, root) — one
+    /// superset covers every depth, since discharge looks tables up per
+    /// digest and unused entries are inert.
+    pub(super) fn discharge_with(
+        &self,
+        public: &[F128],
+        lane: &Accumulator,
+        main: &Accumulator,
+        passenger: &[([F128; 2], MatrixClaim)],
+        statement: &ChainStatement,
+        expect_passenger: bool,
+    ) -> Result<(), RootDischargeFailure> {
         use RootDischargeFailure::*;
-        let root = &self.root;
         // (1) the statement.
         let words =
             |h: &[u32; 16], j: usize| pack4(h[4 * j..4 * j + 4].try_into().expect("4 words"));
         for j in 0..4 {
-            if root.lo.public[self.app_base + j] != words(&self.statement.h_start, j)
-                || root.lo.public[self.app_base + 4 + j] != words(&self.statement.h_end, j)
+            if public[self.app_base + j] != words(&statement.h_start, j)
+                || public[self.app_base + 4 + j] != words(&statement.h_end, j)
             {
                 return Err(Statement);
             }
         }
         // (2) the chain lane vs the chain tables (leaf 0's shape).
-        let lane = root.lane_acc.as_ref().expect("the lane rides every level");
         let blake = chain_blake_r1cs(self.chain.inner.nu);
         let chain_mats = [(&blake.a_0, &blake.b_0)];
         let chain_circuit = &self.chain.inner.built.shape.circuit;
@@ -286,7 +329,7 @@ impl Tower {
         }
         // (3) the main fold vs the outer tables.
         let fl_lo = &self.fl.lo;
-        if !root.acc.discharge(&leaf_boolean_mats(fl_lo)) {
+        if !main.discharge(&leaf_boolean_mats(fl_lo)) {
             return Err(Boolean);
         }
         let el_mats: Vec<_> = fl_lo
@@ -299,51 +342,50 @@ impl Tower {
                 (e.a_0(), e.b_0())
             })
             .collect();
-        if !root.acc.discharge_element(&el_mats) {
+        if !main.discharge_element(&el_mats) {
             return Err(Element);
         }
         let fl_jp = node_jagged_params(fl_lo);
-        let root_jp = node_jagged_params(&root.lo);
+        let root_jp = node_jagged_params(&self.root.lo);
         let base_jp = self.base.as_ref().map(|b| node_jagged_params(&b.lo));
-        let mut circuits: Vec<&Circuit> = vec![&fl_lo.shape.circuit, &root.lo.shape.circuit];
+        let mut circuits: Vec<&Circuit> = vec![&fl_lo.shape.circuit, &self.root.lo.shape.circuit];
         let mut layouts: Vec<([u8; 32], &JaggedParams)> = vec![
             (fl_lo.shape.circuit.digest(), &fl_jp),
-            (root.lo.shape.circuit.digest(), &root_jp),
+            (self.root.lo.shape.circuit.digest(), &root_jp),
         ];
         if let (Some(b), Some(jp)) = (&self.base, &base_jp) {
             circuits.push(&b.lo.shape.circuit);
             layouts.push((b.lo.shape.circuit.digest(), jp));
         }
-        if !root.acc.discharge_sigma(&circuits) {
+        if !main.discharge_sigma(&circuits) {
             return Err(Sigma);
         }
-        if !root.acc.discharge_jagged(&layouts) {
+        if !main.discharge_jagged(&layouts) {
             return Err(Jagged);
         }
         // (4) the passenger: (sigma-shaped, jagged-shaped), keyed by the
         // base — the only orphan a spine ever makes.
-        let pass = &root.block.passenger;
-        let live = pass.iter().any(|(_, c)| entry_live(c));
-        if live != self.expect_passenger {
+        let live = passenger.iter().any(|(_, c)| entry_live(c));
+        if live != expect_passenger {
             return Err(Passenger);
         }
         if live {
             let base = self.base.as_ref().expect("a steady root keeps its base");
             let base_d = base.lo.shape.circuit.digest();
-            if pass.len() != 2
-                || pass[0].0 != digest_f128(&base_d)
-                || pass[1].0 != digest_f128(&base_d)
-                || !entry_live(&pass[0].1)
-                || !entry_live(&pass[1].1)
+            if passenger.len() != 2
+                || passenger[0].0 != digest_f128(&base_d)
+                || passenger[1].0 != digest_f128(&base_d)
+                || !entry_live(&passenger[0].1)
+                || !entry_live(&passenger[1].1)
             {
                 return Err(Passenger);
             }
             let pacc = Accumulator {
-                registry_digest: root.acc.registry_digest,
+                registry_digest: main.registry_digest,
                 per_type: Vec::new(),
                 per_element: Vec::new(),
-                sigma: vec![(base_d, pass[0].1.clone())],
-                jagged: vec![(base_d, pass[1].1.clone())],
+                sigma: vec![(base_d, passenger[0].1.clone())],
+                jagged: vec![(base_d, passenger[1].1.clone())],
             };
             let jp = base_jp.as_ref().expect("computed with the base");
             if !pacc.discharge_sigma(&[&base.lo.shape.circuit])

--- a/crates/flock-prover/src/tower/e2e_tests.rs
+++ b/crates/flock-prover/src/tower/e2e_tests.rs
@@ -14,7 +14,7 @@ use crate::{
     r1cs_hashes::blake3::build_block_r1cs,
     tower::{
         ChainLane, ChainProof, DOMAIN, F128, FlNode, FsChallenger, LeafOuter, Online, RootBundle,
-        RootDischargeFailure, SpineIn, Tower, TowerVerifyError, TowerVk, UnionInstance,
+        RootDischargeFailure, SpanBound, SpineIn, Tower, TowerVerifyError, TowerVk, UnionInstance,
         build_chain_proof, build_fl_node, build_node_outer_app, chain_blake_r1cs,
         chain_jagged_params, env_acc_chain_base, env_acc_main_base, env_app_base, env_pass_base,
         envelope::STEADY_OVERRIDE,
@@ -1080,32 +1080,45 @@ pub(super) fn tower_driver_e2e() {
 }
 
 /// **THE STANDALONE VERIFIER, END TO END.** [`TowerVk::generate`] proves
-/// the six-leaf reference tower once, then [`verify_root`] checks roots
-/// it never built: the VK's own k = 3 root, a fresh k = 4 steady tower,
-/// and a fresh k = 2 base-rooted tower — every table from the VK, every
-/// accumulator REASSEMBLED from the bundle's publics and cross-checked
-/// against the prover's own objects. Then the consumer-side refusals: a
-/// doctored public word dies in the proof verify, a wrong statement dies
-/// on the binding, a truncated bundle and a misfit span die on the
-/// guards.
+/// the six-leaf reference tower once, then [`verify_root`] checks FRESH
+/// towers it never built at every depth class — k = 4 (steady, live
+/// passenger, span [`SpanBound::EndpointsOnly`]), k = 3 (steady,
+/// passenger-less, exact) and k = 2 (base-rooted, exact) — plus the VK's
+/// own reference root; every table from the VK, every accumulator
+/// REASSEMBLED from the bundle's publics and cross-checked against the
+/// prover's own objects. Then the consumer-side refusals: a doctored
+/// public word dies in the proof verify, a wrong statement on the
+/// binding, a truncated bundle and a misfit span on the guards, an
+/// unknown slot key in the decode, and a CROSS-CLASS span lie on the
+/// passenger rule — while the k >= 4 in-class span degeneracy is pinned
+/// as exactly what [`SpanBound::EndpointsOnly`] declares.
 #[test]
-#[ignore] // Heavy — three towers (6+8+4 leaves) end to end.
+#[ignore] // Heavy — four towers (6+8+6+4 leaves) end to end.
 pub(super) fn tower_verify_root_e2e() {
     let cfg = test_config();
     let n_blocks = 256usize;
+    let env = envelope_shape();
     let vk = TowerVk::generate(cfg, n_blocks);
 
     // (0) the VK's own reference root (k = 3, steady shape) verifies
     // through the consumer path.
     let own = *vk.tower.statement();
-    verify_root(&vk, &own, &vk.tower.root_bundle()).expect("the reference root verifies");
+    assert_eq!(
+        verify_root(&vk, &own, &vk.tower.root_bundle()).expect("the reference root verifies"),
+        SpanBound::Exact,
+        "a passenger-less steady root pins its span"
+    );
 
     // (1) a fresh k = 4 steady tower the VK never saw.
     let mut rng = Rng(0xD41_4E13);
     let h0: [u32; 16] = from_fn(|_| rng.next_u32());
     let tower = Tower::prove(cfg, h0, n_blocks, 8);
     let stmt = *tower.statement();
-    verify_root(&vk, &stmt, &tower.root_bundle()).expect("the k = 4 root verifies");
+    assert_eq!(
+        verify_root(&vk, &stmt, &tower.root_bundle()).expect("the k = 4 root verifies"),
+        SpanBound::EndpointsOnly,
+        "a steady root with a live passenger certifies endpoints + class"
+    );
 
     // The reassembly cross-check: publics-decoded == the prover's own
     // objects, all three blocks.
@@ -1174,8 +1187,62 @@ pub(super) fn tower_verify_root_e2e() {
         ),
         "a misfit span must die on geometry"
     );
+    // A doctored slot KEY word dies in the decode: reassembly refuses a
+    // live keyed entry naming a circuit the VK does not know.
+    {
+        let uni_w = |c: &MatrixClaim| 2 + c.col.point.len() + c.row.point.len();
+        let mut key_at = env_acc_main_base(&env);
+        for (a, b) in tower
+            .root
+            .acc
+            .per_type
+            .iter()
+            .chain(tower.root.acc.per_element.iter())
+        {
+            key_at += uni_w(a) + uni_w(b);
+        }
+        let mut bad = tower.root.lo.public.clone();
+        bad[key_at] += F128::ONE;
+        assert!(
+            matches!(reassemble(&bad, &vk), Err(TowerVerifyError::UnknownKey)),
+            "an unknown slot key must be refused, not skipped"
+        );
+    }
+    // THE IN-CLASS SPAN DEGENERACY, pinned: an inflated k >= 4 claim over
+    // an honest k = 4 bundle still verifies — which is exactly why a
+    // green k >= 4 result says EndpointsOnly, never Exact. The count word
+    // in the app block is the recorded protocol follow-up.
+    let mut inflated = stmt;
+    inflated.n_blocks += 2 * 2 * n_blocks;
+    assert_eq!(
+        verify_root(&vk, &inflated, &tower.root_bundle())
+            .expect("the in-class span lie is not detectable today"),
+        SpanBound::EndpointsOnly,
+        "and the result says so"
+    );
 
-    // (3) a fresh k = 2 base-rooted tower — the other root shape.
+    // (3) a fresh k = 3 tower — steady shape, passenger-less, exact span.
+    let t3 = Tower::prove(cfg, native_chain(&h0, 128), n_blocks, 6);
+    assert_eq!(
+        verify_root(&vk, t3.statement(), &t3.root_bundle()).expect("the k = 3 root verifies"),
+        SpanBound::Exact,
+    );
+    // A CROSS-CLASS span lie dies on the passenger rule: the k = 3
+    // bundle claimed as k = 4 owes an orphan it does not carry.
+    let mut lied = *t3.statement();
+    lied.n_blocks += 2 * n_blocks;
+    assert!(
+        matches!(
+            verify_root(&vk, &lied, &t3.root_bundle()),
+            Err(TowerVerifyError::Discharge(RootDischargeFailure::Passenger))
+        ),
+        "a k = 3 bundle claimed steady-deep must die on the passenger"
+    );
+
+    // (4) a fresh k = 2 base-rooted tower — the other root shape.
     let t2 = Tower::prove(cfg, native_chain(&h0, 64), n_blocks, 4);
-    verify_root(&vk, t2.statement(), &t2.root_bundle()).expect("the k = 2 root verifies");
+    assert_eq!(
+        verify_root(&vk, t2.statement(), &t2.root_bundle()).expect("the k = 2 root verifies"),
+        SpanBound::Exact,
+    );
 }

--- a/crates/flock-prover/src/tower/e2e_tests.rs
+++ b/crates/flock-prover/src/tower/e2e_tests.rs
@@ -13,10 +13,10 @@ use flock_core::{
 use crate::{
     r1cs_hashes::blake3::build_block_r1cs,
     tower::{
-        ChainLane, ChainProof, DOMAIN, F128, FlNode, FsChallenger, LeafOuter, Online,
-        RootDischargeFailure, SpineIn, Tower, UnionInstance, build_chain_proof, build_fl_node,
-        build_node_outer_app, chain_blake_r1cs, chain_jagged_params, env_acc_chain_base,
-        env_acc_main_base, env_app_base, env_pass_base,
+        ChainLane, ChainProof, DOMAIN, F128, FlNode, FsChallenger, LeafOuter, Online, RootBundle,
+        RootDischargeFailure, SpineIn, Tower, TowerVerifyError, TowerVk, UnionInstance,
+        build_chain_proof, build_fl_node, build_node_outer_app, chain_blake_r1cs,
+        chain_jagged_params, env_acc_chain_base, env_acc_main_base, env_app_base, env_pass_base,
         envelope::STEADY_OVERRIDE,
         envelope_shape,
         gates_blake3::Rng,
@@ -25,6 +25,7 @@ use crate::{
         node_jagged_params,
         online::{median_total, proof_census_mixed, report_stage},
         outer_union, pack4, test_config, tower_fold_grinding,
+        verify::{reassemble, verify_root},
     },
 };
 
@@ -1076,4 +1077,105 @@ pub(super) fn tower_driver_e2e() {
     tower
         .discharge_root()
         .expect("restored, the root discharges again");
+}
+
+/// **THE STANDALONE VERIFIER, END TO END.** [`TowerVk::generate`] proves
+/// the six-leaf reference tower once, then [`verify_root`] checks roots
+/// it never built: the VK's own k = 3 root, a fresh k = 4 steady tower,
+/// and a fresh k = 2 base-rooted tower — every table from the VK, every
+/// accumulator REASSEMBLED from the bundle's publics and cross-checked
+/// against the prover's own objects. Then the consumer-side refusals: a
+/// doctored public word dies in the proof verify, a wrong statement dies
+/// on the binding, a truncated bundle and a misfit span die on the
+/// guards.
+#[test]
+#[ignore] // Heavy — three towers (6+8+4 leaves) end to end.
+pub(super) fn tower_verify_root_e2e() {
+    let cfg = test_config();
+    let n_blocks = 256usize;
+    let vk = TowerVk::generate(cfg, n_blocks);
+
+    // (0) the VK's own reference root (k = 3, steady shape) verifies
+    // through the consumer path.
+    let own = *vk.tower.statement();
+    verify_root(&vk, &own, &vk.tower.root_bundle()).expect("the reference root verifies");
+
+    // (1) a fresh k = 4 steady tower the VK never saw.
+    let mut rng = Rng(0xD41_4E13);
+    let h0: [u32; 16] = from_fn(|_| rng.next_u32());
+    let tower = Tower::prove(cfg, h0, n_blocks, 8);
+    let stmt = *tower.statement();
+    verify_root(&vk, &stmt, &tower.root_bundle()).expect("the k = 4 root verifies");
+
+    // The reassembly cross-check: publics-decoded == the prover's own
+    // objects, all three blocks.
+    let (main, passenger, lane) =
+        reassemble(&tower.root.lo.public, &vk).expect("the root's blocks decode");
+    assert_eq!(main, tower.root.acc, "main acc, from publics alone");
+    assert_eq!(
+        &lane,
+        tower.root.lane_acc.as_ref().expect("lane"),
+        "chain lane, from publics alone"
+    );
+    assert_eq!(
+        passenger, tower.root.block.passenger,
+        "the passenger, from publics alone"
+    );
+
+    // (2) consumer-side refusals.
+    // A doctored public word dies in the PROOF verify, before any
+    // discharge sees it.
+    let mut bad = tower.root.lo.public.clone();
+    bad[tower.app_base + 4] += F128::ONE;
+    let bundle = RootBundle {
+        public: &bad,
+        proof: &tower.root.lo.proof,
+        commitment: &tower.root.lo.commitment,
+    };
+    assert!(
+        matches!(
+            verify_root(&vk, &stmt, &bundle),
+            Err(TowerVerifyError::Proof(_))
+        ),
+        "a doctored public word must die in the proof verify"
+    );
+    // A wrong statement (honest proof, different claim) dies on the
+    // statement binding.
+    let mut wrong = stmt;
+    wrong.h_end[0] ^= 1;
+    assert!(
+        matches!(
+            verify_root(&vk, &wrong, &tower.root_bundle()),
+            Err(TowerVerifyError::Discharge(RootDischargeFailure::Statement))
+        ),
+        "a wrong statement must die on the binding"
+    );
+    // A truncated public segment dies on the length guard.
+    let short = &tower.root.lo.public[..tower.root.lo.public.len() - 1];
+    let bundle = RootBundle {
+        public: short,
+        proof: &tower.root.lo.proof,
+        commitment: &tower.root.lo.commitment,
+    };
+    assert!(
+        matches!(
+            verify_root(&vk, &stmt, &bundle),
+            Err(TowerVerifyError::PublicsLength)
+        ),
+        "a truncated bundle must die on the length guard"
+    );
+    // A span that is not a whole number of leaf pairs dies on geometry.
+    let mut misfit = stmt;
+    misfit.n_blocks += 1;
+    assert!(
+        matches!(
+            verify_root(&vk, &misfit, &tower.root_bundle()),
+            Err(TowerVerifyError::Geometry)
+        ),
+        "a misfit span must die on geometry"
+    );
+
+    // (3) a fresh k = 2 base-rooted tower — the other root shape.
+    let t2 = Tower::prove(cfg, native_chain(&h0, 64), n_blocks, 4);
+    verify_root(&vk, t2.statement(), &t2.root_bundle()).expect("the k = 2 root verifies");
 }

--- a/crates/flock-prover/src/tower/mod.rs
+++ b/crates/flock-prover/src/tower/mod.rs
@@ -19,6 +19,9 @@
 //!
 //! [`Tower::prove`] drives the three end to end — the production caller —
 //! and [`Tower::discharge_root`] settles the root-side residue.
+//! [`verify_root`] checks a root STANDALONE: a consumer holds only the
+//! statement and [`Tower::root_bundle`]'s artifacts, and every table
+//! comes from a [`TowerVk`] derived from config.
 //!
 //! Bench knobs (`CHAIN_BLOCKS`, `BENCH_RUNS`, `TOWER_STEADY`, and the
 //! test-only `TOWER_CONFIG=chain100`) live in the `#[test]` harness; the
@@ -44,6 +47,7 @@ pub use crate::tower::{
     fl_node::{FlNode, build_fl_node, build_fl_node_k},
     node::{ChainLane, MainBlock, NodeOut, SpineIn, build_node_outer_app},
     query::LeafOuter,
+    verify::{RootBundle, TowerVerifyError, TowerVk, verify_root},
 };
 use crate::{
     challenger::FsChallenger,
@@ -135,4 +139,5 @@ mod online;
 mod query;
 mod real_walker;
 mod tape;
+mod verify;
 mod walker_common;

--- a/crates/flock-prover/src/tower/mod.rs
+++ b/crates/flock-prover/src/tower/mod.rs
@@ -47,7 +47,7 @@ pub use crate::tower::{
     fl_node::{FlNode, build_fl_node, build_fl_node_k},
     node::{ChainLane, MainBlock, NodeOut, SpineIn, build_node_outer_app},
     query::LeafOuter,
-    verify::{RootBundle, TowerVerifyError, TowerVk, verify_root},
+    verify::{RootBundle, SpanBound, TowerVerifyError, TowerVk, verify_root},
 };
 use crate::{
     challenger::FsChallenger,

--- a/crates/flock-prover/src/tower/verify.rs
+++ b/crates/flock-prover/src/tower/verify.rs
@@ -1,0 +1,308 @@
+//! **THE STANDALONE ROOT VERIFIER** (productionization M2): a consumer
+//! checks a tower root with a verification key derived from config alone —
+//! nothing prover-supplied is trusted but the bundle's proof, publics and
+//! commitment.
+//!
+//! [`TowerVk::generate`] is OPTION-A generation: run the builders over a
+//! minimal self-generated tower (six leaves reach all four shapes — chain,
+//! FL, base, steady) and keep it as the verifier's material set. Shapes
+//! are statement-independent, so the dummy tower's circuits, tables and
+//! layouts are byte-identical to any production tower at the same
+//! `(cfg, blocks_per_leaf)`. One-time; cache per config. A serialized,
+//! digest-pinned VK artifact is the wire-format milestone's job.
+//!
+//! [`verify_root`] then: (1) checks the bundle's geometry and public
+//! length, (2) runs the native circuit verify over the root proof with VK
+//! materials — the pcs params come from the VK, never the bundle — (3)
+//! REASSEMBLES the published accumulators (main, chain lane, passenger)
+//! from the bundle's public segment alone via [`read_acc_entry`], the
+//! same decode the builders pin (`check_fold_publics`), and (4) hands
+//! them to the shared discharge legs against the VK's native tables plus
+//! the statement binding. Reassembly-from-publics is the soundness point:
+//! the prover's in-memory accumulators are its own self-check
+//! ([`Tower::discharge_root`]), not a consumer's input.
+
+use flock_core::{
+    aggregate::Accumulator, matrix_fold::MatrixClaim, pcs::Commitment, verifier::FlockVerifyError,
+};
+
+use crate::tower::{
+    DOMAIN, F128, FsChallenger, TowerConfig,
+    chain::MixedProof,
+    driver::{ChainStatement, RootDischargeFailure, Tower},
+    env_acc_main_base, env_pass_base, envelope_shape,
+    fold_region::read_acc_entry,
+    node::{N_KEY_SLOTS, digest_f128, entry_live},
+    outer_union,
+    query::{LeafOuter, leaf_boolean_lcs},
+};
+
+/// The ROOT'S TRANSPORTABLE PART: what a consumer holds beside the
+/// statement. Obtained from [`Tower::root_bundle`]; the wire-format
+/// milestone gives it a byte form.
+pub struct RootBundle<'a> {
+    pub(super) public: &'a [F128],
+    pub(super) proof: &'a MixedProof,
+    pub(super) commitment: &'a Commitment,
+}
+
+/// Why [`verify_root`] refused.
+#[derive(Debug)]
+pub enum TowerVerifyError {
+    /// The statement's span is not a whole number of leaf pairs at this
+    /// VK's leaf size, or too shallow for a rooted tower.
+    Geometry,
+    /// The bundle's public segment is not the envelope length.
+    PublicsLength,
+    /// The root proof itself refused the native circuit verify.
+    Proof(FlockVerifyError),
+    /// A live keyed slot names a circuit this VK does not know.
+    UnknownKey,
+    /// A reassembled accumulator refused the native tables, or the
+    /// statement binding failed.
+    Discharge(RootDischargeFailure),
+}
+
+/// The published accumulator blocks' DECODE PLAN: base offsets and
+/// per-entry `(k_col, k_row)` widths, all shape constants captured from
+/// the VK's reference tower. `read_acc_entry` replays exactly the wire
+/// format the builders pin (`check_fold_publics`), so this is the whole
+/// layout a consumer needs.
+pub(super) struct AccLayout {
+    main_base: usize,
+    lane_base: usize,
+    pass_base: usize,
+    /// Widths per UNKEYED main entry, flat: the per-type pairs then the
+    /// per-element pairs, one entry per claim.
+    main_unkeyed: Vec<(usize, usize)>,
+    n_per_type: usize,
+    sigma_w: (usize, usize),
+    jagged_w: (usize, usize),
+    pass_w: [(usize, usize); 2],
+    /// The lane block keeps the UN-KEYED entry layout (one registry role,
+    /// one implied key — the chain circuit): per-type flat, then sigma,
+    /// then jagged.
+    lane_unkeyed: Vec<(usize, usize)>,
+    lane_sigma_w: (usize, usize),
+    lane_jagged_w: (usize, usize),
+}
+
+impl AccLayout {
+    fn from_tower(t: &Tower) -> AccLayout {
+        let env = envelope_shape();
+        let w = |c: &MatrixClaim| (c.col.point.len(), c.row.point.len());
+        let root = &t.root;
+        let mut main_unkeyed = Vec::new();
+        for (a, b) in root.acc.per_type.iter().chain(root.acc.per_element.iter()) {
+            main_unkeyed.push(w(a));
+            main_unkeyed.push(w(b));
+        }
+        let lane = root.lane_acc.as_ref().expect("the lane rides every level");
+        let mut lane_unkeyed = Vec::new();
+        for (a, b) in &lane.per_type {
+            lane_unkeyed.push(w(a));
+            lane_unkeyed.push(w(b));
+        }
+        AccLayout {
+            main_base: env_acc_main_base(&env),
+            lane_base: t.fl.fold_pub_base,
+            pass_base: env_pass_base(&env),
+            main_unkeyed,
+            n_per_type: root.acc.per_type.len(),
+            sigma_w: w(&root.block.sigma[0].1),
+            jagged_w: w(&root.block.jagged[0].1),
+            pass_w: [w(&root.block.passenger[0].1), w(&root.block.passenger[1].1)],
+            lane_unkeyed,
+            lane_sigma_w: w(&lane.sigma[0].1),
+            lane_jagged_w: w(&lane.jagged[0].1),
+        }
+    }
+}
+
+/// The tower's VERIFICATION KEY for one `(cfg, blocks_per_leaf)`: a
+/// reference tower (the material owners — leaf 0, FL 0, base, steady
+/// root) plus the accumulator blocks' decode plan.
+pub struct TowerVk {
+    pub(super) tower: Tower,
+    pub(super) layout: AccLayout,
+    pub(super) blocks_per_leaf: usize,
+}
+
+impl TowerVk {
+    /// OPTION-A GENERATION: prove a minimal six-leaf tower and keep it.
+    /// Six leaves is the smallest run that materializes all four shapes
+    /// (chain, FL, base, steady = the k = 3 root).
+    pub fn generate(cfg: TowerConfig, blocks_per_leaf: usize) -> TowerVk {
+        let tower = Tower::prove(cfg, [0u32; 16], blocks_per_leaf, 6);
+        let layout = AccLayout::from_tower(&tower);
+        TowerVk {
+            tower,
+            layout,
+            blocks_per_leaf,
+        }
+    }
+}
+
+/// Reassemble the published accumulators — main, passenger, chain lane —
+/// from a root's PUBLIC SEGMENT alone, per the VK's decode plan. Live
+/// keyed slots must name a circuit the VK knows (FL / steady / base);
+/// dead slots decode as the zero claim and are dropped, matching the
+/// prover-side accumulator's live-entries-only contract.
+#[allow(clippy::type_complexity)]
+pub(super) fn reassemble(
+    public: &[F128],
+    vk: &TowerVk,
+) -> Result<(Accumulator, Vec<([F128; 2], MatrixClaim)>, Accumulator), TowerVerifyError> {
+    let l = &vk.layout;
+    let fl_lo = &vk.tower.fl.lo;
+    let steady_lo = &vk.tower.root.lo;
+    let base_lo = &vk
+        .tower
+        .base
+        .as_ref()
+        .expect("the VK tower keeps its base")
+        .lo;
+    let known: [[u8; 32]; 3] = [
+        fl_lo.shape.circuit.digest(),
+        steady_lo.shape.circuit.digest(),
+        base_lo.shape.circuit.digest(),
+    ];
+    let name = |key: [F128; 2]| -> Result<[u8; 32], TowerVerifyError> {
+        known
+            .iter()
+            .find(|d| digest_f128(d) == key)
+            .copied()
+            .ok_or(TowerVerifyError::UnknownKey)
+    };
+
+    // ---- ACC_MAIN: unkeyed pairs, then the keyed sigma + jagged slots ----
+    let mut p = l.main_base;
+    let mut flat: Vec<MatrixClaim> = Vec::with_capacity(l.main_unkeyed.len());
+    for &(kc, kr) in &l.main_unkeyed {
+        let (_, c) = read_acc_entry(public, &mut p, false, kc, kr);
+        flat.push(c);
+    }
+    let mut pairs = flat
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|[a, b]| (a.clone(), b.clone()));
+    let per_type: Vec<_> = pairs.by_ref().take(l.n_per_type).collect();
+    let per_element: Vec<_> = pairs.collect();
+    let mut sigma: Vec<([u8; 32], MatrixClaim)> = Vec::new();
+    for _ in 0..N_KEY_SLOTS {
+        let (k, c) = read_acc_entry(public, &mut p, true, l.sigma_w.0, l.sigma_w.1);
+        if entry_live(&c) {
+            sigma.push((name(k)?, c));
+        }
+    }
+    let mut jagged: Vec<([u8; 32], MatrixClaim)> = Vec::new();
+    for _ in 0..N_KEY_SLOTS {
+        let (k, c) = read_acc_entry(public, &mut p, true, l.jagged_w.0, l.jagged_w.1);
+        if entry_live(&c) {
+            jagged.push((name(k)?, c));
+        }
+    }
+    let main = Accumulator {
+        registry_digest: steady_lo.shape.registry.digest(),
+        per_type,
+        per_element,
+        sigma,
+        jagged,
+    };
+
+    // ---- THE PASSENGER: two keyed entries (sigma-shaped, jagged-shaped),
+    // kept in block form — dead entries ride as decoded ----
+    let mut p = l.pass_base;
+    let passenger: Vec<([F128; 2], MatrixClaim)> = l
+        .pass_w
+        .iter()
+        .map(|&(kc, kr)| read_acc_entry(public, &mut p, true, kc, kr))
+        .collect();
+
+    // ---- ACC_CHAIN: the lane's un-keyed layout, key implied ----
+    let chain_d = vk.tower.chain.inner.built.shape.circuit.digest();
+    let mut p = l.lane_base;
+    let mut lflat: Vec<MatrixClaim> = Vec::with_capacity(l.lane_unkeyed.len());
+    for &(kc, kr) in &l.lane_unkeyed {
+        let (_, c) = read_acc_entry(public, &mut p, false, kc, kr);
+        lflat.push(c);
+    }
+    let lane_per_type: Vec<_> = lflat
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|[a, b]| (a.clone(), b.clone()))
+        .collect();
+    let (_, lsig) = read_acc_entry(public, &mut p, false, l.lane_sigma_w.0, l.lane_sigma_w.1);
+    let (_, ljag) = read_acc_entry(public, &mut p, false, l.lane_jagged_w.0, l.lane_jagged_w.1);
+    let lane = Accumulator {
+        registry_digest: vk.tower.chain.inner.built.shape.registry.digest(),
+        per_type: lane_per_type,
+        per_element: Vec::new(),
+        sigma: vec![(chain_d, lsig)],
+        jagged: vec![(chain_d, ljag)],
+    };
+
+    Ok((main, passenger, lane))
+}
+
+/// **VERIFY A TOWER ROOT, STANDALONE.** Consumer inputs: the VK, the
+/// claimed statement, and the root bundle. Everything else — circuits,
+/// r1cs tables, jagged layouts, union counts, pcs params, the decode
+/// plan — comes from the VK; nothing in the bundle steers the check but
+/// the proof bytes themselves.
+pub fn verify_root(
+    vk: &TowerVk,
+    statement: &ChainStatement,
+    bundle: &RootBundle<'_>,
+) -> Result<(), TowerVerifyError> {
+    // (1) geometry: the depth this statement claims, and which of the two
+    // node shapes roots it (k = 2 is the base's; k >= 3 the steady's).
+    let per_pair = 2 * vk.blocks_per_leaf;
+    if statement.n_blocks == 0 || !statement.n_blocks.is_multiple_of(per_pair) {
+        return Err(TowerVerifyError::Geometry);
+    }
+    let k = statement.n_blocks / per_pair;
+    if k < 2 {
+        return Err(TowerVerifyError::Geometry);
+    }
+    let root_lo: &LeafOuter = if k == 2 {
+        &vk.tower
+            .base
+            .as_ref()
+            .expect("the VK tower keeps its base")
+            .lo
+    } else {
+        &vk.tower.root.lo
+    };
+    if bundle.public.len() != root_lo.public.len() {
+        return Err(TowerVerifyError::PublicsLength);
+    }
+
+    // (2) the root proof, against VK materials only.
+    let u = outer_union(&root_lo.shape.registry, root_lo.shape.counts.clone());
+    let lcs = leaf_boolean_lcs(root_lo);
+    let mut ch = FsChallenger::with_chained_blake3(DOMAIN);
+    bundle
+        .proof
+        .verify_circuit(
+            &u,
+            &root_lo.shape.circuit,
+            bundle.public,
+            &lcs,
+            bundle.commitment,
+            &root_lo.pcs,
+            &mut ch,
+        )
+        .map_err(TowerVerifyError::Proof)?;
+
+    // (3) the published accumulators, from the publics alone.
+    let (main, passenger, lane) = reassemble(bundle.public, vk)?;
+
+    // (4) the shared discharge legs + the statement binding, with the
+    // VK's reference tower as the table owner.
+    vk.tower
+        .discharge_with(bundle.public, &lane, &main, &passenger, statement, k >= 4)
+        .map_err(TowerVerifyError::Discharge)
+}

--- a/crates/flock-prover/src/tower/verify.rs
+++ b/crates/flock-prover/src/tower/verify.rs
@@ -46,6 +46,29 @@ pub struct RootBundle<'a> {
     pub(super) commitment: &'a Commitment,
 }
 
+/// What a green [`verify_root`] CERTIFIED about the claimed span. The
+/// ENDPOINTS (`h_start`, `h_end`) are always bound — they ride the app
+/// block the proof pins. The COUNT is bound only where the root's shape
+/// pins it: a base root folds exactly two leaf pairs, and a
+/// passenger-less steady root is exactly three (a deeper spine always
+/// carries its live orphan — the match-gate adversarial matrix is what
+/// closes the forged-fold escape). From four pairs on, the steady shape
+/// is depth-independent BY DESIGN (the spine's one-digest convergence),
+/// and the app block carries no count word — so within that class the
+/// count is CONSISTENT but not pinned. Binding it exactly means a count
+/// word in the app block, composed child-to-parent like the hash
+/// endpoints: a recorded protocol follow-up, not a verifier-side patch.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SpanBound {
+    /// The claimed `n_blocks` is pinned by the root's shape (two or
+    /// three leaf pairs).
+    Exact,
+    /// The endpoints are pinned and the count is consistent (a whole
+    /// number of leaf pairs, at least four) but NOT pinned within that
+    /// class.
+    EndpointsOnly,
+}
+
 /// Why [`verify_root`] refused.
 #[derive(Debug)]
 pub enum TowerVerifyError {
@@ -248,15 +271,20 @@ pub(super) fn reassemble(
 }
 
 /// **VERIFY A TOWER ROOT, STANDALONE.** Consumer inputs: the VK, the
-/// claimed statement, and the root bundle. Everything else — circuits,
-/// r1cs tables, jagged layouts, union counts, pcs params, the decode
-/// plan — comes from the VK; nothing in the bundle steers the check but
-/// the proof bytes themselves.
+/// claimed statement, and the root bundle. Every verifier MATERIAL —
+/// circuits, r1cs tables, jagged layouts, union counts, pcs params, the
+/// decode plan — comes from the VK; the bundle's publics, proof and
+/// commitment are the CLAIM being checked, never the tables it is
+/// checked against.
+///
+/// A green result is qualified by [`SpanBound`]: the endpoints are
+/// always certified, the count only up to the root's depth class — read
+/// its doc before treating `n_blocks` as verified.
 pub fn verify_root(
     vk: &TowerVk,
     statement: &ChainStatement,
     bundle: &RootBundle<'_>,
-) -> Result<(), TowerVerifyError> {
+) -> Result<SpanBound, TowerVerifyError> {
     // (1) geometry: the depth this statement claims, and which of the two
     // node shapes roots it (k = 2 is the base's; k >= 3 the steady's).
     let per_pair = 2 * vk.blocks_per_leaf;
@@ -304,5 +332,14 @@ pub fn verify_root(
     // VK's reference tower as the table owner.
     vk.tower
         .discharge_with(bundle.public, &lane, &main, &passenger, statement, k >= 4)
-        .map_err(TowerVerifyError::Discharge)
+        .map_err(TowerVerifyError::Discharge)?;
+
+    // (5) what the shape actually pinned: k = 2 and 3 are exact (base
+    // shape; passenger-less steady); k >= 4 certifies the endpoints and
+    // the class, not the count — see [`SpanBound`].
+    Ok(if k <= 3 {
+        SpanBound::Exact
+    } else {
+        SpanBound::EndpointsOnly
+    })
 }


### PR DESCRIPTION
Tower productionization, milestone 2: a consumer can now verify a tower root standalone — nothing prover-supplied is trusted but the bundle's proof, publics and commitment; every table comes from a verification key derived from config.

## What this adds

**`TowerVk::generate(cfg, blocks_per_leaf)`** (`tower/verify.rs`) — Option-A generation as agreed: prove the minimal six-leaf reference tower (the smallest run that materializes all four shapes — chain, FL, base, steady) and keep it as the verifier's material set, plus the accumulator blocks' decode plan (base offsets and per-entry widths, all shape constants). Shapes are statement-independent, so the reference tower's circuits and tables are byte-identical to any production tower at the same `(cfg, blocks_per_leaf)`. One-time (~33s at the demo size); a serialized, digest-pinned VK artifact is M3's job.

**`verify_root(vk, statement, bundle) -> Result<SpanBound, _>`** — the consumer path: geometry and publics-length guards; the native circuit verify over the root proof with VK materials (pcs params from the VK, never the bundle); then the published accumulators — main fold, chain lane, passenger — **reassembled from the bundle's public segment alone** (a `read_acc_entry` replay of the decode the builders pin in `check_fold_publics`) and handed to the shared discharge legs plus the statement binding. Reassembly-from-publics is the soundness point: the prover's in-memory accumulators remain its own self-check (`discharge_root`), never a consumer input.

**`Tower::root_bundle()`** + `RootBundle` — the root's transportable part (publics, proof, commitment). `discharge_root` is refactored over a shared `discharge_with`, so the prover self-check and the verifier run one discharge implementation.

**`tower_verify_root_e2e`** (ignored suite) — the VK proves once, then verifies three towers it never built (k = 2, 3, 4 — both root shapes, with and without the passenger); the publics-decoded blocks equal the prover's own objects byte-exactly (all three blocks); four consumer-side refusals: a doctored public word dies in the proof verify, a wrong statement on the binding, a truncated bundle on the length guard, a misfit span on geometry.

**`examples/tower.rs`** grows a `verify` flag: `cargo run --release --example tower -- 8 256 chain128 verify`.

## What a green result certifies (`SpanBound`)

The endpoints (`h_start`, `h_end`) are always bound. The **count** is bound only where the root's shape pins it: k = 2 (base shape) and k = 3 (passenger-less steady) return `Exact`; from k ≥ 4 the steady shape is depth-independent **by design** and the app block carries no count word, so an honest k ≥ 4 bundle is consistent with any claimed k′ ≥ 4 span — a green result there is `EndpointsOnly`, never a certification of `n_blocks`. The e2e pins this degeneracy explicitly, and the cross-class lies do die (a k = 3 bundle claimed steady-deep fails the passenger rule). The exact fix — a count word in the app block, composed child-to-parent like the endpoints — is a protocol change, recorded as a follow-up decision rather than patched into the verifier.

## Notes for review

- The k-boundary logic: k = statement.n_blocks / (2 · blocks_per_leaf); k = 2 verifies against the base circuit, k ≥ 3 the steady; the passenger is owed exactly at k ≥ 4.
- Live keyed slots must name a circuit the VK knows (FL / steady / base) — an unknown key is a refusal, not a skip; dead slots decode as the zero claim and are dropped, matching the prover accumulator's live-entries-only contract.
- The cross-tower digest equality (reference tower vs fresh towers) is itself validated by the e2e: verify_circuit would refuse otherwise.

## Validation

- verifier e2e green (four towers, 138s): fresh k = 4 / 3 / 2 towers verified with the right `SpanBound`, byte-exact reassembly cross-check, seven refusal legs (doctored public word, wrong statement, truncated bundle, misfit span, unknown slot key, cross-class span lie, plus the pinned in-class degeneracy)
- two-axis self-review (standards + spec): one blocker (the k ≥ 4 span degeneracy — addressed as `SpanBound`), one spec deviation (the k = 3 leg now verifies a fresh tower), doc corrections applied; an unrelated local docs commit was rebased out of the branch
- example verify flag green (vk generate 33.3s one-time, verify_root 0.388s)
- full workspace suite, full ignored tower suite (15 tests), clippy native + znver4 cross, fmt: all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XU432JiGGjEiAybuTbmST3

