### PR TITLE
tower: the root bundle on the wire + the VK fingerprint (productionization M3)

### DIFF
--- a/crates/flock-prover/examples/tower.rs
+++ b/crates/flock-prover/examples/tower.rs
@@ -17,7 +17,7 @@
 
 use std::{env, time::Instant};
 
-use flock_prover::tower::{Tower, TowerConfig, TowerVk, verify_root};
+use flock_prover::tower::{Tower, TowerConfig, TowerVk, verify_root_bytes};
 
 fn main() {
     let mut args = env::args().skip(1);
@@ -69,13 +69,16 @@ fn main() {
         let t2 = Instant::now();
         let vk = TowerVk::generate(cfg, blocks_per_leaf);
         let gen_s = t2.elapsed().as_secs_f64();
+        let bytes = tower.root_bundle_bytes();
         let t3 = Instant::now();
-        let bound =
-            verify_root(&vk, s, &tower.root_bundle()).expect("the root verifies standalone");
+        let (stmt, bound) =
+            verify_root_bytes(&vk, &bytes).expect("the wire bundle verifies standalone");
         let verify_s = t3.elapsed().as_secs_f64();
+        assert_eq!(&stmt, s, "the statement rode the wire");
         println!(
-            "  VERIFIED STANDALONE (consumer path): vk generate {gen_s:.1}s (one-time) \
-             | verify_root {verify_s:.3}s | span bound: {bound:?}"
+            "  VERIFIED STANDALONE (consumer path, over the wire): bundle {:.1} KiB \
+             | vk generate {gen_s:.1}s (one-time) | verify {verify_s:.3}s | span bound: {bound:?}",
+            bytes.len() as f64 / 1024.0,
         );
     }
 }

--- a/crates/flock-prover/src/proof_io.rs
+++ b/crates/flock-prover/src/proof_io.rs
@@ -1,9 +1,12 @@
 //! Serialize / deserialize proofs to bytes (and files).
 //!
-//! Two bundle types: [`R1csProofBundleLigerito`] for the base R1CS proof and
-//! [`MixedProofBundleLigerito`] for the multi-table mixed proof. Both pair a
-//! proof with its commitment (which the verifier needs); the mixed bundle
-//! additionally carries its registry id + counts vector.
+//! Three bundle types: [`R1csProofBundleLigerito`] for the base R1CS proof,
+//! [`MixedProofBundleLigerito`] for the multi-table mixed proof, and
+//! [`TowerRootBundle`] for a recursion-tower root. All pair a proof with its
+//! commitment (which the verifier needs); the mixed bundle additionally
+//! carries its registry id + counts vector, the tower bundle its statement
+//! and VK-selection tags (file transport for it lands with its CLI
+//! consumer — today it travels as bytes via `verify_root_bytes`).
 //!
 //! On-disk format:
 //! ```text
@@ -217,9 +220,10 @@ impl MixedProofBundleLigerito {
 /// outer's transportable part (publics, commitment, proof), tagged with
 /// the tower config and leaf size so a consumer selects — and
 /// cross-checks — the right verification key. The statement rides the
-/// payload for transport; `verify_root_bytes` re-checks every word of it
-/// against the proof, so nothing here is trusted (the span caveat of the
-/// verify module's `SpanBound` applies verbatim).
+/// payload for transport; NOTHING decoded here is trusted, and a bare
+/// `from_bytes` proves nothing — `verify_root_bytes` is the ONE entry
+/// that returns a statement with its qualification (the span caveat of
+/// the verify module's `SpanBound` applies verbatim).
 #[derive(Clone, Serialize, Deserialize)]
 pub struct TowerRootBundle {
     pub config: TowerConfig,
@@ -241,22 +245,6 @@ impl TowerRootBundle {
         let payload = parse_header(bytes, FLAVOR_TOWER_ROOT)?;
         deserialize_payload(payload)
     }
-}
-
-/// Write a tower-root bundle to `path`.
-pub fn write_tower_root_bundle_to_file<P: AsRef<Path>>(
-    path: P,
-    bundle: &TowerRootBundle,
-) -> IoResult<()> {
-    write_bytes_to_file(path, &bundle.to_bytes())
-}
-
-/// Read a tower-root bundle from `path`.
-pub fn read_tower_root_bundle_from_file<P: AsRef<Path>>(
-    path: P,
-) -> Result<TowerRootBundle, BundleReadError> {
-    let bytes = read_bytes_from_file(path).map_err(BundleReadError::Io)?;
-    TowerRootBundle::from_bytes(&bytes).map_err(BundleReadError::Deserialize)
 }
 
 /// Write a mixed bundle to `path`.
@@ -416,8 +404,9 @@ mod tests {
         mixed::{MixedCounts, MixedRegistryId, MixedSetup},
         proof_io::{
             BundleFlavor, DeserializeError, FLAVOR_MIXED_LIGERITO, FLAVOR_R1CS_LIGERITO,
-            HEADER_LEN, MAGIC, MAX_BUNDLE_BYTES, MixedProofBundleLigerito, R1csProofBundleLigerito,
-            VERSION, check_bundle_size, deserialize_payload, peek_flavor, read_bytes_from_file,
+            FLAVOR_TOWER_ROOT, HEADER_LEN, MAGIC, MAX_BUNDLE_BYTES, MixedProofBundleLigerito,
+            R1csProofBundleLigerito, TowerRootBundle, VERSION, check_bundle_size,
+            deserialize_payload, peek_flavor, read_bytes_from_file,
             read_mixed_bundle_ligerito_from_file, write_bytes_to_file,
             write_mixed_bundle_ligerito_to_file,
         },
@@ -653,6 +642,7 @@ mod tests {
         for (flavor, expect) in [
             (FLAVOR_R1CS_LIGERITO, BundleFlavor::R1cs),
             (FLAVOR_MIXED_LIGERITO, BundleFlavor::Mixed),
+            (FLAVOR_TOWER_ROOT, BundleFlavor::TowerRoot),
         ] {
             bytes[6] = flavor;
             assert!(matches!(peek_flavor(&bytes), Ok(f) if f == expect));
@@ -665,6 +655,16 @@ mod tests {
             Err(DeserializeError::FlavorMismatch {
                 expected: FLAVOR_MIXED_LIGERITO,
                 found: FLAVOR_R1CS_LIGERITO
+            })
+        ));
+
+        // Mixed-flavored header read as a tower root: flavor mismatch.
+        bytes[6] = FLAVOR_MIXED_LIGERITO;
+        assert!(matches!(
+            TowerRootBundle::from_bytes(&bytes),
+            Err(DeserializeError::FlavorMismatch {
+                expected: FLAVOR_TOWER_ROOT,
+                found: FLAVOR_MIXED_LIGERITO
             })
         ));
 

--- a/crates/flock-prover/src/proof_io.rs
+++ b/crates/flock-prover/src/proof_io.rs
@@ -9,7 +9,7 @@
 //! ```text
 //!   bytes 0..5    "FLOCK"                  (5-byte magic)
 //!   byte  5       VERSION                  (currently 22)
-//!   bytes 6..7    flavor: 2 = R1cs, 4 = Mixed
+//!   bytes 6..7    flavor: 2 = R1cs, 4 = Mixed, 5 = TowerRoot
 //!                 (0/1 reserved: legacy BaseFold; 3 was the retired chain)
 //!   bytes 7..     bincode-serialized payload
 //! ```
@@ -40,9 +40,13 @@ use std::{
 
 use bincode::{DefaultOptions, Error as BincodeError, Options, serialize_into};
 use flock_core::{pcs::Commitment, proof::R1csProofMergedLigerito};
+use flock_field::F128;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use crate::mixed::MixedRegistryId;
+use crate::{
+    mixed::MixedRegistryId,
+    tower::{ChainStatement, MixedProof, TowerConfig},
+};
 
 /// Magic bytes prepended to every serialized proof. Lets readers reject
 /// random binary data early.
@@ -69,6 +73,7 @@ const VERSION: u8 = 22;
 /// [`peek_flavor`]). Values 0, 1, and 3 are reserved.
 const FLAVOR_R1CS_LIGERITO: u8 = 2;
 const FLAVOR_MIXED_LIGERITO: u8 = 4;
+const FLAVOR_TOWER_ROOT: u8 = 5;
 
 /// What kind of bundle a byte buffer holds. Returned by [`peek_flavor`] so
 /// generic readers (the CLI) can dispatch before parsing the payload.
@@ -76,6 +81,9 @@ const FLAVOR_MIXED_LIGERITO: u8 = 4;
 pub enum BundleFlavor {
     R1cs,
     Mixed,
+    /// A recursion-tower ROOT: statement + root outer proof/publics/
+    /// commitment — what `verify_root_bytes` consumes.
+    TowerRoot,
 }
 
 /// Validate the header (magic + version) and return the bundle flavor,
@@ -94,6 +102,7 @@ pub fn peek_flavor(bytes: &[u8]) -> Result<BundleFlavor, DeserializeError> {
     match bytes[6] {
         FLAVOR_R1CS_LIGERITO => Ok(BundleFlavor::R1cs),
         FLAVOR_MIXED_LIGERITO => Ok(BundleFlavor::Mixed),
+        FLAVOR_TOWER_ROOT => Ok(BundleFlavor::TowerRoot),
         other => Err(DeserializeError::UnknownFlavor(other)),
     }
 }
@@ -109,8 +118,8 @@ pub enum DeserializeError {
     /// The version byte didn't match this build's `VERSION`. The number is
     /// the version found in the file.
     UnsupportedVersion(u8),
-    /// The flavor byte was neither `2` (R1cs Ligerito) nor `4` (Mixed
-    /// Ligerito).
+    /// The flavor byte was none of `2` (R1cs Ligerito), `4` (Mixed
+    /// Ligerito), `5` (TowerRoot).
     UnknownFlavor(u8),
     /// `from_bytes` was called with a slice shorter than `HEADER_LEN`.
     Truncated,
@@ -204,6 +213,52 @@ impl MixedProofBundleLigerito {
     }
 }
 
+/// Bundles a recursion-tower ROOT: the claimed statement plus the root
+/// outer's transportable part (publics, commitment, proof), tagged with
+/// the tower config and leaf size so a consumer selects — and
+/// cross-checks — the right verification key. The statement rides the
+/// payload for transport; `verify_root_bytes` re-checks every word of it
+/// against the proof, so nothing here is trusted (the span caveat of the
+/// verify module's `SpanBound` applies verbatim).
+#[derive(Clone, Serialize, Deserialize)]
+pub struct TowerRootBundle {
+    pub config: TowerConfig,
+    pub blocks_per_leaf: u64,
+    pub statement: ChainStatement,
+    pub public: Vec<F128>,
+    pub commitment: Commitment,
+    pub(crate) proof: MixedProof,
+}
+
+impl TowerRootBundle {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(HEADER_LEN + 1024);
+        write_header(&mut out, FLAVOR_TOWER_ROOT);
+        serialize_into(&mut out, self).expect("bincode serialize TowerRootBundle");
+        out
+    }
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, DeserializeError> {
+        let payload = parse_header(bytes, FLAVOR_TOWER_ROOT)?;
+        deserialize_payload(payload)
+    }
+}
+
+/// Write a tower-root bundle to `path`.
+pub fn write_tower_root_bundle_to_file<P: AsRef<Path>>(
+    path: P,
+    bundle: &TowerRootBundle,
+) -> IoResult<()> {
+    write_bytes_to_file(path, &bundle.to_bytes())
+}
+
+/// Read a tower-root bundle from `path`.
+pub fn read_tower_root_bundle_from_file<P: AsRef<Path>>(
+    path: P,
+) -> Result<TowerRootBundle, BundleReadError> {
+    let bytes = read_bytes_from_file(path).map_err(BundleReadError::Io)?;
+    TowerRootBundle::from_bytes(&bytes).map_err(BundleReadError::Deserialize)
+}
+
 /// Write a mixed bundle to `path`.
 pub fn write_mixed_bundle_ligerito_to_file<P: AsRef<Path>>(
     path: P,
@@ -243,7 +298,10 @@ fn parse_header(bytes: &[u8], expected_flavor: u8) -> Result<&[u8], DeserializeE
         return Err(DeserializeError::UnsupportedVersion(v));
     }
     let flavor = bytes[6];
-    if flavor != FLAVOR_R1CS_LIGERITO && flavor != FLAVOR_MIXED_LIGERITO {
+    if flavor != FLAVOR_R1CS_LIGERITO
+        && flavor != FLAVOR_MIXED_LIGERITO
+        && flavor != FLAVOR_TOWER_ROOT
+    {
         return Err(DeserializeError::UnknownFlavor(flavor));
     }
     if flavor != expected_flavor {

--- a/crates/flock-prover/src/tower/chain.rs
+++ b/crates/flock-prover/src/tower/chain.rs
@@ -51,8 +51,10 @@ use crate::{
 
 /// A circuit-union proof by boolean-zerocheck FLAVOR — parallel arms so
 /// the chain leaf and envelope outers. Both forms share all other regions.
-#[derive(serde::Serialize)]
-pub(super) enum MixedProof {
+/// `pub(crate)` for the wire format's sake: `proof_io`'s tower-root
+/// bundle carries one.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) enum MixedProof {
     Rs(R1csProofCircuitMerged),
     /// Constructed only where the AG round-1 prover kernel exists
     /// (aarch64); the consuming arms are arch-independent.

--- a/crates/flock-prover/src/tower/config.rs
+++ b/crates/flock-prover/src/tower/config.rs
@@ -30,7 +30,7 @@ pub(super) fn pcs_batch_for(union: &UnionInstance, profile: LigeritoProfile) -> 
 /// recursion balloons the FL's replayed transcript past the arity-2
 /// envelope), and the 128-bit aggressive recursion carries the aggressive
 /// Fast128 leaf (rate-1/2 on the rate+2 ladder; m32: Σq 675 → 527).
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum TowerConfig {
     /// The 100-bit tower: Fast100 leaf, Slim100 outers.
     Chain100,

--- a/crates/flock-prover/src/tower/driver.rs
+++ b/crates/flock-prover/src/tower/driver.rs
@@ -24,6 +24,7 @@ use flock_core::{
     pcs::jagged::JaggedParams,
 };
 
+use crate::proof_io::TowerRootBundle;
 use crate::tower::{
     F128,
     chain::{ChainProof, build_chain_proof},
@@ -47,7 +48,7 @@ use crate::tower::{
 /// depth-independent by design and the app block carries no count word.
 /// See `SpanBound` in the verify module before treating a verified
 /// `n_blocks` as exact.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ChainStatement {
     pub h_start: [u32; 16],
     pub h_end: [u32; 16],
@@ -105,6 +106,9 @@ pub struct Tower {
     /// A STEADY root (two spine folds or more) owes the single orphan its
     /// transition made; a shallower root owes none.
     pub(super) expect_passenger: bool,
+    /// The leaf size this tower ran at — the wire bundle's VK-selection
+    /// tag.
+    pub(super) blocks_per_leaf: usize,
 }
 
 impl Tower {
@@ -235,6 +239,7 @@ impl Tower {
             base,
             root,
             expect_passenger: k >= 4,
+            blocks_per_leaf,
         }
     }
 
@@ -289,6 +294,24 @@ impl Tower {
             proof: &self.root.lo.proof,
             commitment: &self.root.lo.commitment,
         }
+    }
+
+    /// The root bundle ON THE WIRE: the proof-IO tower-root flavor
+    /// (statement + publics + commitment + proof, tagged with config and
+    /// leaf size for VK selection). `verify_root_bytes` is the consuming
+    /// end.
+    ///
+    /// [`verify_root_bytes`]: crate::tower::verify_root_bytes
+    pub fn root_bundle_bytes(&self) -> Vec<u8> {
+        TowerRootBundle {
+            config: self.cfg,
+            blocks_per_leaf: self.blocks_per_leaf as u64,
+            statement: self.statement,
+            public: self.root.lo.public.clone(),
+            commitment: self.root.lo.commitment.clone(),
+            proof: self.root.lo.proof.clone(),
+        }
+        .to_bytes()
     }
 
     /// The discharge legs over CALLER-SUPPLIED artifacts: the prover's

--- a/crates/flock-prover/src/tower/e2e_tests.rs
+++ b/crates/flock-prover/src/tower/e2e_tests.rs
@@ -14,8 +14,8 @@ use crate::{
     r1cs_hashes::blake3::build_block_r1cs,
     tower::{
         ChainLane, ChainProof, DOMAIN, F128, FlNode, FsChallenger, LeafOuter, Online, RootBundle,
-        RootDischargeFailure, SpanBound, SpineIn, Tower, TowerVerifyError, TowerVk, UnionInstance,
-        build_chain_proof, build_fl_node, build_node_outer_app, chain_blake_r1cs,
+        RootDischargeFailure, SpanBound, SpineIn, Tower, TowerConfig, TowerVerifyError, TowerVk,
+        UnionInstance, build_chain_proof, build_fl_node, build_node_outer_app, chain_blake_r1cs,
         chain_jagged_params, env_acc_chain_base, env_acc_main_base, env_app_base, env_pass_base,
         envelope::STEADY_OVERRIDE,
         envelope_shape,
@@ -25,7 +25,7 @@ use crate::{
         node_jagged_params,
         online::{median_total, proof_census_mixed, report_stage},
         outer_union, pack4, test_config, tower_fold_grinding,
-        verify::{reassemble, verify_root},
+        verify::{reassemble, verify_root, verify_root_bytes},
     },
 };
 
@@ -1135,6 +1135,30 @@ pub(super) fn tower_verify_root_e2e() {
         "the passenger, from publics alone"
     );
 
+    // THE WIRE: the same k = 4 root as bytes — decode, VK cross-check,
+    // full verify; the statement comes back with its qualification.
+    let bytes = tower.root_bundle_bytes();
+    let (stmt_wire, bound) = verify_root_bytes(&vk, &bytes).expect("the wire bundle verifies");
+    assert_eq!(stmt_wire, stmt, "the statement rode the wire");
+    assert_eq!(bound, SpanBound::EndpointsOnly);
+    // A corrupted payload byte must not verify — the decode or the proof
+    // refuses, and both are refusals.
+    let mut corrupt = bytes.clone();
+    let mid = corrupt.len() / 2;
+    corrupt[mid] ^= 1;
+    assert!(
+        verify_root_bytes(&vk, &corrupt).is_err(),
+        "a corrupted wire bundle must be refused"
+    );
+    // Truncation dies in the decode.
+    assert!(
+        matches!(
+            verify_root_bytes(&vk, &bytes[..bytes.len() - 9]),
+            Err(TowerVerifyError::Encoding(_))
+        ),
+        "a truncated wire bundle must die in the decode"
+    );
+
     // (2) consumer-side refusals.
     // A doctored public word dies in the PROOF verify, before any
     // discharge sees it.
@@ -1246,3 +1270,61 @@ pub(super) fn tower_verify_root_e2e() {
         SpanBound::Exact,
     );
 }
+
+/// **THE VK'S PUBLISHED IDENTITY, PINNED** (chain128 @ 256-block
+/// leaves): the digest fingerprint a consumer compares their locally
+/// generated VK against instead of trusting a shipped blob. Any
+/// deliberate shape change moves these — re-bless with
+/// `TOWER_VK_FP_PRINT=1 ... --nocapture`, two identical prints before
+/// committing, per the fixture discipline.
+#[test]
+#[ignore] // Heavy — one VK generation (a six-leaf reference tower).
+pub(super) fn tower_vk_fingerprint_pinned() {
+    let cfg = test_config();
+    if cfg != TowerConfig::Chain128 {
+        eprintln!("the fingerprint pin is chain128-only; skipping under {cfg:?}");
+        return;
+    }
+    let vk = TowerVk::generate(cfg, 256);
+    let fp = vk.fingerprint();
+    let hex = |d: &[u8; 32]| d.iter().map(|b| format!("{b:02x}")).collect::<String>();
+    if var("TOWER_VK_FP_PRINT").is_ok() {
+        println!("chain_circuit:  {}", hex(&fp.chain_circuit));
+        println!("fl_circuit:     {}", hex(&fp.fl_circuit));
+        println!("base_circuit:   {}", hex(&fp.base_circuit));
+        println!("steady_circuit: {}", hex(&fp.steady_circuit));
+        println!("chain_registry: {}", hex(&fp.chain_registry));
+        println!("outer_registry: {}", hex(&fp.outer_registry));
+        println!("publics_len:    {}", fp.publics_len);
+    }
+    assert_eq!(fp.blocks_per_leaf, 256);
+    assert_eq!(hex(&fp.chain_circuit), PIN_CHAIN_CIRCUIT, "chain circuit");
+    assert_eq!(hex(&fp.fl_circuit), PIN_FL_CIRCUIT, "FL circuit");
+    assert_eq!(hex(&fp.base_circuit), PIN_BASE_CIRCUIT, "base circuit");
+    assert_eq!(
+        hex(&fp.steady_circuit),
+        PIN_STEADY_CIRCUIT,
+        "steady circuit"
+    );
+    assert_eq!(
+        hex(&fp.chain_registry),
+        PIN_CHAIN_REGISTRY,
+        "chain registry"
+    );
+    assert_eq!(
+        hex(&fp.outer_registry),
+        PIN_OUTER_REGISTRY,
+        "outer registry"
+    );
+    assert_eq!(fp.publics_len, PIN_PUBLICS_LEN, "publics length");
+}
+
+// The blessed chain128@256 fingerprint (see `tower_vk_fingerprint_pinned`).
+// Blessed 2026-09-04: two identical prints at the M3 wire-format tip.
+const PIN_CHAIN_CIRCUIT: &str = "b8f442da32b9961612ccaf9acb39cadcd4592e913b2b208a1b9740d01c10e9c9";
+const PIN_FL_CIRCUIT: &str = "d272428abed26bd2685078eca64f265c0a5362d6e42f4392e83c9c36af4fcfa1";
+const PIN_BASE_CIRCUIT: &str = "3cec36dc2c40c45020105e2144880623e4f87a0a8263922dde172006a3233e51";
+const PIN_STEADY_CIRCUIT: &str = "8ce5ce16dfb72069aa81e673bd0f0676c2271954a963b086d84a23574fc9c0e2";
+const PIN_CHAIN_REGISTRY: &str = "3126c5ce825e8fc3942843c0548ba43964b1daa5751a834fcbbc1c3ab58e40fe";
+const PIN_OUTER_REGISTRY: &str = "acfbc7354af8436af480ea66609bb9b1cd0856b27426db2b4d8a69fe9014c10e";
+const PIN_PUBLICS_LEN: usize = 5684;

--- a/crates/flock-prover/src/tower/e2e_tests.rs
+++ b/crates/flock-prover/src/tower/e2e_tests.rs
@@ -1142,14 +1142,16 @@ pub(super) fn tower_verify_root_e2e() {
     assert_eq!(stmt_wire, stmt, "the statement rode the wire");
     assert_eq!(bound, SpanBound::EndpointsOnly);
     // A corrupted payload byte must not verify — the decode or the proof
-    // refuses, and both are refusals.
-    let mut corrupt = bytes.clone();
-    let mid = corrupt.len() / 2;
-    corrupt[mid] ^= 1;
-    assert!(
-        verify_root_bytes(&vk, &corrupt).is_err(),
-        "a corrupted wire bundle must be refused"
-    );
+    // refuses, and both are refusals. One flip in the proof body's
+    // region, one in the early tags/statement region.
+    for at in [bytes.len() / 2, 8usize] {
+        let mut corrupt = bytes.clone();
+        corrupt[at] ^= 1;
+        assert!(
+            verify_root_bytes(&vk, &corrupt).is_err(),
+            "a corrupted wire bundle (byte {at}) must be refused"
+        );
+    }
     // Truncation dies in the decode.
     assert!(
         matches!(

--- a/crates/flock-prover/src/tower/mod.rs
+++ b/crates/flock-prover/src/tower/mod.rs
@@ -47,15 +47,20 @@ pub use crate::tower::{
     fl_node::{FlNode, build_fl_node, build_fl_node_k},
     node::{ChainLane, MainBlock, NodeOut, SpineIn, build_node_outer_app},
     query::LeafOuter,
-    verify::{RootBundle, SpanBound, TowerVerifyError, TowerVk, verify_root},
+    verify::{
+        RootBundle, SpanBound, TowerVerifyError, TowerVk, TowerVkFingerprint, verify_root,
+        verify_root_bytes,
+    },
 };
+// The wire format (`proof_io`'s tower-root bundle) carries a `MixedProof`.
+pub(crate) use crate::tower::chain::MixedProof;
 use crate::{
     challenger::FsChallenger,
     prover::UnionSlotProverInput,
     r1cs_hashes::merkle_r1cs::SLOT_WORDS,
     schedule::TableType,
     tower::{
-        chain::{MixedInner, MixedProof, native_chain},
+        chain::{MixedInner, native_chain},
         child_walker::{
             ChildSlots, ChildTape, ZskipTapeRec, ZskipWires, check_child_region, emit_child_region,
         },

--- a/crates/flock-prover/src/tower/verify.rs
+++ b/crates/flock-prover/src/tower/verify.rs
@@ -26,9 +26,9 @@ use flock_core::{
     aggregate::Accumulator, matrix_fold::MatrixClaim, pcs::Commitment, verifier::FlockVerifyError,
 };
 
+use crate::proof_io::{DeserializeError, TowerRootBundle};
 use crate::tower::{
-    DOMAIN, F128, FsChallenger, TowerConfig,
-    chain::MixedProof,
+    DOMAIN, F128, FsChallenger, MixedProof, TowerConfig,
     driver::{ChainStatement, RootDischargeFailure, Tower},
     env_acc_main_base, env_pass_base, envelope_shape,
     fold_region::read_acc_entry,
@@ -84,6 +84,12 @@ pub enum TowerVerifyError {
     /// A reassembled accumulator refused the native tables, or the
     /// statement binding failed.
     Discharge(RootDischargeFailure),
+    /// The wire bundle did not decode (bad header, wrong flavor,
+    /// corrupted payload).
+    Encoding(DeserializeError),
+    /// The wire bundle's config or leaf size is not this VK's — the
+    /// consumer selected the wrong verification key.
+    VkMismatch,
 }
 
 /// The published accumulator blocks' DECODE PLAN: base offsets and
@@ -342,4 +348,68 @@ pub fn verify_root(
     } else {
         SpanBound::EndpointsOnly
     })
+}
+
+/// **VERIFY A TOWER ROOT FROM ITS WIRE BYTES** (the proof-IO tower-root
+/// flavor, [`Tower::root_bundle_bytes`]'s output): decode, cross-check
+/// the bundle's VK-selection tags against this VK, then [`verify_root`]
+/// over the carried statement. Returns the statement WITH its
+/// [`SpanBound`] qualification — the statement traveled in the payload,
+/// and every word of it was re-checked against the proof.
+pub fn verify_root_bytes(
+    vk: &TowerVk,
+    bytes: &[u8],
+) -> Result<(ChainStatement, SpanBound), TowerVerifyError> {
+    let b = TowerRootBundle::from_bytes(bytes).map_err(TowerVerifyError::Encoding)?;
+    if b.config != vk.tower.cfg || b.blocks_per_leaf != vk.blocks_per_leaf as u64 {
+        return Err(TowerVerifyError::VkMismatch);
+    }
+    let bound = verify_root(
+        vk,
+        &b.statement,
+        &RootBundle {
+            public: &b.public,
+            proof: &b.proof,
+            commitment: &b.commitment,
+        },
+    )?;
+    Ok((b.statement, bound))
+}
+
+/// The VK'S IDENTITY, small enough to publish: the config, the leaf
+/// size, and the digests of every circuit and registry the verifier
+/// checks against. Two honestly generated VKs at the same
+/// `(cfg, blocks_per_leaf)` produce the same fingerprint (shapes are
+/// statement-independent), so a consumer regenerates locally and
+/// compares against a published fingerprint instead of trusting a
+/// shipped VK blob.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TowerVkFingerprint {
+    pub config: TowerConfig,
+    pub blocks_per_leaf: usize,
+    pub chain_circuit: [u8; 32],
+    pub fl_circuit: [u8; 32],
+    pub base_circuit: [u8; 32],
+    pub steady_circuit: [u8; 32],
+    pub chain_registry: [u8; 32],
+    pub outer_registry: [u8; 32],
+    pub publics_len: usize,
+}
+
+impl TowerVk {
+    pub fn fingerprint(&self) -> TowerVkFingerprint {
+        let t = &self.tower;
+        let base_lo = &t.base.as_ref().expect("the VK tower keeps its base").lo;
+        TowerVkFingerprint {
+            config: t.cfg,
+            blocks_per_leaf: self.blocks_per_leaf,
+            chain_circuit: t.chain.inner.built.shape.circuit.digest(),
+            fl_circuit: t.fl.lo.shape.circuit.digest(),
+            base_circuit: base_lo.shape.circuit.digest(),
+            steady_circuit: t.root.lo.shape.circuit.digest(),
+            chain_registry: t.chain.inner.built.shape.registry.digest(),
+            outer_registry: t.root.lo.shape.registry.digest(),
+            publics_len: t.root.lo.public.len(),
+        }
+    }
 }


### PR DESCRIPTION
Tower productionization, milestone 3: the consumer story becomes transportable — a root proof travels as bytes, and a verification key has a publishable identity.

## What this adds

**proof-IO flavor 5 = TowerRoot** — `{config, blocks_per_leaf, statement, publics, commitment, proof}` under the standard FLOCK header. VERSION stays 22: a new flavor leaves existing payloads untouched, and pre-M3 readers reject it cleanly as `UnknownFlavor`. `MixedProof` gains `Clone + Deserialize` and widens to `pub(crate)` so proof-IO can carry it.

**`Tower::root_bundle_bytes()` / `verify_root_bytes(vk, bytes) -> (ChainStatement, SpanBound)`** — decode, VK-selection cross-check (config + leaf size → `VkMismatch`), then the full `verify_root` over the statement that rode the payload. Every word of the carried statement is re-checked against the proof; the `SpanBound` qualification from #46 applies verbatim.

**`TowerVk::fingerprint()`** — the VK's publishable identity: config, leaf size, the four circuit digests (chain/FL/base/steady), both registry digests, and the publics length. The circuit tree deliberately has no serde, so the VK model is regenerate-locally-and-compare, not ship-a-blob. The chain128@256 fingerprint is **pinned** (`tower_vk_fingerprint_pinned`, `TOWER_VK_FP_PRINT` re-bless knob, blessed with two identical prints) — any deliberate shape change re-blesses it like the other fixtures.

## Review

Two-axis self-review (standards + spec): the spec pass found no deviations (it independently confirmed the pinned `publics_len` against the envelope constant and that `verify_root` is byte-identical to #46's); the standards pass traced the adversarial-bytes path end to end (size-capped bincode, trailing bytes rejected, every hostile shape a typed refusal) and found one blocker — the tower-root **file helpers were dead API** whose read path couldn't reach the verifier. They're deleted; file transport lands with its CLI consumer. Also applied: flavor-5 header coverage in the default suite, doc corrections, a second corruption leg.

## Validation

- verifier e2e with the new wire legs green (bytes round-trip returns statement + bound; corrupted payload byte and truncated bundle both refuse)
- fingerprint pin green twice with identical prints; full workspace suite; clippy native + znver4 cross; fmt clean
- example over the wire: bundle 345.3 KiB at demo size, verify 0.389s, `SpanBound` reported

The k ≥ 4 span count-word (from #46's review) remains a separate protocol decision; this format is agnostic to it — a VERSION bump when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XU432JiGGjEiAybuTbmST3
