### PR TITLE
tower: the publish schedule as data + the walker vocabulary (productionization M4)

### DIFF
--- a/crates/flock-prover/src/tower/chain.rs
+++ b/crates/flock-prover/src/tower/chain.rs
@@ -22,7 +22,7 @@ use {
         r1cs_hashes::blake3::{Compression, build_block_r1cs},
         tower::{
             ChildSlots, ChildTape, SLOT_WORDS, check_child_region, emit_child_region,
-            gates_blake3::Rng, test_config,
+            expected_child_tail_schedule, gates_blake3::Rng, test_config,
         },
     },
     flock_core::{
@@ -897,5 +897,10 @@ pub(super) fn chain_child_region_emits_alone() {
         region.pub_base + consumed,
         built2.public.len(),
         "the region's publics are the whole tail"
+    );
+    assert_eq!(
+        region.tail_schedule,
+        expected_child_tail_schedule(&ct),
+        "the lone child region's tail publishes on its declared schedule"
     );
 }

--- a/crates/flock-prover/src/tower/child_walker.rs
+++ b/crates/flock-prover/src/tower/child_walker.rs
@@ -1853,8 +1853,6 @@ pub(super) enum ZskipWires {
     Ag { seed_w: [Wire; 2], nonce_w: Wire },
 }
 
-/// What one emitted child region hands back: where its public block starts,
-/// the walk counts the checker needs, and the assertion-emission wires.
 /// The child tail's EXPECTED publish schedule, every width an expression
 /// over the TAPE's own geometry — the independent reference the emitted
 /// table ([`ChildRegion::tail_schedule`]) is held against at every build.
@@ -1883,6 +1881,8 @@ pub(super) fn expected_child_tail_schedule(ct: &ChildTape<'_>) -> Vec<(&'static 
     ]
 }
 
+/// What one emitted child region hands back: where its public block starts,
+/// the walk counts the checker needs, and the assertion-emission wires.
 pub(super) struct ChildRegion {
     pub(super) pub_base: usize,
     pub(super) n_query_pub: usize,
@@ -2034,7 +2034,7 @@ pub(super) fn emit_child_region(
 
     assert_eq!(
         ct.mp_o.val_vs.len(),
-        256 + ct.n_p,
+        2 * RS_SHAT_WORDS + ct.n_p,
         "the R=2 + P schedule spans both claim kinds"
     );
     let (mp_pws, mp_rho2_w, mp_sig_w, anc_w) = walker_common::emit_multipoint_intake(

--- a/crates/flock-prover/src/tower/child_walker.rs
+++ b/crates/flock-prover/src/tower/child_walker.rs
@@ -44,11 +44,17 @@ use crate::{
         OpenLevel, PdRec, RoundRec, SLOT_WORDS, ShapeBuilder, UnionInstance, Wire, ag_seed_bytes,
         assertion_mac, bytes_payload_mask, cap_payloads, cap_wires, check_residual_publics,
         circuit_structure_claim_wires, cw, declare_envelope_slots, decode_ag_point,
-        emit_boolean_reported_check, emit_element_reported_check, emit_family_h, emit_fs_chain,
-        emit_publics_hash, emit_query_phase, emit_recombination, emit_residual_region, flatten_ops,
-        level_geometry, level_sources, observed_f256, pack8, parse_open_levels, payload_words,
-        pin_recombination, query_phase_b3_rows, replay_ligerito_spine256, squeeze_word_wire,
-        strat_scheds, walker_common,
+        emit_boolean_reported_check, emit_element_reported_check, emit_fs_chain, emit_publics_hash,
+        emit_query_phase, emit_recombination, emit_residual_region, flatten_ops, level_geometry,
+        level_sources, observed_f256, pack8, parse_open_levels, payload_words, pin_recombination,
+        query_phase_b3_rows, replay_ligerito_spine256, squeeze_word_wire, strat_scheds,
+        walker_common,
+        walker_common::{
+            LBL_AG_R1_NONCE, LBL_AG_R1_POINT, LBL_AG_SKIP, LBL_ELEMENT_LC, LBL_ELEMENT_ZC,
+            LBL_FROBENIUS, LBL_LINCHECK, LBL_MERGED_OPEN, LBL_MULTIPOINT, LBL_PRODUCT_GKR,
+            LBL_RING_SWITCH, LBL_ZEROCHECK, RS_SHAT_WORDS, TailEntry, Z_PARTIAL_WORDS,
+            publish_tail, zskip_wires,
+        },
     },
     verifier::{verify_ligerito_union_circuit, verify_ligerito_union_circuit_ag},
 };
@@ -461,7 +467,7 @@ impl<'p> ChildTape<'p> {
                     assert!(matches!(ops[i2], Op::ObserveSlice(64)), "ag round1_c");
                     i2 += 1;
                     assert!(
-                        matches!(&ops[i2], Op::Label(l) if l.as_slice() == b"flock-ag-skip-r1-point"),
+                        matches!(&ops[i2], Op::Label(l) if l.as_slice() == LBL_AG_R1_POINT),
                         "ag r1 seed label"
                     );
                     i2 += 1;
@@ -474,7 +480,7 @@ impl<'p> ChildTape<'p> {
                     let seed_fin1 = fin_at(i2);
                     i2 += 1;
                     assert!(
-                        matches!(&ops[i2], Op::Label(l) if l.as_slice() == b"flock-ag-skip-r1-nonce"),
+                        matches!(&ops[i2], Op::Label(l) if l.as_slice() == LBL_AG_R1_NONCE),
                         "ag r1 nonce label"
                     );
                     i2 += 1;
@@ -537,7 +543,10 @@ impl<'p> ChildTape<'p> {
                 lc_r.push((vc_at(squeeze_i).1, fin_at(squeeze_i)));
                 i2 = squeeze_i + 1;
             }
-            assert!(matches!(ops[i2], Op::ObserveSlice(64)), "z_partial slice");
+            assert!(
+                matches!(ops[i2], Op::ObserveSlice(Z_PARTIAL_WORDS)),
+                "z_partial slice"
+            );
             let (zp, _) = vc_at(i2);
             (zc_r, zskip, outer, lc_alpha, betas, zcf, lc_msgs, lc_r, zp)
         };
@@ -994,27 +1003,27 @@ impl<'p> ChildTape<'p> {
         let zc_l = match proof {
             MixedProof::Rs(_) => {
                 assert!(
-                    find(b"flock-ag-skip-v1").is_empty(),
+                    find(LBL_AG_SKIP).is_empty(),
                     "an RS tape carries no AG-skip region"
                 );
-                find(b"flock-zerocheck-v0")
+                find(LBL_ZEROCHECK)
             }
             MixedProof::Ag(_) => {
                 assert!(
-                    find(b"flock-zerocheck-v0").is_empty(),
+                    find(LBL_ZEROCHECK).is_empty(),
                     "an AG tape carries no RS zerocheck region"
                 );
-                find(b"flock-ag-skip-v1")
+                find(LBL_AG_SKIP)
             }
         };
-        let lc_l = find(b"flock-lincheck-v0");
-        let elzc_l = find(b"flock-element-union-zc-v0");
-        let el_l = find(b"flock-element-union-lc-v0");
-        let gkr_l = find(b"flock-product-gkr-batched-v0");
-        let mo_l = find(b"flock-merged-open-v1");
-        let rs_l = find(b"flock-ring-switch-v0");
-        let mp_l = find(b"flock-multipoint-twisted-v1");
-        let fa_l = find(b"flock-frobenius-assist-v0");
+        let lc_l = find(LBL_LINCHECK);
+        let elzc_l = find(LBL_ELEMENT_ZC);
+        let el_l = find(LBL_ELEMENT_LC);
+        let gkr_l = find(LBL_PRODUCT_GKR);
+        let mo_l = find(LBL_MERGED_OPEN);
+        let rs_l = find(LBL_RING_SWITCH);
+        let mp_l = find(LBL_MULTIPOINT);
+        let fa_l = find(LBL_FROBENIUS);
         assert_eq!(zc_l.len(), 1, "one boolean zerocheck");
         assert_eq!(lc_l.len(), 1, "one boolean lincheck");
         if has_el {
@@ -1248,14 +1257,17 @@ impl<'p> ChildTape<'p> {
         let mut rs_recs: Vec<(usize, usize, usize)> = Vec::new();
         for k in 0..2 {
             assert!(
-                matches!(&ops[i], Op::Label(l) if l.as_slice() == b"flock-ring-switch-v0"),
+                matches!(&ops[i], Op::Label(l) if l.as_slice() == LBL_RING_SWITCH),
                 "rs region {k}"
             );
             i += 1;
-            assert!(matches!(ops[i], Op::ObserveSlice(128)), "s_hat_v slice");
+            assert!(
+                matches!(ops[i], Op::ObserveSlice(RS_SHAT_WORDS)),
+                "s_hat_v slice"
+            );
             let (sv, _) = vc_at(i);
             assert_eq!(
-                &vals_rec[sv..sv + 128],
+                &vals_rec[sv..sv + RS_SHAT_WORDS],
                 &proof.pcs_open().ring_switches[k].s_hat_v[..],
                 "s_hat_v {k} on the stream"
             );
@@ -1302,7 +1314,7 @@ impl<'p> ChildTape<'p> {
             proof.pcs_open().merged_rounds.len(),
             "the W rounds fill the dense domain"
         );
-        while !matches!(&ops[i], Op::Label(l) if l.as_slice() == b"flock-multipoint-twisted-v1") {
+        while !matches!(&ops[i], Op::Label(l) if l.as_slice() == LBL_MULTIPOINT) {
             i += 1;
         }
         i += 1;
@@ -1333,7 +1345,11 @@ impl<'p> ChildTape<'p> {
             n_vals += 1;
             i += 1;
         }
-        assert_eq!(n_vals, 256 + n_p, "2x128 RS dual values + P group values");
+        assert_eq!(
+            n_vals,
+            2 * RS_SHAT_WORDS + n_p,
+            "2x128 RS dual values + P group values"
+        );
         while matches!(ops[i], Op::Pow { .. }) {
             i += 1;
         }
@@ -1378,7 +1394,7 @@ impl<'p> ChildTape<'p> {
         }
         assert_eq!(rounds, fro.rounds.len(), "mp round count");
         assert!(
-            matches!(&ops[i], Op::Label(l) if l.as_slice() == b"flock-frobenius-assist-v0"),
+            matches!(&ops[i], Op::Label(l) if l.as_slice() == LBL_FROBENIUS),
             "anchor label follows the rounds"
         );
         assert_eq!(t, fro.anchor.v, "T_m == anchor.v under the R=2+P schedule");
@@ -1534,7 +1550,7 @@ impl<'p> ChildTape<'p> {
         let mut target = F128::ZERO;
         let mut coeffs: Vec<Vec<F128>> = Vec::new();
         for (k, &(sv, _, rc)) in rs_recs.iter().enumerate() {
-            let shv = &vals_rec[sv..sv + 128];
+            let shv = &vals_rec[sv..sv + RS_SHAT_WORDS];
             let rdp: Vec<F128> = (0..7).map(|j| chals[rc + j]).collect();
             let eq = build_eq(&rdp);
             target += gs[k] * inner_product(&tensor_algebra_transpose(shv), &eq);
@@ -1839,10 +1855,41 @@ pub(super) enum ZskipWires {
 
 /// What one emitted child region hands back: where its public block starts,
 /// the walk counts the checker needs, and the assertion-emission wires.
+/// The child tail's EXPECTED publish schedule, every width an expression
+/// over the TAPE's own geometry — the independent reference the emitted
+/// table ([`ChildRegion::tail_schedule`]) is held against at every build.
+pub(super) fn expected_child_tail_schedule(ct: &ChildTape<'_>) -> Vec<(&'static str, usize)> {
+    let jag_vals = ct.jag.rs.len()
+        + ct.jag
+            .groups
+            .iter()
+            .map(|(combo, dense)| usize::from(combo.is_some()) + dense.len())
+            .sum::<usize>();
+    vec![
+        ("chain ordinals ga+mg", 2),
+        (
+            "element zc+lc ends",
+            if ct.el_assert.is_some() { 2 } else { 0 },
+        ),
+        ("anchor end", 1),
+        ("spine t_final", 2),
+        ("intake target", 1),
+        ("intake running", 1),
+        ("residual accs", 2 * ct.levels.len() * ct.yr_len),
+        ("residual inner", 2),
+        ("sigma value", 1),
+        ("sigma point", ct.mu_i),
+        ("jagged claim values", jag_vals),
+    ]
+}
+
 pub(super) struct ChildRegion {
     pub(super) pub_base: usize,
     pub(super) n_query_pub: usize,
     pub(super) n_tail: usize,
+    /// The published tail's `(name, width)` schedule, as emitted — held
+    /// against [`expected_child_tail_schedule`] at every build.
+    pub(super) tail_schedule: Vec<(&'static str, usize)>,
     pub(super) structure_claim_w: Vec<(Vec<Wire>, Vec<Wire>, Wire)>,
     /// The jagged assertion's value wires (the count win), in emission
     /// order: rs claims, then per group the combo and its dense members —
@@ -2060,7 +2107,7 @@ pub(super) fn emit_child_region(
         })
         .collect();
     let mat_rr_w: Vec<Wire> = lc_pw.iter().map(|&(_, w)| w).collect();
-    let zpartial_ws: Vec<Wire> = (0..64).map(|i| wv(ct.zp_v + i)).collect();
+    let zpartial_ws: Vec<Wire> = (0..Z_PARTIAL_WORDS).map(|i| wv(ct.zp_v + i)).collect();
     let mut beta_wires = vec![None; ct.inner.built.shape.registry.num_boolean()];
     let mut pin_wires = Vec::with_capacity(ct.sigma_native.boolean_pins.len());
     let mut lcb_w = assertion_mac(
@@ -2170,11 +2217,11 @@ pub(super) fn emit_child_region(
     );
 
     // Everything publishes HERE, after every public input is declared
-    // (`built.public` lists entries in declaration order). Tail order:
-    // [query phase (alphas), accs | ga, mg |
-    // gkr deltas | el deltas, el zc end, el lc end | mp_delta, anc,
-    // t_final, tgt, runw | resid | inner | s_sigma | rho... | sqrt deltas |
-    // anchor delta].
+    // (`built.public` lists entries in declaration order): the query
+    // block (alphas + level accs), then THE TAIL SCHEDULE — the table
+    // below IS the child's published wire format, `check_child_region`'s
+    // independent positional walk is its backstop, and the tape pin
+    // holds its `(name, width)` list.
     let pub_base = sb.public_len();
     for a_wires in &to_publish {
         for w in a_wires {
@@ -2185,45 +2232,41 @@ pub(super) fn emit_child_region(
         sb.publish(w[0]);
         sb.publish(w[1]);
     }
-    sb.publish(ga_w);
-    sb.publish(mg_w);
-    if let Some((el_zr, el_lcw, _, _, _)) = el_pub {
-        sb.publish(el_zr);
-        sb.publish(el_lcw);
-    }
-    sb.publish(anc_w);
-    sb.publish(t_final[0]);
-    sb.publish(t_final[1]);
-    sb.publish(tgt_w);
-    sb.publish(runw);
-    for accs in &resid_pub {
-        for w in accs {
-            sb.publish(w[0]);
-            sb.publish(w[1]);
-        }
-    }
-    sb.publish(inner_w[0]);
-    sb.publish(inner_w[1]);
-    // ---- the SIGMA ASSERTION emission (route B, in-circuit) ----
-    // The claim exits as bound publics: the value is the deferred s_sigma
-    // stream word — the SAME wire the rhs input check just consumed — and
-    // the point is the GKR's own accumulated squeeze wires.
-    sb.publish(sig_w);
-    for w in &pt_w {
-        sb.publish(*w);
-    }
-    // ---- the JAGGED ASSERTION emission (the count win) ----
-    // Raw W claim values in emission order (rs, then per group combo +
-    // dense members), checker-held against the deferred export.
-    for w in &jag_w {
-        sb.publish(*w);
-    }
-    let n_tail = 2 + n_el_pd + 5 + 2 * levels.len() * ct.yr_len + 2 + 1 + ct.mu_i + jag_w.len();
+    let tail = [
+        // The published chain ordinals (GKR alpha, multipoint gamma).
+        TailEntry::new("chain ordinals ga+mg", vec![ga_w, mg_w]),
+        // The element chain ends (mixed children only).
+        TailEntry::new(
+            "element zc+lc ends",
+            el_pub.map_or_else(Vec::new, |(el_zr, el_lcw, _, _, _)| vec![el_zr, el_lcw]),
+        ),
+        TailEntry::new("anchor end", vec![anc_w]),
+        TailEntry::new("spine t_final", t_final.to_vec()),
+        TailEntry::new("intake target", vec![tgt_w]),
+        TailEntry::new("intake running", vec![runw]),
+        TailEntry::new(
+            "residual accs",
+            resid_pub.iter().flatten().flatten().copied().collect(),
+        ),
+        TailEntry::new("residual inner", inner_w.to_vec()),
+        // The SIGMA ASSERTION emission (route B, in-circuit): the value
+        // is the deferred s_sigma stream word — the SAME wire the rhs
+        // input check just consumed — and the point is the GKR's own
+        // accumulated squeeze wires.
+        TailEntry::new("sigma value", vec![sig_w]),
+        TailEntry::new("sigma point", pt_w.clone()),
+        // The JAGGED ASSERTION emission (the count win): raw W claim
+        // values in emission order (rs, then per group combo + dense
+        // members), checker-held against the deferred export.
+        TailEntry::new("jagged claim values", jag_w.clone()),
+    ];
+    let (n_tail, tail_schedule) = publish_tail(sb, &tail, |_, _| {});
     let n_query_pub: usize = 2 * levels.len() + levels.iter().map(|l| l.a_count).sum::<usize>();
     ChildRegion {
         pub_base,
         n_query_pub,
         n_tail,
+        tail_schedule,
         structure_claim_w,
         jag_w,
         jag_sig_w: mp_sig_w.clone(),
@@ -2234,35 +2277,9 @@ pub(super) fn emit_child_region(
             .iter()
             .map(|&(_, fin)| outs[trace.squeezes[fin][0]][0])
             .collect(),
-        b_zpartial_w: (0..64).map(|i| wv(ct.zp_v + i)).collect(),
+        b_zpartial_w: (0..Z_PARTIAL_WORDS).map(|i| wv(ct.zp_v + i)).collect(),
         mat_eval_w,
-        zskip: match &ct.zskip {
-            ZskipTapeRec::Rs { fin, .. } => ZskipWires::Rs(outs[trace.squeezes[*fin][0]][0]),
-            ZskipTapeRec::Ag {
-                seed_fins,
-                nonce_payload,
-                ..
-            } => {
-                let nonce_wi = stream
-                    .words
-                    .iter()
-                    .position(|w| {
-                        matches!(
-                            w,
-                            StreamWord::Bytes { payload, word: 0 }
-                                if *payload == *nonce_payload
-                        )
-                    })
-                    .expect("the r1 nonce rides one stream word");
-                ZskipWires::Ag {
-                    seed_w: [
-                        squeeze_word_wire(&outs, trace, seed_fins[0], 0),
-                        squeeze_word_wire(&outs, trace, seed_fins[1], 0),
-                    ],
-                    nonce_w: ww[nonce_wi].expect("the nonce payload word is wired"),
-                }
-            }
-        },
+        zskip: zskip_wires(&ct.zskip, &outs, trace, stream, &ww),
         pf: (pfslot, pf_w),
         child_pub_w: pub_w,
     }
@@ -2503,62 +2520,25 @@ fn emit_family_h_and_intake_boundary(
     zw: Wire,
     ow: Wire,
 ) -> (Wire, Wire) {
-    let macs = cs.macs;
-    let mrs = cs.mrs;
-    let mp_o = &ct.mp_o;
-    let w_rounds = &ct.w_rounds[..];
-    let inner_pd2 = &ct.inner_pd2;
-    let (shv_w, value_w, rdp_w, gamma_w) = walker_common::family_h_source_wires(
-        outs,
+    walker_common::emit_family_h_boundary(
+        sb,
+        cs,
         trace,
+        outs,
         wv,
         &ct.rs_recs,
         &ct.rs_gam_fins,
-        &mp_o.val_vs,
-    );
-    let (rsh_w, vrs_w) = emit_family_h(
-        sb,
-        cs.q.family.expect("family-H slot"),
-        cs.macs,
-        cs.fold_macs,
-        cs.spine,
-        cs.spine256,
-        cs.resid
-            .iter()
-            .find(|&&(key, _)| key == 701)
-            .expect("the child slots declare an F256 MAC slot")
-            .1,
-        1usize << cs.nu,
-        &shv_w,
-        &value_w,
-        &rdp_w,
-        gamma_w,
+        &ct.mp_o,
+        &ct.gammas_o,
+        &ct.w_rounds,
+        &ct.inner_pd2,
         pfslot,
         pf_w,
-        zw,
-        ow,
         vals,
         consts,
-    );
-    let mut pdh_w = zw;
-    for pd in &ct.gammas_o {
-        let gw = squeeze_word_wire(outs, trace, pd.fin, pd.squeeze_offset);
-        pdh_w = sb.gate(macs, &[pdh_w, gw, wv(pd.val_v)])[0];
-    }
-    let tgt_w = sb.gate(macs, &[rsh_w, ow, pdh_w])[0];
-    let mut runw = tgt_w;
-    for rr in w_rounds {
-        let rho_w = outs[trace.squeezes[rr.fin][0]][0];
-        runw = sb.gate(mrs, &[runw, wv(rr.g_v), wv(rr.g_v + 1), rho_w])[0];
-    }
-    let mut vgrp_w = zw;
-    for &vi in &mp_o.val_vs[256..] {
-        vgrp_w = sb.gate(macs, &[vgrp_w, ow, wv(vi)])[0];
-    }
-    let v_w = sb.gate(macs, &[vrs_w, ow, vgrp_w])[0];
-    let rhs_v_w = sb.gate(macs, &[zw, wv(inner_pd2.q_v), v_w])[0];
-    sb.connect(runw, rhs_v_w);
-    (tgt_w, runw)
+        zw,
+        ow,
+    )
 }
 
 /// ---- the ELEMENT PIOP rounds in-circuit (mixed children only) ----
@@ -2710,7 +2690,7 @@ fn emit_anchor_expect(
     let mut rinv_n2: Vec<F128> = rho_mrg_n.clone();
     let mut rinv_w: Vec<Wire> = rho_mrg_w.clone();
     let mut ghat = zw;
-    for j in 0..128 {
+    for j in 0..RS_SHAT_WORDS {
         if j > 0 {
             let mut lvl_w = Vec::with_capacity(m_mp2);
             for t2 in 0..m_mp2 {
@@ -2778,7 +2758,10 @@ fn emit_anchor_expect(
         let coeff = if si == 0 {
             ghat
         } else {
-            sb.gate(spine, &[zw, zw, zw, zw, zw, zw, mp_pws[128], ghat, zw])[3]
+            sb.gate(
+                spine,
+                &[zw, zw, zw, zw, zw, zw, mp_pws[RS_SHAT_WORDS], ghat, zw],
+            )[3]
         };
         let wd = sb.gate(spine, &[zw, zw, zw, zw, zw, zw, w_st, gdp[0], zw])[3];
         expect_w = sb.gate(spine, &[zw, zw, zw, expect_w, zw, zw, coeff, wd, zw])[3];
@@ -2876,7 +2859,7 @@ fn emit_anchor_expect(
             let o = sb.gate(alslot, &a_in);
             gdp = [o[0], o[1], o[2], o[3]];
         }
-        let coeff = sb.gate(macs, &[zw, mp_pws[256 + g_ix], e_at_w])[0];
+        let coeff = sb.gate(macs, &[zw, mp_pws[2 * RS_SHAT_WORDS + g_ix], e_at_w])[0];
         let wd = sb.gate(macs, &[zw, w_st, gdp[0]])[0];
         expect_w = sb.gate(macs, &[expect_w, coeff, wd])[0];
     }

--- a/crates/flock-prover/src/tower/fl_node.rs
+++ b/crates/flock-prover/src/tower/fl_node.rs
@@ -50,11 +50,11 @@ use crate::{
         check_child_region, check_fold_publics, check_jagged_fold_publics, emit_ag_point_binding,
         emit_child_region, emit_fold_region, emit_fs_chain_partitioned, emit_jagged_fold_region,
         emit_lagrange_lows, emit_recorded_pow_checks, env_acc_chain_base, env_app_base,
-        envelope_shape, flatten_ops, fold_region_ops, jagged_fold_region_ops,
-        labeled_bytes_payloads, live_element_input_from_rows, locate_and_pin_folds,
-        locate_and_pin_jagged_folds, merge_chain, native_chain, outer_lanes, outer_union,
-        outer_zc_ag, pack4, pack8, pad_envelope_counts, pcs_batch_for, replay_fold_endpoints,
-        replay_jagged_fold_endpoints, steady_reps, tower_fold_grinding,
+        envelope_shape, expected_child_tail_schedule, flatten_ops, fold_region_ops,
+        jagged_fold_region_ops, labeled_bytes_payloads, live_element_input_from_rows,
+        locate_and_pin_folds, locate_and_pin_jagged_folds, merge_chain, native_chain, outer_lanes,
+        outer_union, outer_zc_ag, pack4, pack8, pad_envelope_counts, pcs_batch_for,
+        replay_fold_endpoints, replay_jagged_fold_endpoints, steady_reps, tower_fold_grinding,
     },
     verifier::{verify_ligerito_union_circuit_ag_deferred, verify_ligerito_union_circuit_deferred},
 };
@@ -438,6 +438,11 @@ pub fn build_fl_node_k(cfg: TowerConfig, cps: &[&ChainProof]) -> FlNode {
                     &mut consts,
                 );
                 sb.end_island(isl);
+                assert_eq!(
+                    r.tail_schedule,
+                    expected_child_tail_schedule(t),
+                    "child {i}'s tail publishes on its declared schedule"
+                );
                 r
             })
             .collect();

--- a/crates/flock-prover/src/tower/mod.rs
+++ b/crates/flock-prover/src/tower/mod.rs
@@ -63,6 +63,7 @@ use crate::{
         chain::{MixedInner, native_chain},
         child_walker::{
             ChildSlots, ChildTape, ZskipTapeRec, ZskipWires, check_child_region, emit_child_region,
+            expected_child_tail_schedule,
         },
         config::{leaf_zc_ag, outer_union, outer_zc_ag, pcs_batch_for, tower_fold_grinding},
         envelope::{
@@ -115,6 +116,7 @@ use crate::{
         },
         real_walker::{
             RealRegion, RealTape, check_real_child_region, emit_family_h, emit_real_child_region,
+            expected_real_tail_schedule,
         },
         tape::{
             InnerPd, MpRec, OpenLevel, PdRec, PiopRec, RoundRec, parse_open_levels,

--- a/crates/flock-prover/src/tower/node.rs
+++ b/crates/flock-prover/src/tower/node.rs
@@ -54,11 +54,11 @@ use crate::{
         check_real_child_region, emit_ag_point_binding, emit_fold_region, emit_fs_chain,
         emit_fs_chain_partitioned, emit_jagged_fold_region, emit_lagrange_lows,
         emit_real_child_region, emit_recorded_pow_checks, env_acc_chain_base, env_acc_main_base,
-        env_app_base, env_pass_base, envelope_shape, flatten_ops, fold_region_ops,
-        jagged_fold_region_ops, labeled_bytes_payloads, leaf_boolean_lcs, leaf_boolean_mats,
-        live_element_input_from_rows, locate_and_pin_folds, locate_and_pin_jagged_folds,
-        merge_chain, outer_lanes, outer_union, outer_zc_ag, pack8, pad_envelope_counts,
-        payload_words, pcs_batch_for, read_acc_entry, replay_fold_endpoints,
+        env_app_base, env_pass_base, envelope_shape, expected_real_tail_schedule, flatten_ops,
+        fold_region_ops, jagged_fold_region_ops, labeled_bytes_payloads, leaf_boolean_lcs,
+        leaf_boolean_mats, live_element_input_from_rows, locate_and_pin_folds,
+        locate_and_pin_jagged_folds, merge_chain, outer_lanes, outer_union, outer_zc_ag, pack8,
+        pad_envelope_counts, payload_words, pcs_batch_for, read_acc_entry, replay_fold_endpoints,
         replay_jagged_fold_endpoints, steady_reps, tower_fold_grinding,
     },
 };
@@ -871,6 +871,11 @@ pub fn build_node_outer_app(
                 );
                 sb.end_island(isl);
                 mac_marks.push(sb.rows_in_slot(cs.macs));
+                assert_eq!(
+                    r.tail_schedule,
+                    expected_real_tail_schedule(rt),
+                    "the real child's tail publishes on its declared schedule"
+                );
                 r
             })
             .collect();

--- a/crates/flock-prover/src/tower/node.rs
+++ b/crates/flock-prover/src/tower/node.rs
@@ -874,7 +874,7 @@ pub fn build_node_outer_app(
                 assert_eq!(
                     r.tail_schedule,
                     expected_real_tail_schedule(rt),
-                    "the real child's tail publishes on its declared schedule"
+                    "real child {i}'s tail publishes on its declared schedule"
                 );
                 r
             })

--- a/crates/flock-prover/src/tower/real_walker.rs
+++ b/crates/flock-prover/src/tower/real_walker.rs
@@ -38,6 +38,12 @@ use crate::{
         level_sources, observed_f256, outer_union, pack8, parse_open_levels, payload_words,
         pin_recombination, query_phase_b3_rows, replay_ligerito_spine256, squeeze_word_wire,
         strat_scheds, walker_common,
+        walker_common::{
+            LBL_AG_R1_NONCE, LBL_AG_R1_POINT, LBL_AG_SKIP, LBL_ELEMENT_LC, LBL_ELEMENT_ZC,
+            LBL_FROBENIUS, LBL_LINCHECK, LBL_MERGED_OPEN, LBL_MULTIPOINT, LBL_PRODUCT_GKR,
+            LBL_RING_SWITCH, LBL_ZEROCHECK, RS_SHAT_WORDS, TailEntry, Z_PARTIAL_WORDS,
+            publish_tail, zskip_wires,
+        },
     },
 };
 
@@ -228,27 +234,27 @@ impl<'p> RealTape<'p> {
         let zc_l = match &lo.proof {
             MixedProof::Rs(_) => {
                 assert!(
-                    find(b"flock-ag-skip-v1").is_empty(),
+                    find(LBL_AG_SKIP).is_empty(),
                     "an RS tape carries no AG-skip region"
                 );
-                find(b"flock-zerocheck-v0")
+                find(LBL_ZEROCHECK)
             }
             MixedProof::Ag(_) => {
                 assert!(
-                    find(b"flock-zerocheck-v0").is_empty(),
+                    find(LBL_ZEROCHECK).is_empty(),
                     "an AG tape carries no RS zerocheck region"
                 );
-                find(b"flock-ag-skip-v1")
+                find(LBL_AG_SKIP)
             }
         };
-        let lc_l = find(b"flock-lincheck-v0");
-        let elzc_l = find(b"flock-element-union-zc-v0");
-        let el_l = find(b"flock-element-union-lc-v0");
-        let gkr_l = find(b"flock-product-gkr-batched-v0");
-        let mo_l = find(b"flock-merged-open-v1");
-        let rs_l = find(b"flock-ring-switch-v0");
-        let mp_l = find(b"flock-multipoint-twisted-v1");
-        let fa_l = find(b"flock-frobenius-assist-v0");
+        let lc_l = find(LBL_LINCHECK);
+        let elzc_l = find(LBL_ELEMENT_ZC);
+        let el_l = find(LBL_ELEMENT_LC);
+        let gkr_l = find(LBL_PRODUCT_GKR);
+        let mo_l = find(LBL_MERGED_OPEN);
+        let rs_l = find(LBL_RING_SWITCH);
+        let mp_l = find(LBL_MULTIPOINT);
+        let fa_l = find(LBL_FROBENIUS);
         assert_eq!(
             (
                 zc_l.len(),
@@ -310,7 +316,7 @@ impl<'p> RealTape<'p> {
         assert!(n_p > 0, "the mixed inner groups its pd claims");
         assert_eq!(
             mp_i.val_vs.len(),
-            256 + n_p,
+            2 * RS_SHAT_WORDS + n_p,
             "T0 spans the RS dual values then the P group values"
         );
         let gamma_mp = chals[mp_i.gamma_ch];
@@ -656,14 +662,17 @@ fn parse_rs_regions_and_two_halves(
         let mut recs: Vec<(usize, usize, usize)> = Vec::new();
         for k in 0..2 {
             assert!(
-                matches!(&ops[i2], Op::Label(l) if l.as_slice() == b"flock-ring-switch-v0"),
+                matches!(&ops[i2], Op::Label(l) if l.as_slice() == LBL_RING_SWITCH),
                 "rs region {k}"
             );
             i2 += 1;
-            assert!(matches!(ops[i2], Op::ObserveSlice(128)), "s_hat_v slice");
+            assert!(
+                matches!(ops[i2], Op::ObserveSlice(RS_SHAT_WORDS)),
+                "s_hat_v slice"
+            );
             let (sv, _) = vc_at(i2);
             assert_eq!(
-                &vals_rec[sv..sv + 128],
+                &vals_rec[sv..sv + RS_SHAT_WORDS],
                 &lo.proof.pcs_open().ring_switches[k].s_hat_v[..],
                 "s_hat_v {k} on the stream"
             );
@@ -706,7 +715,7 @@ fn parse_rs_regions_and_two_halves(
         let mut rs_half = F128::ZERO;
         let mut coeffs: Vec<Vec<F128>> = Vec::new();
         for (k, &(sv, _, rc)) in rs_recs2.iter().enumerate() {
-            let shv = &vals_rec[sv..sv + 128];
+            let shv = &vals_rec[sv..sv + RS_SHAT_WORDS];
             let rdp: Vec<F128> = (0..7).map(|j| chals[rc + j]).collect();
             let eq = build_eq(&rdp);
             rs_half += gs[k] * inner_product(&tensor_algebra_transpose(shv), &eq);
@@ -970,7 +979,7 @@ fn parse_anchor_boolean_replica(
                 assert!(matches!(ops[i2], Op::ObserveSlice(64)), "ag round1_c");
                 i2 += 1;
                 assert!(
-                    matches!(&ops[i2], Op::Label(l) if l.as_slice() == b"flock-ag-skip-r1-point"),
+                    matches!(&ops[i2], Op::Label(l) if l.as_slice() == LBL_AG_R1_POINT),
                     "ag r1 seed label"
                 );
                 i2 += 1;
@@ -983,7 +992,7 @@ fn parse_anchor_boolean_replica(
                 let seed_fin1 = fin_at(i2);
                 i2 += 1;
                 assert!(
-                    matches!(&ops[i2], Op::Label(l) if l.as_slice() == b"flock-ag-skip-r1-nonce"),
+                    matches!(&ops[i2], Op::Label(l) if l.as_slice() == LBL_AG_R1_NONCE),
                     "ag r1 nonce label"
                 );
                 i2 += 1;
@@ -1049,7 +1058,10 @@ fn parse_anchor_boolean_replica(
             lc_r.push((vc_at(i2).0, vc_at(squeeze_i).1, fin_at(squeeze_i)));
             i2 = squeeze_i + 1;
         }
-        assert!(matches!(ops[i2], Op::ObserveSlice(64)), "z_partial slice");
+        assert!(
+            matches!(ops[i2], Op::ObserveSlice(Z_PARTIAL_WORDS)),
+            "z_partial slice"
+        );
         let (zp, _) = vc_at(i2);
         (zc_r, zskip, outer, lc_alpha, betas, zcf, lc_r, zp)
     };
@@ -1449,10 +1461,55 @@ fn parse_anchor_boolean_replica(
 /// What one emitted REAL child region hands back: where its public block
 /// starts, the walk counts, and the assertion-emission wires the 2→1 merge
 /// node CONNECTS the fold region's claim words to — all three families.
+/// The real tail's EXPECTED publish schedule, every width an expression
+/// over the TAPE's own geometry and the proof object — the same
+/// formulas the checker's positional walk consumes by — the independent
+/// reference the emitted table ([`RealRegion::tail_schedule`]) is held
+/// against at every build.
+pub(super) fn expected_real_tail_schedule(rt: &RealTape<'_>) -> Vec<(&'static str, usize)> {
+    let lc_i = rt.lo.proof.boolean_lincheck();
+    let n_mat = 1
+        + rt.lc_rounds_b.len()
+        + 2 * lc_i.matrix_evals.len()
+        + rt.mat_assert.x_inner_rest.len()
+        + rt.n_log_i
+        + 2 * rt.betas_b.len()
+        + Z_PARTIAL_WORDS
+        + 1;
+    let n_ela = 1
+        + rt.piop_i.zc_rounds.len()
+        + rt.piop_i.lc_rounds.len()
+        + 3
+        + 2 * rt.el_assert.evals.len();
+    let jag_vals = rt.jag.rs.len()
+        + rt.jag
+            .groups
+            .iter()
+            .map(|(combo, dense)| usize::from(combo.is_some()) + dense.len())
+            .sum::<usize>();
+    vec![
+        ("spine t_final", 2),
+        ("intake target", 1),
+        ("intake running", 1),
+        ("residual accs", 2 * rt.levels.len() * rt.yr_len),
+        ("residual inner", 2),
+        ("sigma value", 1),
+        ("sigma point", rt.mu_i),
+        ("element zc+lc ends", 2),
+        ("anchor end", 1),
+        ("matrix assertion publics", n_mat),
+        ("element assertion publics", n_ela),
+        ("jagged claim values", jag_vals),
+    ]
+}
+
 pub(super) struct RealRegion {
     pub(super) pub_base: usize,
     pub(super) n_query_pub: usize,
     pub(super) n_tail: usize,
+    /// The published tail's `(name, width)` schedule, as emitted — held
+    /// against [`expected_real_tail_schedule`] at every build.
+    pub(super) tail_schedule: Vec<(&'static str, usize)>,
     n_mat_pub: usize,
     n_ela_pub: usize,
     /// Labeled `public_len` checkpoints through the emission — the publics
@@ -1905,7 +1962,7 @@ pub(super) fn emit_real_child_region(
         sb, cs, rt, &outs, &wv, &mlv_pw, &lc_pw, el_alpha_w, va_w, vb_w, el_lcw, pfslot, pf_w, zw,
         ow, vals, &mut cen,
     );
-    let pub_base = emit_publishes_in_swap_order(
+    let (pub_base, n_tail, tail_schedule) = emit_publishes_in_swap_order(
         sb,
         cs,
         &to_publish,
@@ -1922,21 +1979,11 @@ pub(super) fn emit_real_child_region(
         anc_w,
         &mat_pub,
         &ela_pub,
+        &jag_w,
         &mut cen,
     );
-    emit_jagged_assertion(sb, cs, &jag_w, &mut cen);
 
     let n_query_pub: usize = 2 * levels.len() + levels.iter().map(|l| l.a_count).sum::<usize>();
-    let n_tail = 4
-        + 2 * levels.len() * rt.yr_len
-        + 2
-        + 1
-        + rt.mu_i
-        + 2
-        + 1
-        + mat_pub.len()
-        + ela_pub.len()
-        + jag_w.len();
     let el_zc_rho_w: Vec<Wire> = piop_i
         .zc_rounds
         .iter()
@@ -1969,39 +2016,13 @@ pub(super) fn emit_real_child_region(
         pub_base,
         n_query_pub,
         n_tail,
+        tail_schedule,
         n_mat_pub: mat_pub.len(),
         census: cen,
         jag_w,
         jag_sig_w: mp_sig_w.clone(),
         jag_row_w,
-        zskip: match &rt.zskip {
-            ZskipTapeRec::Rs { fin, .. } => ZskipWires::Rs(outs[trace.squeezes[*fin][0]][0]),
-            ZskipTapeRec::Ag {
-                seed_fins,
-                nonce_payload,
-                ..
-            } => {
-                let nonce_wi = rt
-                    .stream
-                    .words
-                    .iter()
-                    .position(|w| {
-                        matches!(
-                            w,
-                            StreamWord::Bytes { payload, word: 0 }
-                                if *payload == *nonce_payload
-                        )
-                    })
-                    .expect("the r1 nonce rides one stream word");
-                ZskipWires::Ag {
-                    seed_w: [
-                        squeeze_word_wire(&outs, trace, seed_fins[0], 0),
-                        squeeze_word_wire(&outs, trace, seed_fins[1], 0),
-                    ],
-                    nonce_w: ww[nonce_wi].expect("the nonce payload word is wired"),
-                }
-            }
-        },
+        zskip: zskip_wires(&rt.zskip, &outs, trace, &rt.stream, &ww),
         n_ela_pub: ela_pub.len(),
         structure_claim_w,
         el_zc_rho_w,
@@ -2121,7 +2142,6 @@ fn emit_intake_spine_residual(
     let zw = sb.public_input();
     vals.push(F128::ONE);
     let ow = sb.public_input();
-    let mrslot = cs.mrs;
     let spine256 = cs.spine256;
     // The assert-zero anchor: a dedicated zero public NO gate consumes,
     // so the zero-delta outputs connected into its class add no
@@ -2177,57 +2197,25 @@ fn emit_intake_spine_residual(
     // The complete family-H relation.  All inputs below are already bound
     // transcript or proof wires; no target/V advice and no native checker are
     // part of the recursive statement anymore.
-    let (shv_w, value_w, rdp_w, gamma_w) = walker_common::family_h_source_wires(
-        outs,
+    let (tgt_w, runw) = walker_common::emit_family_h_boundary(
+        sb,
+        cs,
         trace,
+        outs,
         &wv,
         &rt.rs_recs,
         &rt.rs_gam_fins,
-        &mp_i.val_vs,
-    );
-    let (rsh_w, vrs_w) = emit_family_h(
-        sb,
-        cs.q.family.expect("family-H slot"),
-        cs.macs,
-        cs.fold_macs,
-        cs.spine,
-        cs.spine256,
-        cs.resid
-            .iter()
-            .find(|&&(key, _)| key == 701)
-            .expect("the child slots declare an F256 MAC slot")
-            .1,
-        1usize << cs.nu,
-        &shv_w,
-        &value_w,
-        &rdp_w,
-        gamma_w,
+        mp_i,
+        gammas_i,
+        w_rounds,
+        inner_pd_i,
         pfslot,
         pf_w,
-        zw,
-        ow,
         vals,
         consts,
+        zw,
+        ow,
     );
-
-    let mut pdh_w = zw;
-    for pd in gammas_i {
-        let gw = squeeze_word_wire(outs, trace, pd.fin, pd.squeeze_offset);
-        pdh_w = sb.gate(cs.macs, &[pdh_w, gw, wv(pd.val_v)])[0];
-    }
-    let tgt_w = sb.gate(cs.macs, &[rsh_w, ow, pdh_w])[0];
-    let mut runw = tgt_w;
-    for rr in w_rounds {
-        let r_w = outs[trace.squeezes[rr.fin][0]][0];
-        runw = sb.gate(mrslot, &[runw, wv(rr.g_v), wv(rr.g_v + 1), r_w])[0];
-    }
-    let mut vgrp_w = zw;
-    for &vi in &mp_i.val_vs[256..] {
-        vgrp_w = sb.gate(cs.macs, &[vgrp_w, ow, wv(vi)])[0];
-    }
-    let v_w = sb.gate(cs.macs, &[vrs_w, ow, vgrp_w])[0];
-    let rhs_v_w = sb.gate(cs.macs, &[zw, wv(inner_pd_i.q_v), v_w])[0];
-    sb.connect(runw, rhs_v_w);
 
     cen.push((
         "family-H + merged boundary",
@@ -2556,7 +2544,7 @@ fn emit_anchor_expect(
     let mut rinv_n2: Vec<F128> = rho_mrg_n.clone();
     let mut rinv_w: Vec<Wire> = rho_mrg_w.clone();
     let mut ghat = zw;
-    for j in 0..128 {
+    for j in 0..RS_SHAT_WORDS {
         if j > 0 {
             let mut lvl_w = Vec::with_capacity(m_mp2);
             for t3 in 0..m_mp2 {
@@ -2623,7 +2611,10 @@ fn emit_anchor_expect(
         let coeff = if si == 0 {
             ghat
         } else {
-            sb.gate(spine, &[zw, zw, zw, zw, zw, zw, mp_pws[128], ghat, zw])[3]
+            sb.gate(
+                spine,
+                &[zw, zw, zw, zw, zw, zw, mp_pws[RS_SHAT_WORDS], ghat, zw],
+            )[3]
         };
         let wd = sb.gate(spine, &[zw, zw, zw, zw, zw, zw, w_st, gdp[0], zw])[3];
         expect_w = sb.gate(spine, &[zw, zw, zw, expect_w, zw, zw, coeff, wd, zw])[3];
@@ -2718,7 +2709,7 @@ fn emit_anchor_expect(
             let o = sb.gate(alslot, &a_in);
             gdp = [o[0], o[1], o[2], o[3]];
         }
-        let coeff = sb.gate(macs, &[zw, mp_pws[256 + g_ix], e_at_w])[0];
+        let coeff = sb.gate(macs, &[zw, mp_pws[2 * RS_SHAT_WORDS + g_ix], e_at_w])[0];
         let wd = sb.gate(macs, &[zw, w_st, gdp[0]])[0];
         expect_w = sb.gate(macs, &[expect_w, coeff, wd])[0];
     }
@@ -2817,7 +2808,7 @@ fn emit_assertion_families(
         mat_pub.push(mlv_pw[1 + j].1);
     }
     let mat_rr_w: Vec<Wire> = lc_pw.iter().map(|&(_, w)| w).collect();
-    let zpartial_ws: Vec<Wire> = (0..64).map(|i| wv(rt.zp_v + i)).collect();
+    let zpartial_ws: Vec<Wire> = (0..Z_PARTIAL_WORDS).map(|i| wv(rt.zp_v + i)).collect();
     let va_b = wv(rt.zc_finals_v);
     let vb_b = wv(rt.zc_finals_v + 1);
     let mut lcb_w = sb.gate(cs.macs, &[vb_b, bl_alpha_w, va_b])[0];
@@ -2916,7 +2907,14 @@ fn emit_assertion_families(
     }
 }
 
-/// the publishes, in the swap's recorded order
+/// the publishes, in the swap's recorded order: the query block, then
+/// THE TAIL SCHEDULE — the table below IS the real walker's published
+/// wire format (a DIFFERENT order from the child's, deliberately),
+/// `check_real_child_region`'s independent positional walk is its
+/// backstop, and the tape pin holds its `(name, width)` list. The jagged
+/// block (raw W claim values in emission order — rs, then per group
+/// combo + dense members, the fresh-claim surfaces a merge fold connects
+/// to) closes the tail.
 #[allow(clippy::too_many_arguments)]
 fn emit_publishes_in_swap_order(
     sb: &mut ShapeBuilder,
@@ -2935,8 +2933,9 @@ fn emit_publishes_in_swap_order(
     anc_w: Wire,
     mat_pub: &[Wire],
     ela_pub: &[Wire],
+    jag_w: &[Wire],
     cen: &mut Vec<(&'static str, usize, usize)>,
-) -> usize {
+) -> (usize, usize, Vec<(&'static str, usize)>) {
     let pub_base = sb.public_len();
     for a_wires in to_publish {
         for w in a_wires {
@@ -2952,71 +2951,33 @@ fn emit_publishes_in_swap_order(
         sb.public_len(),
         sb.rows_in_slot(cs.macs),
     ));
-    sb.publish(t_final[0]);
-    sb.publish(t_final[1]);
-    sb.publish(tgt_w);
-    sb.publish(runw);
-    for accs in resid_pub {
-        for w in accs {
-            sb.publish(w[0]);
-            sb.publish(w[1]);
-        }
-    }
-    cen.push((
-        "TAIL: chain ends + residual accs",
-        sb.public_len(),
-        sb.rows_in_slot(cs.macs),
-    ));
-    sb.publish(inner_w[0]);
-    sb.publish(inner_w[1]);
-    sb.publish(sig_w);
-    for w in pt_w {
-        sb.publish(*w);
-    }
-    cen.push((
-        "TAIL: sigma + GKR point",
-        sb.public_len(),
-        sb.rows_in_slot(cs.macs),
-    ));
-    sb.publish(el_zr);
-    sb.publish(el_lcw);
-    sb.publish(anc_w);
-    for w in mat_pub {
-        sb.publish(*w);
-    }
-    for w in ela_pub {
-        sb.publish(*w);
-    }
-    cen.push((
-        "TAIL: el ends + assertion publics",
-        sb.public_len(),
-        sb.rows_in_slot(cs.macs),
-    ));
+    let tail = [
+        TailEntry::new("spine t_final", t_final.to_vec()),
+        TailEntry::new("intake target", vec![tgt_w]),
+        TailEntry::new("intake running", vec![runw]),
+        TailEntry::new(
+            "residual accs",
+            resid_pub.iter().flatten().flatten().copied().collect(),
+        )
+        .with_census("TAIL: chain ends + residual accs"),
+        TailEntry::new("residual inner", inner_w.to_vec()),
+        TailEntry::new("sigma value", vec![sig_w]),
+        TailEntry::new("sigma point", pt_w.to_vec()).with_census("TAIL: sigma + GKR point"),
+        TailEntry::new("element zc+lc ends", vec![el_zr, el_lcw]),
+        TailEntry::new("anchor end", vec![anc_w]),
+        TailEntry::new("matrix assertion publics", mat_pub.to_vec()),
+        TailEntry::new("element assertion publics", ela_pub.to_vec())
+            .with_census("TAIL: el ends + assertion publics"),
+        TailEntry::new("jagged claim values", jag_w.to_vec())
+            .with_census("TAIL: jagged claim values"),
+    ];
     // Family H is now internal arithmetic.  Its source words are already
     // bound where they enter the transcript/proof stream, so no duplicate
     // public re-exposure or checker-only advice remains.
-    pub_base
-}
-
-/// the JAGGED ASSERTION emission (the count win)
-///
-/// Raw W claim values in emission order (rs, then per group combo +
-/// dense members), checker-held against the deferred export — the
-/// fresh-claim surfaces a merge fold connects to.
-fn emit_jagged_assertion(
-    sb: &mut ShapeBuilder,
-    cs: &ChildSlots,
-    jag_w: &[Wire],
-    cen: &mut Vec<(&'static str, usize, usize)>,
-) {
-    for w in jag_w {
-        sb.publish(*w);
-    }
-    cen.push((
-        "TAIL: jagged claim values",
-        sb.public_len(),
-        sb.rows_in_slot(cs.macs),
-    ));
+    let (n_tail, tail_schedule) = publish_tail(sb, &tail, |sb, label| {
+        cen.push((label, sb.public_len(), sb.rows_in_slot(cs.macs)));
+    });
+    (pub_base, n_tail, tail_schedule)
 }
 
 /// Walk one emitted REAL child region's public block and hold every
@@ -3158,7 +3119,7 @@ pub(super) fn check_real_child_region(public: &[F128], rt: &RealTape<'_>, r: &Re
     for (j, &z) in rt.mat_assert.z_partial.iter().enumerate() {
         assert_eq!(public[mq + j], z, "z_partial {j} published");
     }
-    mq += 64;
+    mq += Z_PARTIAL_WORDS;
     assert_eq!(
         public[mq], rt.mat_assert.target,
         "the in-circuit boolean lc replay ends at the assertion's target"

--- a/crates/flock-prover/src/tower/real_walker.rs
+++ b/crates/flock-prover/src/tower/real_walker.rs
@@ -1458,9 +1458,6 @@ fn parse_anchor_boolean_replica(
     }
 }
 
-/// What one emitted REAL child region hands back: where its public block
-/// starts, the walk counts, and the assertion-emission wires the 2→1 merge
-/// node CONNECTS the fold region's claim words to — all three families.
 /// The real tail's EXPECTED publish schedule, every width an expression
 /// over the TAPE's own geometry and the proof object — the same
 /// formulas the checker's positional walk consumes by — the independent
@@ -1503,6 +1500,9 @@ pub(super) fn expected_real_tail_schedule(rt: &RealTape<'_>) -> Vec<(&'static st
     ]
 }
 
+/// What one emitted REAL child region hands back: where its public block
+/// starts, the walk counts, and the assertion-emission wires the 2→1 merge
+/// node CONNECTS the fold region's claim words to — all three families.
 pub(super) struct RealRegion {
     pub(super) pub_base: usize,
     pub(super) n_query_pub: usize,
@@ -3119,7 +3119,10 @@ pub(super) fn check_real_child_region(public: &[F128], rt: &RealTape<'_>, r: &Re
     for (j, &z) in rt.mat_assert.z_partial.iter().enumerate() {
         assert_eq!(public[mq + j], z, "z_partial {j} published");
     }
-    mq += Z_PARTIAL_WORDS;
+    // The checker's offsets stay LITERAL on purpose: this walk is the
+    // backstop that falsifies a wrong schedule constant, so it must not
+    // share one with the emitter.
+    mq += 64;
     assert_eq!(
         public[mq], rt.mat_assert.target,
         "the in-circuit boolean lc replay ends at the assertion's target"

--- a/crates/flock-prover/src/tower/tape.rs
+++ b/crates/flock-prover/src/tower/tape.rs
@@ -2,7 +2,16 @@ use std::mem::take;
 
 use flock_transcript::transcript_record::{TranscriptOp, TranscriptOp as Op};
 
-use crate::{r1cs_hashes::fs_chain::FsChainTrace, tower::Wire};
+use crate::{
+    r1cs_hashes::fs_chain::FsChainTrace,
+    tower::{
+        Wire,
+        walker_common::{
+            LBL_ELEMENT_LC, LBL_ELEMENT_ZC, LBL_FROBENIUS, LBL_INNER_PD, LBL_MERGED_OPEN,
+            LBL_MULTIPOINT, LBL_OPEN_BASIS, LBL_RING_SWITCH,
+        },
+    },
+};
 
 /// One packed-direct claim on the tape: its absorbed VALUE and gamma. The
 /// POINT is not on the stream since merged-open v1 — it is transcript-derived
@@ -203,9 +212,7 @@ pub(super) fn parse_open_levels(
     // enter the tape at the wrong level.
     let label = ops
         .iter()
-        .position(
-            |o| matches!(o, Op::Label(l) if l.as_slice() == b"flock-ligerito-basis-f256-split-v0"),
-        )
+        .position(|o| matches!(o, Op::Label(l) if l.as_slice() == LBL_OPEN_BASIS))
         .expect("Ligerito opening label");
     assert!(
         matches!(ops.get(label + 1), Some(Op::ObserveScalar)),
@@ -236,7 +243,7 @@ pub(super) fn parse_open_levels(
     let mut intake_rs = 0usize;
     let mut intake_pd_vals: Vec<usize> = Vec::new();
     while cur.i < start {
-        if matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == b"flock-element-union-zc-v0") {
+        if matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == LBL_ELEMENT_ZC) {
             cur.bump();
             cur.skip_pows();
             let (tau_fin, tau_ch, tau_len) = match ops[cur.i] {
@@ -263,7 +270,7 @@ pub(super) fn parse_open_levels(
             cur.expect_obs_scalar(); // eb
             cur.expect_obs_scalar(); // ec
             assert!(
-                matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == b"flock-element-union-lc-v0"),
+                matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == LBL_ELEMENT_LC),
                 "lc label"
             );
             cur.bump();
@@ -297,7 +304,7 @@ pub(super) fn parse_open_levels(
             });
             continue;
         }
-        if matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == b"flock-merged-open-v1") {
+        if matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == LBL_MERGED_OPEN) {
             in_pd = true;
             intake_rs = 0;
             intake_pd_vals.clear();
@@ -308,7 +315,7 @@ pub(super) fn parse_open_levels(
             // Ring-switched claims front the intake on boolean-bearing
             // tapes: [label, s_hat_v slice, r_dprime slice] each, then the
             // bare gamma squeezes.
-            if matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == b"flock-ring-switch-v0") {
+            if matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == LBL_RING_SWITCH) {
                 intake_rs += 1;
                 cur.bump(); // label
                 cur.bump(); // s_hat_v slice
@@ -370,7 +377,7 @@ pub(super) fn parse_open_levels(
             }
             continue;
         }
-        if matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == b"flock-multipoint-twisted-v1") {
+        if matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == LBL_MULTIPOINT) {
             // The multipoint region: P group-value absorbs, the batching
             // gamma, m two-product rounds, then the anchor's label + v +
             // 2(m + 1) rounds. Each loop terminates on the next label /
@@ -400,7 +407,7 @@ pub(super) fn parse_open_levels(
                 cur.bump();
             }
             assert!(
-                matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == b"flock-frobenius-assist-v0"),
+                matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == LBL_FROBENIUS),
                 "op {}: expected the anchor label, got {:?}",
                 cur.i,
                 ops[cur.i]
@@ -432,7 +439,7 @@ pub(super) fn parse_open_levels(
             });
             continue;
         }
-        if matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == b"flock-pcs-packed-direct-v0") {
+        if matches!(&ops[cur.i], Op::Label(l) if l.as_slice() == LBL_INNER_PD) {
             cur.bump();
             let q_v = cur.v;
             cur.expect_obs_scalar(); // q_eval

--- a/crates/flock-prover/src/tower/walker_common.rs
+++ b/crates/flock-prover/src/tower/walker_common.rs
@@ -15,15 +15,17 @@ use flock_core::{
         univariate_skip_optimized::{medium_challenges_ghash, small_challenges_ghash},
     },
 };
-use flock_transcript::transcript_record::{TranscriptOp as Op, TranscriptShape};
+use flock_transcript::transcript_record::{
+    Stream, StreamWord, TranscriptOp as Op, TranscriptShape,
+};
 
 use crate::{
     r1cs_hashes::fs_chain::FsChainTrace,
     tower::{
         ChildSlots, F128, GkrLayerRec, GkrRec, InnerPd, Lvl, MergedChain, MixedProof, MpRec,
-        OpenLevel, RoundRec, ShapeBuilder, Wire, ZskipTapeRec, assert_chain_replays,
-        duplex_row_count_model, emit_spine256, level_query_phase_b3_rows, merge_chain,
-        squeeze_word_wire,
+        OpenLevel, PdRec, RoundRec, ShapeBuilder, Wire, ZskipTapeRec, ZskipWires,
+        assert_chain_replays, duplex_row_count_model, emit_family_h, emit_spine256,
+        level_query_phase_b3_rows, merge_chain, squeeze_word_wire,
     },
 };
 
@@ -329,8 +331,9 @@ pub(super) fn census_levels_and_chain_rows(
 /// anchor's claimed v (a copy constraint), then the anchor's own rounds
 /// folding that v to the endpoint the expect consumes — the squeezes are
 /// the sigma wires. The gamma-power wires are KEPT: the anchor expect
-/// consumes mp_pws[j] (j < 128) for ĝ, mp_pws[128] for the second RS
-/// statement, and mp_pws[256 + k] for the P group coefficients. BOTH
+/// consumes `mp_pws[j]` (`j < RS_SHAT_WORDS`) for ĝ,
+/// `mp_pws[RS_SHAT_WORDS]` for the second RS statement, and
+/// `mp_pws[2 * RS_SHAT_WORDS + k]` for the P group coefficients. BOTH
 /// walkers must emit this exact intake.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn emit_multipoint_intake(
@@ -599,6 +602,208 @@ pub(super) fn baked_inner_t_vals(zskip: &ZskipTapeRec) -> Vec<F128> {
         "the seven baked inner constants"
     );
     t_vals_b
+}
+
+// ---- THE REGION-LABEL VOCABULARY ----
+// Every transcript region label the walkers and the tape parser locate
+// against, one name per label — matching the protocol's own absorb sites
+// in flock-core byte for byte. The REGION ORDER contract lives at the two
+// label maps (`child_walker::parse_label_map` and `RealTape::new`),
+// identical on both walkers: [zerocheck / AG skip | lincheck | element zc
+// | element lc | product GKR | merged open | ring switch | multipoint |
+// frobenius assist], with the opening-basis and inner packed-direct
+// labels inside the open phase (`tape::parse_open_levels`).
+pub(super) const LBL_ZEROCHECK: &[u8] = b"flock-zerocheck-v0";
+pub(super) const LBL_AG_SKIP: &[u8] = b"flock-ag-skip-v1";
+pub(super) const LBL_AG_R1_POINT: &[u8] = b"flock-ag-skip-r1-point";
+pub(super) const LBL_AG_R1_NONCE: &[u8] = b"flock-ag-skip-r1-nonce";
+pub(super) const LBL_LINCHECK: &[u8] = b"flock-lincheck-v0";
+pub(super) const LBL_ELEMENT_ZC: &[u8] = b"flock-element-union-zc-v0";
+pub(super) const LBL_ELEMENT_LC: &[u8] = b"flock-element-union-lc-v0";
+pub(super) const LBL_PRODUCT_GKR: &[u8] = b"flock-product-gkr-batched-v0";
+pub(super) const LBL_MERGED_OPEN: &[u8] = b"flock-merged-open-v1";
+pub(super) const LBL_RING_SWITCH: &[u8] = b"flock-ring-switch-v0";
+pub(super) const LBL_MULTIPOINT: &[u8] = b"flock-multipoint-twisted-v1";
+pub(super) const LBL_FROBENIUS: &[u8] = b"flock-frobenius-assist-v0";
+pub(super) const LBL_OPEN_BASIS: &[u8] = b"flock-ligerito-basis-f256-split-v0";
+pub(super) const LBL_INNER_PD: &[u8] = b"flock-pcs-packed-direct-v0";
+
+/// The boolean zerocheck's absorbed `z_partial` slice, in words. The
+/// checker's matrix block and the assertion publics count by it — BOTH
+/// walkers locate and re-emit exactly this many words.
+pub(super) const Z_PARTIAL_WORDS: usize = 64;
+
+/// One ring-switch claim's `s_hat` width, in words (the F128 basis).
+/// The multipoint gamma-power schedule spans `2 * RS_SHAT_WORDS` RS
+/// powers before the P group coefficients — the R=2+P schedule (see
+/// [`emit_multipoint_intake`]'s doc); BOTH walkers pin the same span.
+pub(super) const RS_SHAT_WORDS: usize = 128;
+
+/// One block of a walker's published TAIL: its name and the wires it
+/// publishes, in order. A walker's tail is a `Vec<TailEntry>` — THE
+/// PUBLISH SCHEDULE AS DATA: [`publish_tail`] iterates it, `n_tail` is
+/// its width sum (never a hand-maintained closed form), and the schedule
+/// `(name, width)` list lands in the region output so the tape-pin tests
+/// hold it against independent width expressions. The two walkers keep
+/// SEPARATE tables (their publish orders differ deliberately), and the
+/// `check_*` walks stay positionally independent of the table — the
+/// checker re-deriving every offset by hand is the soundness backstop
+/// that falsifies a wrong table.
+pub(super) struct TailEntry {
+    pub(super) name: &'static str,
+    pub(super) wires: Vec<Wire>,
+    /// A census checkpoint recorded after this block (the REAL walker's
+    /// bench instrumentation; `None` everywhere on the child).
+    pub(super) census_after: Option<&'static str>,
+}
+
+impl TailEntry {
+    pub(super) fn new(name: &'static str, wires: Vec<Wire>) -> TailEntry {
+        TailEntry {
+            name,
+            wires,
+            census_after: None,
+        }
+    }
+    pub(super) fn with_census(mut self, label: &'static str) -> TailEntry {
+        self.census_after = Some(label);
+        self
+    }
+}
+
+/// Publish a walker's tail per its schedule. Returns `(n_tail, schedule)`
+/// — the width sum and the `(name, width)` list the region exports for
+/// the tape pins.
+pub(super) fn publish_tail(
+    sb: &mut ShapeBuilder,
+    entries: &[TailEntry],
+    mut checkpoint: impl FnMut(&mut ShapeBuilder, &'static str),
+) -> (usize, Vec<(&'static str, usize)>) {
+    let mut schedule = Vec::with_capacity(entries.len());
+    for e in entries {
+        for w in &e.wires {
+            sb.publish(*w);
+        }
+        schedule.push((e.name, e.wires.len()));
+        if let Some(label) = e.census_after {
+            checkpoint(sb, label);
+        }
+    }
+    (schedule.iter().map(|&(_, n)| n).sum(), schedule)
+}
+
+/// Family-H plus the merged intake BOUNDARY, in-circuit: the complete
+/// family-H relation over the RS sources, the packed-direct gamma chain,
+/// the intake TARGET (`rsh + pd`), the W-rounds fold of the target to
+/// RUNNING, and the closure `running == q_eval · (v_rs + v_grp)` as a
+/// copy constraint. All inputs are already bound transcript or proof
+/// wires — no target/V advice and no native checker are part of the
+/// recursive statement. BOTH walkers must emit this exact block. Returns
+/// `(tgt_w, runw)`.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn emit_family_h_boundary(
+    sb: &mut ShapeBuilder,
+    cs: &ChildSlots,
+    trace: &FsChainTrace,
+    outs: &[Vec<Wire>],
+    wv: &impl Fn(usize) -> Wire,
+    rs_recs: &[(usize, usize, usize)],
+    rs_gam_fins: &[(usize, usize)],
+    mp: &MpRec,
+    gammas: &[PdRec],
+    w_rounds: &[RoundRec],
+    inner_pd: &InnerPd,
+    pfslot: SlotId,
+    pf_w: usize,
+    vals: &mut Vec<F128>,
+    consts: &mut Vec<(F128, Wire)>,
+    zw: Wire,
+    ow: Wire,
+) -> (Wire, Wire) {
+    let (shv_w, value_w, rdp_w, gamma_w) =
+        family_h_source_wires(outs, trace, wv, rs_recs, rs_gam_fins, &mp.val_vs);
+    let (rsh_w, vrs_w) = emit_family_h(
+        sb,
+        cs.q.family.expect("family-H slot"),
+        cs.macs,
+        cs.fold_macs,
+        cs.spine,
+        cs.spine256,
+        cs.resid
+            .iter()
+            .find(|&&(key, _)| key == 701)
+            .expect("the child slots declare an F256 MAC slot")
+            .1,
+        1usize << cs.nu,
+        &shv_w,
+        &value_w,
+        &rdp_w,
+        gamma_w,
+        pfslot,
+        pf_w,
+        zw,
+        ow,
+        vals,
+        consts,
+    );
+    let mut pdh_w = zw;
+    for pd in gammas {
+        let gw = squeeze_word_wire(outs, trace, pd.fin, pd.squeeze_offset);
+        pdh_w = sb.gate(cs.macs, &[pdh_w, gw, wv(pd.val_v)])[0];
+    }
+    let tgt_w = sb.gate(cs.macs, &[rsh_w, ow, pdh_w])[0];
+    let mut runw = tgt_w;
+    for rr in w_rounds {
+        let rho_w = outs[trace.squeezes[rr.fin][0]][0];
+        runw = sb.gate(cs.mrs, &[runw, wv(rr.g_v), wv(rr.g_v + 1), rho_w])[0];
+    }
+    let mut vgrp_w = zw;
+    for &vi in &mp.val_vs[2 * RS_SHAT_WORDS..] {
+        vgrp_w = sb.gate(cs.macs, &[vgrp_w, ow, wv(vi)])[0];
+    }
+    let v_w = sb.gate(cs.macs, &[vrs_w, ow, vgrp_w])[0];
+    let rhs_v_w = sb.gate(cs.macs, &[zw, wv(inner_pd.q_v), v_w])[0];
+    sb.connect(runw, rhs_v_w);
+    (tgt_w, runw)
+}
+
+/// The z_skip flavor surface, materialized as wires: the RS rho squeeze,
+/// or the AG seed pair plus the r1 nonce's stream word. BOTH walkers
+/// materialize this exact surface for their region output.
+pub(super) fn zskip_wires(
+    zskip: &ZskipTapeRec,
+    outs: &[Vec<Wire>],
+    trace: &FsChainTrace,
+    stream: &Stream,
+    ww: &[Option<Wire>],
+) -> ZskipWires {
+    match zskip {
+        ZskipTapeRec::Rs { fin, .. } => ZskipWires::Rs(outs[trace.squeezes[*fin][0]][0]),
+        ZskipTapeRec::Ag {
+            seed_fins,
+            nonce_payload,
+            ..
+        } => {
+            let nonce_wi = stream
+                .words
+                .iter()
+                .position(|w| {
+                    matches!(
+                        w,
+                        StreamWord::Bytes { payload, word: 0 }
+                            if *payload == *nonce_payload
+                    )
+                })
+                .expect("the r1 nonce rides one stream word");
+            ZskipWires::Ag {
+                seed_w: [
+                    squeeze_word_wire(outs, trace, seed_fins[0], 0),
+                    squeeze_word_wire(outs, trace, seed_fins[1], 0),
+                ],
+                nonce_w: ww[nonce_wi].expect("the nonce payload word is wired"),
+            }
+        }
+    }
 }
 
 /// The residual region's prefix-slot product: every chunked (1 + a + b)

--- a/crates/flock-prover/src/tower/walker_common.rs
+++ b/crates/flock-prover/src/tower/walker_common.rs
@@ -540,10 +540,10 @@ pub(super) fn family_h_source_wires(
 ) -> ([Vec<Wire>; 2], [Vec<Wire>; 2], [Vec<Wire>; 2], [Wire; 2]) {
     let shv_w: [Vec<Wire>; 2] = from_fn(|k| {
         let sv = rs_recs[k].0;
-        (0..128).map(|i| wv(sv + i)).collect()
+        (0..RS_SHAT_WORDS).map(|i| wv(sv + i)).collect()
     });
     let value_w: [Vec<Wire>; 2] = from_fn(|k| {
-        val_vs[128 * k..128 * (k + 1)]
+        val_vs[RS_SHAT_WORDS * k..RS_SHAT_WORDS * (k + 1)]
             .iter()
             .map(|&vi| wv(vi))
             .collect()
@@ -643,8 +643,9 @@ pub(super) const RS_SHAT_WORDS: usize = 128;
 /// publishes, in order. A walker's tail is a `Vec<TailEntry>` — THE
 /// PUBLISH SCHEDULE AS DATA: [`publish_tail`] iterates it, `n_tail` is
 /// its width sum (never a hand-maintained closed form), and the schedule
-/// `(name, width)` list lands in the region output so the tape-pin tests
-/// hold it against independent width expressions. The two walkers keep
+/// `(name, width)` list lands in the region output, where EVERY BUILD
+/// asserts it against independent width expressions over the tape's own
+/// geometry (`expected_*_tail_schedule`). The two walkers keep
 /// SEPARATE tables (their publish orders differ deliberately), and the
 /// `check_*` walks stay positionally independent of the table — the
 /// checker re-deriving every offset by hand is the soundness backstop


### PR DESCRIPTION
Tower productionization, milestone 4: the walkers' implicit schedules become data — with zero transcript or publics movement, proven by the untouched pin lattice.

## What this changes

**Phase 1 — the publish-tail schedule as data.** Each walker's published tail is now a literal `TailEntry` table driven by `walker_common::publish_tail`. The two walkers keep **separate** tables (their publish orders differ deliberately — no unification, per the standing walker rulings). `n_tail` is the table's width sum instead of a hand-maintained closed-form magic sum, and the child's stale publish-order comment (it listed entries the code no longer publishes) is gone. The emitted `(name, width)` schedule is exported on `ChildRegion`/`RealRegion` and asserted against **independent** width expressions over the tape's own geometry at every build (`expected_child_tail_schedule` / `expected_real_tail_schedule`). The `check_*` positional walks are untouched — the checker re-deriving every offset by hand remains the soundness backstop that falsifies a wrong table.

**Phase 2 — the region-label vocabulary.** The 14 transcript region labels (`flock-zerocheck-v0` … `flock-pcs-packed-direct-v0`) become named `walker_common` constants carrying the region-order contract; both label maps and the tape parser stop duplicating the strings.

**Phase 3 — the pinned scalar schedule, named.** `Z_PARTIAL_WORDS` (64) and `RS_SHAT_WORDS` (128); the R=2+P span and the multipoint gamma-power scheme (`mp_pws[j] / [RS_SHAT_WORDS] / [2·RS_SHAT_WORDS + k]`) now read as expressions over the named constant instead of bare 256s.

**Phase 4 — byte-identical twins only** (the #44 bar): `zskip_wires` and `emit_family_h_boundary` fold ~80 line-for-line duplicated lines into `walker_common` (verified identical modulo tape-field naming before extraction). The remaining small twins (vmap/wv builders, leaf-eval slot-cache loops) stay for the walker follow-up batch. No `check_*` validator was merged or modified.

## Review

Two-axis self-review: the standards pass verified refactor fidelity entry-for-entry against the deleted code (both tables, both twin extractions, census positions, constant semantics) and found no blockers; the spec pass walked both old `n_tail` closed forms term-by-term against the new tables (exact) and caught **one hard-constraint violation** — the Phase-3 rename had leaked `Z_PARTIAL_WORDS` into `check_real_child_region`'s offset walk, quietly coupling the backstop to the emitter's constant. Reverted to the literal with the reason in a comment; `check_*` is now truly untouched vs main. Also applied: the remaining same-semantic renames on the emit side, the region structs' doc comments restored (the inserted fns had hijacked them), doc precision on where the schedule assert lives.

## Validation

The acceptance test for a schedule refactor is that nothing moves: full workspace suite (all byte fixtures unchanged), **full ignored tower suite 16/16 with zero re-pins** (both tape pins, all e2es, the new schedule asserts firing in every build), clippy native + znver4 cross, fmt — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XU432JiGGjEiAybuTbmST3
