### PR TITLE
tower: the span counter — the number of hashes joins the statement

### DIFF
--- a/crates/flock-prover/examples/tower.rs
+++ b/crates/flock-prover/examples/tower.rs
@@ -76,7 +76,7 @@ fn main() {
         assert_eq!(&stmt, s, "the statement rode the wire");
         println!(
             "  VERIFIED STANDALONE (consumer path, over the wire): bundle {:.1} KiB \
-             | vk generate {gen_s:.1}s (one-time) | verify {verify_s:.3}s | span: exact",
+             | vk generate {gen_s:.1}s (one-time) | verify {verify_s:.3}s | statement certified",
             bytes.len() as f64 / 1024.0,
         );
     }

--- a/crates/flock-prover/examples/tower.rs
+++ b/crates/flock-prover/examples/tower.rs
@@ -71,13 +71,12 @@ fn main() {
         let gen_s = t2.elapsed().as_secs_f64();
         let bytes = tower.root_bundle_bytes();
         let t3 = Instant::now();
-        let (stmt, bound) =
-            verify_root_bytes(&vk, &bytes).expect("the wire bundle verifies standalone");
+        let stmt = verify_root_bytes(&vk, &bytes).expect("the wire bundle verifies standalone");
         let verify_s = t3.elapsed().as_secs_f64();
         assert_eq!(&stmt, s, "the statement rode the wire");
         println!(
             "  VERIFIED STANDALONE (consumer path, over the wire): bundle {:.1} KiB \
-             | vk generate {gen_s:.1}s (one-time) | verify {verify_s:.3}s | span bound: {bound:?}",
+             | vk generate {gen_s:.1}s (one-time) | verify {verify_s:.3}s | span: exact",
             bytes.len() as f64 / 1024.0,
         );
     }

--- a/crates/flock-prover/src/proof_io.rs
+++ b/crates/flock-prover/src/proof_io.rs
@@ -68,8 +68,12 @@ const MAX_BUNDLE_BYTES: usize = 64 * 1024 * 1024;
 /// different query/rate/PoW schedule and cannot be interpreted safely; the
 /// mixed registry codes 3 and 4 (`merkle26+blake3@nu*`) were retired and
 /// are never reused. `fast100`/`slim100`/`secure` payloads are unchanged.
+/// v23 (2026-09-07): the SPAN COUNTER — the envelope app block grew to
+/// nine words (`g^{n_blocks}` composed child-to-parent), so every tower
+/// outer's transcript moved; a v22 tower-root bundle cannot verify under
+/// v23 shapes. R1cs/Mixed payloads are structurally unchanged.
 /// (The per-version history this file used to carry lives in git.)
-const VERSION: u8 = 22;
+const VERSION: u8 = 23;
 
 /// Flavor discriminator (1 byte). Lets a generic reader peek what kind of
 /// bundle a file holds without parsing the payload first (see
@@ -222,8 +226,8 @@ impl MixedProofBundleLigerito {
 /// cross-checks — the right verification key. The statement rides the
 /// payload for transport; NOTHING decoded here is trusted, and a bare
 /// `from_bytes` proves nothing — `verify_root_bytes` is the ONE entry
-/// that returns a statement with its qualification (the span caveat of
-/// the verify module's `SpanBound` applies verbatim).
+/// that returns a verified statement — endpoints and count alike (the
+/// span counter in the app block pins `n_blocks` at every depth).
 #[derive(Clone, Serialize, Deserialize)]
 pub struct TowerRootBundle {
     pub config: TowerConfig,

--- a/crates/flock-prover/src/tower/chain.rs
+++ b/crates/flock-prover/src/tower/chain.rs
@@ -378,6 +378,10 @@ pub struct ChainProof {
     pub(super) inner: MixedInner,
     pub(super) h_start: [u32; 16],
     pub(super) h_end: [u32; 16],
+    /// The segment's compression count — what the FL's baked span
+    /// counter (`g^{Σ n_blocks}`) sums over. Shape-bound: a different
+    /// count is a different chain (and FL) circuit digest.
+    pub(super) n_blocks: usize,
     /// What the leaf cost, split SETUP vs ONLINE — see [`Online`]. The
     /// LAST online iteration under steady repetition. Read by the in-file
     /// `#[test]` benches only.
@@ -543,6 +547,7 @@ pub fn build_chain_proof(cfg: TowerConfig, h_start: [u32; 16], n_blocks: usize) 
             work,
             sigma,
         },
+        n_blocks,
         h_start,
         h_end,
         t: *onlines.last().expect("one online iteration"),

--- a/crates/flock-prover/src/tower/driver.rs
+++ b/crates/flock-prover/src/tower/driver.rs
@@ -338,10 +338,15 @@ impl Tower {
                 return Err(Statement);
             }
         }
-        // THE SPAN COUNTER: the ninth app word is g^{n_blocks}, composed
-        // multiplicatively child-to-parent — the count is proof-bound at
-        // EVERY depth (Ron's call: the number of hashes is statement).
-        if public[self.app_base + 8] != span_count_word(statement.n_blocks as u128) {
+        // THE SPAN COUNTER: app word 8 is g^{n_blocks}, composed
+        // multiplicatively child-to-parent, and word 9 is the counter
+        // BASE g^{blocks_per_leaf} — the root end of the grounding chain
+        // (each parent copy-constrains its children's base word; the
+        // root's is also pinned natively by check_public). Together the
+        // count is proof-bound at EVERY depth.
+        if public[self.app_base + 8] != span_count_word(statement.n_blocks as u128)
+            || public[self.app_base + 9] != span_count_word(self.blocks_per_leaf as u128)
+        {
             return Err(Statement);
         }
         // (2) the chain lane vs the chain tables (leaf 0's shape).

--- a/crates/flock-prover/src/tower/driver.rs
+++ b/crates/flock-prover/src/tower/driver.rs
@@ -37,17 +37,15 @@ use crate::tower::{
     },
     online::census_kib,
     query::leaf_boolean_mats,
+    span_count_word,
     verify::RootBundle,
 };
 
 /// What a tower run attests: `h_end == H^{n_blocks}(h_start)` over the
-/// BLAKE3 compression chain.
-///
-/// A standalone verifier pins the ENDPOINTS unconditionally but the
-/// COUNT only up to the root's depth class — the steady shape is
-/// depth-independent by design and the app block carries no count word.
-/// See `SpanBound` in the verify module before treating a verified
-/// `n_blocks` as exact.
+/// BLAKE3 compression chain — endpoints AND count. The count rides the
+/// app block's ninth word as the span counter `g^{n_blocks}` (the FL
+/// bakes its shape-bound value; every node multiplies its children's),
+/// so a standalone verifier pins the whole statement at every depth.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ChainStatement {
     pub h_start: [u32; 16],
@@ -339,6 +337,12 @@ impl Tower {
             {
                 return Err(Statement);
             }
+        }
+        // THE SPAN COUNTER: the ninth app word is g^{n_blocks}, composed
+        // multiplicatively child-to-parent — the count is proof-bound at
+        // EVERY depth (Ron's call: the number of hashes is statement).
+        if public[self.app_base + 8] != span_count_word(statement.n_blocks as u128) {
+            return Err(Statement);
         }
         // (2) the chain lane vs the chain tables (leaf 0's shape).
         let blake = chain_blake_r1cs(self.chain.inner.nu);

--- a/crates/flock-prover/src/tower/e2e_tests.rs
+++ b/crates/flock-prover/src/tower/e2e_tests.rs
@@ -14,7 +14,7 @@ use crate::{
     r1cs_hashes::blake3::build_block_r1cs,
     tower::{
         ChainLane, ChainProof, DOMAIN, F128, FlNode, FsChallenger, LeafOuter, Online, RootBundle,
-        RootDischargeFailure, SpanBound, SpineIn, Tower, TowerConfig, TowerVerifyError, TowerVk,
+        RootDischargeFailure, SpineIn, Tower, TowerConfig, TowerVerifyError, TowerVk,
         UnionInstance, build_chain_proof, build_fl_node, build_node_outer_app, chain_blake_r1cs,
         chain_jagged_params, env_acc_chain_base, env_acc_main_base, env_app_base, env_pass_base,
         envelope::STEADY_OVERRIDE,
@@ -1082,16 +1082,15 @@ pub(super) fn tower_driver_e2e() {
 /// **THE STANDALONE VERIFIER, END TO END.** [`TowerVk::generate`] proves
 /// the six-leaf reference tower once, then [`verify_root`] checks FRESH
 /// towers it never built at every depth class — k = 4 (steady, live
-/// passenger, span [`SpanBound::EndpointsOnly`]), k = 3 (steady,
-/// passenger-less, exact) and k = 2 (base-rooted, exact) — plus the VK's
-/// own reference root; every table from the VK, every accumulator
-/// REASSEMBLED from the bundle's publics and cross-checked against the
-/// prover's own objects. Then the consumer-side refusals: a doctored
-/// public word dies in the proof verify, a wrong statement on the
-/// binding, a truncated bundle and a misfit span on the guards, an
-/// unknown slot key in the decode, and a CROSS-CLASS span lie on the
-/// passenger rule — while the k >= 4 in-class span degeneracy is pinned
-/// as exactly what [`SpanBound::EndpointsOnly`] declares.
+/// passenger), k = 3 (steady, passenger-less) and k = 2 (base-rooted) —
+/// plus the VK's own reference root; every table from the VK, every
+/// accumulator REASSEMBLED from the bundle's publics and cross-checked
+/// against the prover's own objects. Then the consumer-side refusals: a
+/// doctored public word dies in the proof verify, a wrong statement on
+/// the binding, a truncated bundle and a misfit span on the guards, an
+/// unknown slot key in the decode — and the SPAN LIES: with the span
+/// counter in the app block, an inflated in-class claim and a
+/// cross-class claim BOTH die on the statement leg, at every depth.
 #[test]
 #[ignore] // Heavy — four towers (6+8+6+4 leaves) end to end.
 pub(super) fn tower_verify_root_e2e() {
@@ -1103,22 +1102,14 @@ pub(super) fn tower_verify_root_e2e() {
     // (0) the VK's own reference root (k = 3, steady shape) verifies
     // through the consumer path.
     let own = *vk.tower.statement();
-    assert_eq!(
-        verify_root(&vk, &own, &vk.tower.root_bundle()).expect("the reference root verifies"),
-        SpanBound::Exact,
-        "a passenger-less steady root pins its span"
-    );
+    verify_root(&vk, &own, &vk.tower.root_bundle()).expect("the reference root verifies");
 
     // (1) a fresh k = 4 steady tower the VK never saw.
     let mut rng = Rng(0xD41_4E13);
     let h0: [u32; 16] = from_fn(|_| rng.next_u32());
     let tower = Tower::prove(cfg, h0, n_blocks, 8);
     let stmt = *tower.statement();
-    assert_eq!(
-        verify_root(&vk, &stmt, &tower.root_bundle()).expect("the k = 4 root verifies"),
-        SpanBound::EndpointsOnly,
-        "a steady root with a live passenger certifies endpoints + class"
-    );
+    verify_root(&vk, &stmt, &tower.root_bundle()).expect("the k = 4 root verifies");
 
     // The reassembly cross-check: publics-decoded == the prover's own
     // objects, all three blocks.
@@ -1138,9 +1129,8 @@ pub(super) fn tower_verify_root_e2e() {
     // THE WIRE: the same k = 4 root as bytes — decode, VK cross-check,
     // full verify; the statement comes back with its qualification.
     let bytes = tower.root_bundle_bytes();
-    let (stmt_wire, bound) = verify_root_bytes(&vk, &bytes).expect("the wire bundle verifies");
+    let stmt_wire = verify_root_bytes(&vk, &bytes).expect("the wire bundle verifies");
     assert_eq!(stmt_wire, stmt, "the statement rode the wire");
-    assert_eq!(bound, SpanBound::EndpointsOnly);
     // A corrupted payload byte must not verify — the decode or the proof
     // refuses, and both are refusals. One flip in the proof body's
     // region, one in the early tags/statement region.
@@ -1234,43 +1224,40 @@ pub(super) fn tower_verify_root_e2e() {
             "an unknown slot key must be refused, not skipped"
         );
     }
-    // THE IN-CLASS SPAN DEGENERACY, pinned: an inflated k >= 4 claim over
-    // an honest k = 4 bundle still verifies — which is exactly why a
-    // green k >= 4 result says EndpointsOnly, never Exact. The count word
-    // in the app block is the recorded protocol follow-up.
+    // THE IN-CLASS SPAN LIE DIES: an inflated k >= 4 claim over an
+    // honest k = 4 bundle now fails the statement leg — the span counter
+    // in the app block pins the count inside the class (this exact lie
+    // used to verify, which is why verify_root once answered
+    // EndpointsOnly).
     let mut inflated = stmt;
     inflated.n_blocks += 2 * 2 * n_blocks;
-    assert_eq!(
-        verify_root(&vk, &inflated, &tower.root_bundle())
-            .expect("the in-class span lie is not detectable today"),
-        SpanBound::EndpointsOnly,
-        "and the result says so"
+    assert!(
+        matches!(
+            verify_root(&vk, &inflated, &tower.root_bundle()),
+            Err(TowerVerifyError::Discharge(RootDischargeFailure::Statement))
+        ),
+        "an inflated in-class span must die on the counter"
     );
 
     // (3) a fresh k = 3 tower — steady shape, passenger-less, exact span.
     let t3 = Tower::prove(cfg, native_chain(&h0, 128), n_blocks, 6);
-    assert_eq!(
-        verify_root(&vk, t3.statement(), &t3.root_bundle()).expect("the k = 3 root verifies"),
-        SpanBound::Exact,
-    );
-    // A CROSS-CLASS span lie dies on the passenger rule: the k = 3
-    // bundle claimed as k = 4 owes an orphan it does not carry.
+    verify_root(&vk, t3.statement(), &t3.root_bundle()).expect("the k = 3 root verifies");
+    // A CROSS-CLASS span lie now dies on the statement leg too (the
+    // counter mismatches before the passenger rule is consulted; the
+    // passenger rule stays as structural defense-in-depth).
     let mut lied = *t3.statement();
     lied.n_blocks += 2 * n_blocks;
     assert!(
         matches!(
             verify_root(&vk, &lied, &t3.root_bundle()),
-            Err(TowerVerifyError::Discharge(RootDischargeFailure::Passenger))
+            Err(TowerVerifyError::Discharge(RootDischargeFailure::Statement))
         ),
-        "a k = 3 bundle claimed steady-deep must die on the passenger"
+        "a k = 3 bundle claimed steady-deep must die on the counter"
     );
 
     // (4) a fresh k = 2 base-rooted tower — the other root shape.
     let t2 = Tower::prove(cfg, native_chain(&h0, 64), n_blocks, 4);
-    assert_eq!(
-        verify_root(&vk, t2.statement(), &t2.root_bundle()).expect("the k = 2 root verifies"),
-        SpanBound::Exact,
-    );
+    verify_root(&vk, t2.statement(), &t2.root_bundle()).expect("the k = 2 root verifies");
 }
 
 /// **THE VK'S PUBLISHED IDENTITY, PINNED** (chain128 @ 256-block
@@ -1322,11 +1309,13 @@ pub(super) fn tower_vk_fingerprint_pinned() {
 }
 
 // The blessed chain128@256 fingerprint (see `tower_vk_fingerprint_pinned`).
-// Blessed 2026-09-04: two identical prints at the M3 wire-format tip.
+// Blessed 2026-09-07: two identical prints at the span-counter tip
+// (chain circuit + registries UNCHANGED by design; the three outer
+// circuits moved with the nine-word app block).
 const PIN_CHAIN_CIRCUIT: &str = "b8f442da32b9961612ccaf9acb39cadcd4592e913b2b208a1b9740d01c10e9c9";
-const PIN_FL_CIRCUIT: &str = "d272428abed26bd2685078eca64f265c0a5362d6e42f4392e83c9c36af4fcfa1";
-const PIN_BASE_CIRCUIT: &str = "3cec36dc2c40c45020105e2144880623e4f87a0a8263922dde172006a3233e51";
-const PIN_STEADY_CIRCUIT: &str = "8ce5ce16dfb72069aa81e673bd0f0676c2271954a963b086d84a23574fc9c0e2";
+const PIN_FL_CIRCUIT: &str = "19adfce7b9e9be24a2bf11e19306aeee95544a34a9a5b8e7275004ad00d17910";
+const PIN_BASE_CIRCUIT: &str = "5c1e83f6b9ad8f07b1a2ef254db1cf42f0101e24cabd3c33b1179ab2943fdd82";
+const PIN_STEADY_CIRCUIT: &str = "e1598ff2c0f340f0b991df50b9c687188fb2a06b2dd2711985efd461bdd2bf6c";
 const PIN_CHAIN_REGISTRY: &str = "3126c5ce825e8fc3942843c0548ba43964b1daa5751a834fcbbc1c3ab58e40fe";
 const PIN_OUTER_REGISTRY: &str = "acfbc7354af8436af480ea66609bb9b1cd0856b27426db2b4d8a69fe9014c10e";
 const PIN_PUBLICS_LEN: usize = 5684;

--- a/crates/flock-prover/src/tower/e2e_tests.rs
+++ b/crates/flock-prover/src/tower/e2e_tests.rs
@@ -1021,6 +1021,17 @@ pub(super) fn tower_driver_e2e() {
     );
     tower.root.lo.public[at] = saved;
 
+    // (a') a doctored counter BASE word — the grounding chain's root end.
+    let at = tower.app_base + 9;
+    let saved = tower.root.lo.public[at];
+    tower.root.lo.public[at] += F128::ONE;
+    assert_eq!(
+        tower.discharge_root(),
+        Err(RootDischargeFailure::Statement),
+        "a doctored counter base must be refused"
+    );
+    tower.root.lo.public[at] = saved;
+
     // (b) a doctored lane claim.
     let lane = tower.root.lane_acc.as_mut().expect("the lane rides");
     let saved = lane.per_type[0].0.value;
@@ -1127,7 +1138,7 @@ pub(super) fn tower_verify_root_e2e() {
     );
 
     // THE WIRE: the same k = 4 root as bytes — decode, VK cross-check,
-    // full verify; the statement comes back with its qualification.
+    // full verify; the statement comes back verified, count included.
     let bytes = tower.root_bundle_bytes();
     let stmt_wire = verify_root_bytes(&vk, &bytes).expect("the wire bundle verifies");
     assert_eq!(stmt_wire, stmt, "the statement rode the wire");
@@ -1309,13 +1320,13 @@ pub(super) fn tower_vk_fingerprint_pinned() {
 }
 
 // The blessed chain128@256 fingerprint (see `tower_vk_fingerprint_pinned`).
-// Blessed 2026-09-07: two identical prints at the span-counter tip
+// Blessed 2026-09-07 (second cut: the grounded counter-base word)
 // (chain circuit + registries UNCHANGED by design; the three outer
 // circuits moved with the nine-word app block).
 const PIN_CHAIN_CIRCUIT: &str = "b8f442da32b9961612ccaf9acb39cadcd4592e913b2b208a1b9740d01c10e9c9";
-const PIN_FL_CIRCUIT: &str = "19adfce7b9e9be24a2bf11e19306aeee95544a34a9a5b8e7275004ad00d17910";
-const PIN_BASE_CIRCUIT: &str = "5c1e83f6b9ad8f07b1a2ef254db1cf42f0101e24cabd3c33b1179ab2943fdd82";
-const PIN_STEADY_CIRCUIT: &str = "e1598ff2c0f340f0b991df50b9c687188fb2a06b2dd2711985efd461bdd2bf6c";
+const PIN_FL_CIRCUIT: &str = "45c54e4003df6692d180ac70187b3ce5c34be259a7174f328d9ab95b6acb2f2a";
+const PIN_BASE_CIRCUIT: &str = "0c8d7382f9824b4fe4894786494e5887e8cad3af262eaf6655cb2116a7830153";
+const PIN_STEADY_CIRCUIT: &str = "fafab0ced83b6f778e799c926041fad49625cce69075093fe3305b7ffb5e22c7";
 const PIN_CHAIN_REGISTRY: &str = "3126c5ce825e8fc3942843c0548ba43964b1daa5751a834fcbbc1c3ab58e40fe";
 const PIN_OUTER_REGISTRY: &str = "acfbc7354af8436af480ea66609bb9b1cd0856b27426db2b4d8a69fe9014c10e";
 const PIN_PUBLICS_LEN: usize = 5684;

--- a/crates/flock-prover/src/tower/envelope.rs
+++ b/crates/flock-prover/src/tower/envelope.rs
@@ -58,18 +58,27 @@ pub(super) struct EnvShape {
 
 /// The APPLICATION STATEMENT's width in the envelope's public segment:
 /// the hash-chain span `(h_start, h_end)` — four packed words each —
-/// plus the SPAN COUNTER `g^{n_blocks}` (Ron's call, 2026-09-07: the
-/// number of hashes is part of the statement). Nine 128-bit words.
-pub(super) const ENV_APP_WORDS: usize = 9;
+/// plus the SPAN COUNTER `g^{n_blocks}` (word 8; Ron's call, 2026-09-07:
+/// the number of hashes is part of the statement) and the COUNTER BASE
+/// `C = g^{blocks_per_leaf}` (word 9). Ten 128-bit words.
+///
+/// The base word is the counter's GROUNDING: a fixed public is only
+/// natively checked at the ROOT (`check_public` — below the root the
+/// walks treat child publics as witness wires), so every parent
+/// copy-constrains each child's word 9 to its own baked C, the chain
+/// ends at the root's native check, and every word 8 is then bound by
+/// PROVEN relations — `C^k` via mac rows at the FL, the children's
+/// product via a mac row at every node.
+pub(super) const ENV_APP_WORDS: usize = 10;
 
 /// The span counter's base: the polynomial `x` in F128, certified a
 /// GENERATOR of the multiplicative group by `span_generator_full_order`
 /// — so two spans collide only at a difference of `2^128 - 1`, which no
 /// tower reaches. The count composes MULTIPLICATIVELY child-to-parent
-/// (char-2 kills integer field addition): an FL bakes
-/// `g^{k · blocks_per_leaf}` as a fixed public (shape-bound — a
-/// different leaf size is a different FL circuit digest), and every node
-/// multiplies its children's counter words with one MAC row.
+/// (char-2 kills integer field addition): an FL raises the GROUNDED
+/// base word to its arity via mac rows, and every node multiplies its
+/// children's counter words with one MAC row — see [`ENV_APP_WORDS`] for
+/// the grounding chain.
 pub(super) const SPAN_G: F128 = F128 { lo: 2, hi: 0 };
 
 /// `SPAN_G^e` by square-and-multiply — the native side of the span

--- a/crates/flock-prover/src/tower/envelope.rs
+++ b/crates/flock-prover/src/tower/envelope.rs
@@ -56,9 +56,67 @@ pub(super) struct EnvShape {
     pub(super) lanes: usize,
 }
 
-/// The APPLICATION STATEMENT's width in the envelope's public segment: the
-/// hash-chain PoC's span `(h_start, h_end)`, eight 128-bit words.
-pub(super) const ENV_APP_WORDS: usize = 8;
+/// The APPLICATION STATEMENT's width in the envelope's public segment:
+/// the hash-chain span `(h_start, h_end)` — four packed words each —
+/// plus the SPAN COUNTER `g^{n_blocks}` (Ron's call, 2026-09-07: the
+/// number of hashes is part of the statement). Nine 128-bit words.
+pub(super) const ENV_APP_WORDS: usize = 9;
+
+/// The span counter's base: the polynomial `x` in F128, certified a
+/// GENERATOR of the multiplicative group by `span_generator_full_order`
+/// — so two spans collide only at a difference of `2^128 - 1`, which no
+/// tower reaches. The count composes MULTIPLICATIVELY child-to-parent
+/// (char-2 kills integer field addition): an FL bakes
+/// `g^{k · blocks_per_leaf}` as a fixed public (shape-bound — a
+/// different leaf size is a different FL circuit digest), and every node
+/// multiplies its children's counter words with one MAC row.
+pub(super) const SPAN_G: F128 = F128 { lo: 2, hi: 0 };
+
+/// `SPAN_G^e` by square-and-multiply — the native side of the span
+/// counter: the statement leg holds the published word against
+/// `span_count_word(statement.n_blocks)`.
+pub(super) fn span_count_word(e: u128) -> F128 {
+    let mut acc = F128::ONE;
+    let mut base = SPAN_G;
+    let mut e = e;
+    while e > 0 {
+        if e & 1 == 1 {
+            acc *= base;
+        }
+        base = base * base;
+        e >>= 1;
+    }
+    acc
+}
+
+/// THE GENERATOR CERTIFICATE: `SPAN_G` has full order `2^128 - 1` — for
+/// every prime factor `p`, `g^{(2^128 - 1)/p} != 1`. The factorization is
+/// `(2^64 - 1)(2^64 + 1)` = 3 · 5 · 17 · 257 · 641 · 65537 · 6700417 ·
+/// 274177 · 67280421310721. Plus the homomorphism the composition rests
+/// on: `g^{a+b} = g^a · g^b`.
+#[test]
+fn span_generator_full_order() {
+    const GROUP_ORDER: u128 = u128::MAX; // 2^128 - 1
+    const PRIMES: [u128; 9] = [3, 5, 17, 257, 641, 65537, 6700417, 274177, 67280421310721];
+    assert_eq!(
+        PRIMES.iter().product::<u128>(),
+        GROUP_ORDER,
+        "factorization"
+    );
+    for p in PRIMES {
+        assert_ne!(
+            span_count_word(GROUP_ORDER / p),
+            F128::ONE,
+            "SPAN_G's order is divisible by {p}"
+        );
+    }
+    assert_eq!(span_count_word(GROUP_ORDER), F128::ONE, "Lagrange sanity");
+    assert_eq!(
+        span_count_word(1 << 20) * span_count_word((1 << 20) + 12345),
+        span_count_word((1 << 21) + 12345),
+        "the counter composes multiplicatively"
+    );
+}
 
 /// Steady-repetition override: how many EXTRA times a builder re-runs its
 /// ONLINE phases (tapes + walk + witgen + prove + verify) over the

--- a/crates/flock-prover/src/tower/fl_node.rs
+++ b/crates/flock-prover/src/tower/fl_node.rs
@@ -47,14 +47,15 @@ use crate::{
         SLOT_WORDS, ShapeBuilder, SwapGate, SwapTable, TowerConfig, UnionInstance,
         UnionSlotProverInput, Wire, ZskipTapeRec, ZskipWires, assert_chain_replays,
         balance_extra_rows, bytes_payload_mask, challenge_word_locs, check_ag_skip_publics,
-        check_child_region, check_fold_publics, check_jagged_fold_publics, emit_ag_point_binding,
-        emit_child_region, emit_fold_region, emit_fs_chain_partitioned, emit_jagged_fold_region,
-        emit_lagrange_lows, emit_recorded_pow_checks, env_acc_chain_base, env_app_base,
-        envelope_shape, expected_child_tail_schedule, flatten_ops, fold_region_ops,
+        check_child_region, check_fold_publics, check_jagged_fold_publics, cw,
+        emit_ag_point_binding, emit_child_region, emit_fold_region, emit_fs_chain_partitioned,
+        emit_jagged_fold_region, emit_lagrange_lows, emit_recorded_pow_checks, env_acc_chain_base,
+        env_app_base, envelope_shape, expected_child_tail_schedule, flatten_ops, fold_region_ops,
         jagged_fold_region_ops, labeled_bytes_payloads, live_element_input_from_rows,
         locate_and_pin_folds, locate_and_pin_jagged_folds, merge_chain, native_chain, outer_lanes,
         outer_union, outer_zc_ag, pack4, pack8, pad_envelope_counts, pcs_batch_for,
-        replay_fold_endpoints, replay_jagged_fold_endpoints, steady_reps, tower_fold_grinding,
+        replay_fold_endpoints, replay_jagged_fold_endpoints, span_count_word, steady_reps,
+        tower_fold_grinding,
     },
     verifier::{verify_ligerito_union_circuit_ag_deferred, verify_ligerito_union_circuit_deferred},
 };
@@ -870,10 +871,16 @@ pub fn build_fl_node_k(cfg: TowerConfig, cps: &[&ChainProof]) -> FlNode {
         // declares the same count vector and segment length every other
         // envelope outer does, and both the app block and the accumulator
         // claims ride the envelope's fixed TAIL.
-        let app_w: Vec<Wire> = (0..4)
+        let mut app_w: Vec<Wire> = (0..4)
             .map(|j| regions[0].child_pub_w[3 + j])
             .chain((0..4).map(|j| regions[k_ary - 1].child_pub_w[11 - 4 + j]))
             .collect();
+        // THE SPAN COUNTER, baked: the FL's children are fixed-size chain
+        // segments, so g^{Σ n_blocks} is a SHAPE CONSTANT — a fixed public
+        // input, bound by the circuit digest (a different leaf size is a
+        // different FL circuit).
+        let span: u128 = cps.iter().map(|cp| cp.n_blocks as u128).sum();
+        app_w.push(cw(&mut sb, &mut vals, &mut consts, span_count_word(span)));
         let stmt_base = {
             pad_envelope_counts(
                 &mut sb,

--- a/crates/flock-prover/src/tower/fl_node.rs
+++ b/crates/flock-prover/src/tower/fl_node.rs
@@ -875,12 +875,28 @@ pub fn build_fl_node_k(cfg: TowerConfig, cps: &[&ChainProof]) -> FlNode {
             .map(|j| regions[0].child_pub_w[3 + j])
             .chain((0..4).map(|j| regions[k_ary - 1].child_pub_w[11 - 4 + j]))
             .collect();
-        // THE SPAN COUNTER, baked: the FL's children are fixed-size chain
-        // segments, so g^{Σ n_blocks} is a SHAPE CONSTANT — a fixed public
-        // input, bound by the circuit digest (a different leaf size is a
-        // different FL circuit).
-        let span: u128 = cps.iter().map(|cp| cp.n_blocks as u128).sum();
-        app_w.push(cw(&mut sb, &mut vals, &mut consts, span_count_word(span)));
+        // THE SPAN COUNTER: the base C = g^{n_blocks} rides word 9 as a
+        // fixed public — GROUNDED by the parent chain (every parent
+        // copy-constrains it to its own, up to the root's native
+        // check_public) — and word 8 = C^k via mac rows, so the count is
+        // bound by proven relations, not by fixed-public metadata.
+        let per_leaf = cps[0].n_blocks;
+        assert!(
+            cps.iter().all(|cp| cp.n_blocks == per_leaf),
+            "one leaf size per FL"
+        );
+        let c_w = cw(
+            &mut sb,
+            &mut vals,
+            &mut consts,
+            span_count_word(per_leaf as u128),
+        );
+        let mut e_w = c_w;
+        for _ in 1..k_ary {
+            e_w = sb.gate(cs.macs, &[zw, e_w, c_w])[0];
+        }
+        app_w.push(e_w);
+        app_w.push(c_w);
         let stmt_base = {
             pad_envelope_counts(
                 &mut sb,

--- a/crates/flock-prover/src/tower/mod.rs
+++ b/crates/flock-prover/src/tower/mod.rs
@@ -48,8 +48,7 @@ pub use crate::tower::{
     node::{ChainLane, MainBlock, NodeOut, SpineIn, build_node_outer_app},
     query::LeafOuter,
     verify::{
-        RootBundle, SpanBound, TowerVerifyError, TowerVk, TowerVkFingerprint, verify_root,
-        verify_root_bytes,
+        RootBundle, TowerVerifyError, TowerVk, TowerVkFingerprint, verify_root, verify_root_bytes,
     },
 };
 // The wire format (`proof_io`'s tower-root bundle) carries a `MixedProof`.
@@ -69,7 +68,7 @@ use crate::{
         envelope::{
             ENV_ACC_MAIN_WORDS, EnvShape, EnvTail, declare_envelope_slots, env_acc_chain_base,
             env_acc_main_base, env_app_base, env_pass_base, envelope_shape, outer_lanes,
-            pad_envelope_counts, slot_cached, steady_reps,
+            pad_envelope_counts, slot_cached, span_count_word, steady_reps,
         },
         fl_node::chain_blake_r1cs,
         fold_region::{

--- a/crates/flock-prover/src/tower/node.rs
+++ b/crates/flock-prover/src/tower/node.rs
@@ -1676,10 +1676,19 @@ pub fn build_node_outer_app(
                 }
             }
             let last = &regions[n_kids - 1];
-            (0..4)
+            let mut out: Vec<Wire> = (0..4)
                 .map(|j| regions[0].child_pub_w[off + j])
                 .chain((0..4).map(|j| last.child_pub_w[off + 4 + j]))
-                .collect()
+                .collect();
+            // THE SPAN COUNTER composes MULTIPLICATIVELY: the node's word
+            // is the product of its children's (g^{a+b} = g^a · g^b), one
+            // MAC row per extra child — depth never enters the shape.
+            let mut e = regions[0].child_pub_w[off + 8];
+            for rk in &regions[1..] {
+                e = sb.gate(cs.macs, &[zw, e, rk.child_pub_w[off + 8]])[0];
+            }
+            out.push(e);
+            out
         });
         // The publish of the combined span rides the envelope's fixed tail
         // block (below, with the padding), never inline.

--- a/crates/flock-prover/src/tower/node.rs
+++ b/crates/flock-prover/src/tower/node.rs
@@ -51,7 +51,7 @@ use crate::{
         TowerConfig, UnionInstance, UnionSlotProverInput, Weight, Wire, ZskipTapeRec, ZskipWires,
         assert_chain_replays, balance_extra_rows, bytes_payload_mask, challenge_word_locs,
         check_ag_skip_publics, check_fold_publics, check_jagged_fold_publics,
-        check_real_child_region, emit_ag_point_binding, emit_fold_region, emit_fs_chain,
+        check_real_child_region, cw, emit_ag_point_binding, emit_fold_region, emit_fs_chain,
         emit_fs_chain_partitioned, emit_jagged_fold_region, emit_lagrange_lows,
         emit_real_child_region, emit_recorded_pow_checks, env_acc_chain_base, env_acc_main_base,
         env_app_base, env_pass_base, envelope_shape, expected_real_tail_schedule, flatten_ops,
@@ -1688,6 +1688,21 @@ pub fn build_node_outer_app(
                 e = sb.gate(cs.macs, &[zw, e, rk.child_pub_w[off + 8]])[0];
             }
             out.push(e);
+            // THE COUNTER BASE, chained: every child's word 9 is
+            // copy-constrained to this node's own baked C, so the fixed
+            // public grounds out at the ROOT's native check_public — the
+            // link that makes the counter adversarially proof-bound (a
+            // fixed public alone is never checked below the root).
+            let c_w = cw(
+                &mut sb,
+                &mut vals,
+                &mut consts,
+                los[0].public[env_app_base(&env) + 9],
+            );
+            for rk in &regions {
+                sb.connect(rk.child_pub_w[off + 9], c_w);
+            }
+            out.push(c_w);
             out
         });
         // The publish of the combined span rides the envelope's fixed tail

--- a/crates/flock-prover/src/tower/verify.rs
+++ b/crates/flock-prover/src/tower/verify.rs
@@ -46,29 +46,6 @@ pub struct RootBundle<'a> {
     pub(super) commitment: &'a Commitment,
 }
 
-/// What a green [`verify_root`] CERTIFIED about the claimed span. The
-/// ENDPOINTS (`h_start`, `h_end`) are always bound — they ride the app
-/// block the proof pins. The COUNT is bound only where the root's shape
-/// pins it: a base root folds exactly two leaf pairs, and a
-/// passenger-less steady root is exactly three (a deeper spine always
-/// carries its live orphan — the match-gate adversarial matrix is what
-/// closes the forged-fold escape). From four pairs on, the steady shape
-/// is depth-independent BY DESIGN (the spine's one-digest convergence),
-/// and the app block carries no count word — so within that class the
-/// count is CONSISTENT but not pinned. Binding it exactly means a count
-/// word in the app block, composed child-to-parent like the hash
-/// endpoints: a recorded protocol follow-up, not a verifier-side patch.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum SpanBound {
-    /// The claimed `n_blocks` is pinned by the root's shape (two or
-    /// three leaf pairs).
-    Exact,
-    /// The endpoints are pinned and the count is consistent (a whole
-    /// number of leaf pairs, at least four) but NOT pinned within that
-    /// class.
-    EndpointsOnly,
-}
-
 /// Why [`verify_root`] refused.
 #[derive(Debug)]
 pub enum TowerVerifyError {
@@ -283,14 +260,15 @@ pub(super) fn reassemble(
 /// commitment are the CLAIM being checked, never the tables it is
 /// checked against.
 ///
-/// A green result is qualified by [`SpanBound`]: the endpoints are
-/// always certified, the count only up to the root's depth class — read
-/// its doc before treating `n_blocks` as verified.
+/// A green result certifies the FULL statement — endpoints and count
+/// alike: the ninth app word carries the span counter `g^{n_blocks}`,
+/// composed multiplicatively child-to-parent, so the count is
+/// proof-bound at every depth.
 pub fn verify_root(
     vk: &TowerVk,
     statement: &ChainStatement,
     bundle: &RootBundle<'_>,
-) -> Result<SpanBound, TowerVerifyError> {
+) -> Result<(), TowerVerifyError> {
     // (1) geometry: the depth this statement claims, and which of the two
     // node shapes roots it (k = 2 is the base's; k >= 3 the steady's).
     let per_pair = 2 * vk.blocks_per_leaf;
@@ -338,33 +316,21 @@ pub fn verify_root(
     // VK's reference tower as the table owner.
     vk.tower
         .discharge_with(bundle.public, &lane, &main, &passenger, statement, k >= 4)
-        .map_err(TowerVerifyError::Discharge)?;
-
-    // (5) what the shape actually pinned: k = 2 and 3 are exact (base
-    // shape; passenger-less steady); k >= 4 certifies the endpoints and
-    // the class, not the count — see [`SpanBound`].
-    Ok(if k <= 3 {
-        SpanBound::Exact
-    } else {
-        SpanBound::EndpointsOnly
-    })
+        .map_err(TowerVerifyError::Discharge)
 }
 
 /// **VERIFY A TOWER ROOT FROM ITS WIRE BYTES** (the proof-IO tower-root
 /// flavor, [`Tower::root_bundle_bytes`]'s output): decode, cross-check
 /// the bundle's VK-selection tags against this VK, then [`verify_root`]
-/// over the carried statement. Returns the statement WITH its
-/// [`SpanBound`] qualification — the statement traveled in the payload,
-/// and every word of it was re-checked against the proof.
-pub fn verify_root_bytes(
-    vk: &TowerVk,
-    bytes: &[u8],
-) -> Result<(ChainStatement, SpanBound), TowerVerifyError> {
+/// over the carried statement. Returns the statement — it traveled in
+/// the payload, and every word of it (the count included, via the span
+/// counter) was re-checked against the proof.
+pub fn verify_root_bytes(vk: &TowerVk, bytes: &[u8]) -> Result<ChainStatement, TowerVerifyError> {
     let b = TowerRootBundle::from_bytes(bytes).map_err(TowerVerifyError::Encoding)?;
     if b.config != vk.tower.cfg || b.blocks_per_leaf != vk.blocks_per_leaf as u64 {
         return Err(TowerVerifyError::VkMismatch);
     }
-    let bound = verify_root(
+    verify_root(
         vk,
         &b.statement,
         &RootBundle {
@@ -373,7 +339,7 @@ pub fn verify_root_bytes(
             commitment: &b.commitment,
         },
     )?;
-    Ok((b.statement, bound))
+    Ok(b.statement)
 }
 
 /// The VK'S IDENTITY, small enough to publish: the config, the leaf

--- a/crates/flock-prover/tests/union_m6_fixtures.rs
+++ b/crates/flock-prover/tests/union_m6_fixtures.rs
@@ -149,6 +149,10 @@ fn random_sha2_inputs(rng: &mut Rng, n: usize) -> Vec<Sha2Compression> {
 // VALUE-ONLY (claim points are transcript-derived and verifier-recomputed,
 // never prover messages; ~92 KB of self-absorbed points deleted from the
 // recursion replay). Label flock-merged-open-v0 -> v1.
+// Re-pinned 2026-09-07: proof-IO VERSION 22 -> 23 (the tower span
+// counter) — only the bundle HEADER byte moved; payloads are unchanged,
+// and the header-less anchor digests did not move, which is the
+// cross-check. Two deterministic print runs agreed.
 // Re-pinned 2026-08-05: BLAKE3 R1CS "Option E" lin-id drop — the b3 table
 // narrowed 121 -> 93 word-cols (b_new/d_new slots dissolved into the
 // cascade), so every blake3-committed fixture's bytes move. The pure
@@ -206,22 +210,22 @@ fn m6_merged_union_proof_bytes_pinned() {
         (
             "merged-nu10-1024-1024",
             [1024, 1024],
-            "e50fcc617bc0e02cdb7592c8c702483864ae1f0acaf2b6239ae820ea6a054b04",
+            "493ce5531c9d8feb591f0e00bffb1aaf0bd0e1307ac4d5c1490fbaca6e54a5e3",
         ),
         (
             "merged-nu10-50-37",
             [50, 37],
-            "2e9fa4c9d476cb3453b6e01f2d68d22b43871d8691635acb8837dd896bc654c0",
+            "31c2098ce646bb57b9c7c4bb98855aebb45bff5ee90d95816550dbc5a3d08ce8",
         ),
         (
             "merged-nu10-8-8",
             [8, 8],
-            "388612533f9f425591168a6d560288a9c591879e37f7ace55c5636f6cd1c7251",
+            "09c23f3aa9794834b9b19cda27ede0e794dcf1ef59894415700e5b01ead18775",
         ),
         (
             "merged-nu10-0-64",
             [0, 64],
-            "6ea3899c9c235e0012297323d24d5440b8a704e9fbe12c793e0070d1210dced5",
+            "0e2d3d81dd8057aeebff8d72ae4a1adcf3b76efaa84b922d30a3513e2eeeb656",
         ),
     ];
 

--- a/crates/flock-prover/tests/union_m6_fixtures.rs
+++ b/crates/flock-prover/tests/union_m6_fixtures.rs
@@ -199,7 +199,7 @@ fn merged_bundle_digest(
 /// registry id, counts vector, commitment, and the merged proof — plus the
 /// claim values. The registry here (BLAKE3+SHA-256 at ν = 10) IS the
 /// `Blake3Sha2Nu10` tier, so this pins exactly what `proof_io` puts on disk
-/// for the current v21 mixed proof. It retains the removed jagged fixture's
+/// for the current mixed proof (the header carries `proof_io::VERSION`). It retains the removed jagged fixture's
 /// statements and witness streams; the Ligerito query ladder intentionally
 /// changed with v18.
 #[test]


### PR DESCRIPTION
Per Ron's decision: `n_blocks` is part of what a tower attests. This closes the k ≥ 4 span degeneracy found in #46's review — the count is now proof-bound at every depth.

## The mechanism

The envelope app block grows to **nine words**: `(h_start, h_end, g^{n_blocks})`. Characteristic 2 rules out composing an integer count with field addition, so the count composes **multiplicatively**:

- `SPAN_G` = the polynomial `x`, certified a full-order generator of F128* by a default-run test walking the nine prime cofactors of 2^128 − 1 — two spans collide only at an unreachable difference.
- The FL **bakes** `g^{Σ n_blocks}` as a fixed public input: shape-bound, so a different leaf size is a different FL circuit digest.
- Every node multiplies its children's counter words with **one MAC row** in the existing mac slot — depth never enters the shape, and **no new table type**: both registry digests are unchanged.
- The discharge statement leg holds the ninth word against `span_count_word(statement.n_blocks)` natively (~40 squarings).

## Consequences

- **`SpanBound` is deleted** — `verify_root` returns `Result<()>` and certifies the full statement at every depth; `verify_root_bytes` returns the statement plain.
- The e2e leg that pinned the degeneracy ("an inflated k ≥ 4 claim still verifies") **flips into a refusal leg** — the same lie now dies on the counter. The cross-class lie moves from the passenger rule to the statement leg; the passenger rule stays as structural defense-in-depth.
- proof-IO VERSION 22 → 23. The four m6 bundle-bytes pins re-blessed (only the header byte moved; the header-less anchor digests did **not** move — the cross-check). VK fingerprint re-blessed: chain circuit and both registries identical, exactly the three outer circuits moved, `publics_len` stays 5684 (the padding absorbed the ninth word).

## Review

Two-axis self-review: the spec pass verified all eight points clean (factorization included). The standards pass found a **real soundness blocker in the first cut**: the FL's counter word was a fixed public — digest-committed but enforced only by the *native* `check_public`, which the tower runs solely at the root — so a bespoke malicious prover could patch it and forge in-class counts. Fixed by **grounding the counter**: the app block is ten words, word 9 carries the counter base `C = g^{blocks_per_leaf}`, every parent copy-constrains its children's base word to its own baked C (rooted at the native check + an explicit statement-leg check), and word 8 is now derived by MAC rows at *every* level (`C^k` at the FL, the children's product at nodes) — proven relations all the way down. A counter-base tamper leg joined the driver e2e. The invariants survived the fix: chain circuit, both registries, and `publics_len` 5684 all unchanged.

## Validation

Generator certificate green; chain leaf byte-identical (digest unchanged); driver e2e; verifier e2e with all span lies refused; full ignored tower suite 16/16; workspace suite; clippy native + znver4 cross; fmt; example over the wire (345.3 KiB bundle, 0.383s verify, span exact). All re-blessings done with two identical prints.

Note for coordination: every tower-outer transcript moved, so unmerged branches (Benedikt's) will meet moved fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XU432JiGGjEiAybuTbmST3
