### PR TITLE
r1cs: share SparseBinaryMatrix storage; BLAKE3 gate reuses the cached block

### DIFF
--- a/crates/flock-core/src/circuit.rs
+++ b/crates/flock-core/src/circuit.rs
@@ -1238,11 +1238,7 @@ mod tests {
     };
 
     fn stub() -> SparseBinaryMatrix {
-        SparseBinaryMatrix {
-            num_rows: 0,
-            num_cols: 0,
-            rows: Vec::new(),
-        }
+        SparseBinaryMatrix::new(0, 0, Vec::new())
     }
 
     /// A boolean type of the given width with the given schema — only its

--- a/crates/flock-core/src/circuit/builder.rs
+++ b/crates/flock-core/src/circuit/builder.rs
@@ -158,9 +158,9 @@ pub trait GateType {
 /// can be run many times concurrently — the whole point of the split.
 trait SlotBuild: Any + Send + Sync {
     /// MOVE the table out. Called once, by `finish`, on its way into the
-    /// registry — which then owns it. Cloning here instead cost 2 deep copies
-    /// of every table's matrices; BLAKE3's are ~21M nonzeros, so that was
-    /// ~300 ms of pure memcpy per circuit.
+    /// registry — which then owns it. (A table's matrices share their row
+    /// storage, so a clone would be cheap today; the move keeps the
+    /// ownership story single-owner.)
     fn take_table(&mut self) -> TableType;
     fn n_in(&self) -> usize;
     fn n_out(&self) -> usize;

--- a/crates/flock-core/src/element_r1cs/union.rs
+++ b/crates/flock-core/src/element_r1cs/union.rs
@@ -859,21 +859,9 @@ mod tests {
         TableType {
             k_log,
             useful_bits,
-            a_0: SparseBinaryMatrix {
-                num_rows: 0,
-                num_cols: 0,
-                rows: Vec::new(),
-            },
-            b_0: SparseBinaryMatrix {
-                num_rows: 0,
-                num_cols: 0,
-                rows: Vec::new(),
-            },
-            c_0: SparseBinaryMatrix {
-                num_rows: 0,
-                num_cols: 0,
-                rows: Vec::new(),
-            },
+            a_0: SparseBinaryMatrix::new(0, 0, Vec::new()),
+            b_0: SparseBinaryMatrix::new(0, 0, Vec::new()),
+            c_0: SparseBinaryMatrix::new(0, 0, Vec::new()),
             const_pin: None,
             class: TableClass::Boolean,
             io_schema: Vec::new(),

--- a/crates/flock-core/src/lincheck.rs
+++ b/crates/flock-core/src/lincheck.rs
@@ -390,7 +390,7 @@ fn csc_from_rows(m: &SparseBinaryMatrix) -> (Vec<u32>, Vec<u32>) {
     assert!(m.num_rows <= u32::MAX as usize);
     assert!(m.num_cols <= u32::MAX as usize);
     let mut col_ptr = vec![0u32; m.num_cols + 1];
-    for row in &m.rows {
+    for row in m.rows.iter() {
         for &c in row {
             col_ptr[c + 1] += 1;
         }
@@ -2393,11 +2393,7 @@ mod tests {
         for row in &mut rows {
             row.sort();
         }
-        SparseBinaryMatrix {
-            num_rows: k,
-            num_cols: k,
-            rows,
-        }
+        SparseBinaryMatrix::new(k, k, rows)
     }
 
     // ---- Unit tests for the kernels ----

--- a/crates/flock-core/src/lincheck/union.rs
+++ b/crates/flock-core/src/lincheck/union.rs
@@ -953,11 +953,7 @@ mod tests {
     };
 
     fn stub() -> SparseBinaryMatrix {
-        SparseBinaryMatrix {
-            num_rows: 0,
-            num_cols: 0,
-            rows: Vec::new(),
-        }
+        SparseBinaryMatrix::new(0, 0, Vec::new())
     }
 
     fn ty(k_log: usize, useful_bits: usize) -> TableType {

--- a/crates/flock-core/src/matrix_fold.rs
+++ b/crates/flock-core/src/matrix_fold.rs
@@ -1455,11 +1455,7 @@ mod tests {
                 cs
             })
             .collect();
-        SparseBinaryMatrix {
-            num_rows: n,
-            num_cols: n,
-            rows,
-        }
+        SparseBinaryMatrix::new(n, n, rows)
     }
 
     /// An honest claim at the lincheck's weight shape: `low(2^s) ⊗ eq(point)`.

--- a/crates/flock-core/src/r1cs.rs
+++ b/crates/flock-core/src/r1cs.rs
@@ -9,6 +9,7 @@
 //! boolean (`k = 2^k_log`). `C_0 = I_k` is implicit (we still carry the
 //! materialized `c_0` matrix for utilities like `satisfies`).
 
+use std::sync::Arc;
 use std::{
     array::from_fn,
     slice::{from_raw_parts, from_raw_parts_mut},
@@ -29,11 +30,34 @@ use crate::{
 };
 
 /// Sparse boolean matrix. `rows[i]` lists the column indices where the entry is 1.
+///
+/// The row storage is frozen behind an `Arc` at construction: a matrix is
+/// built once and then read by the registry, by every clone of a circuit
+/// shape, and by the lincheck circuit, so `Clone` bumps a count instead of
+/// deep-copying tens of millions of indices (BLAKE3's base block alone holds
+/// 44M of them, 339 MiB per copy).
 #[derive(Clone, Debug)]
 pub struct SparseBinaryMatrix {
     pub num_rows: usize,
     pub num_cols: usize,
-    pub rows: Vec<Vec<usize>>,
+    pub rows: Arc<Vec<Vec<usize>>>,
+}
+
+impl SparseBinaryMatrix {
+    /// Freeze `rows` as the matrix's shared storage. Trailing capacity is
+    /// released first: the rows never grow again, so slack from push-built
+    /// rows would be dead weight in every holder.
+    pub fn new(num_rows: usize, num_cols: usize, mut rows: Vec<Vec<usize>>) -> Self {
+        for row in &mut rows {
+            row.shrink_to_fit();
+        }
+        rows.shrink_to_fit();
+        Self {
+            num_rows,
+            num_cols,
+            rows: Arc::new(rows),
+        }
+    }
 }
 
 /// Memory/variable layout of the committed witness (address bit `i` of the
@@ -426,7 +450,7 @@ impl BlockR1cs {
 pub(crate) fn absorb_matrix(h: &mut Hasher, m: &SparseBinaryMatrix) {
     h.update(&(m.num_rows as u64).to_le_bytes());
     h.update(&(m.num_cols as u64).to_le_bytes());
-    for row in &m.rows {
+    for row in m.rows.iter() {
         h.update(&(row.len() as u64).to_le_bytes());
         for &col in row {
             h.update(&(col as u64).to_le_bytes());
@@ -551,7 +575,7 @@ fn flatten_csr(m: &SparseBinaryMatrix) -> (Vec<u32>, Vec<u32>) {
     let mut row_ptr = Vec::with_capacity(m.num_rows + 1);
     let mut cols = Vec::with_capacity(nnz);
     row_ptr.push(0u32);
-    for row in &m.rows {
+    for row in m.rows.iter() {
         for &c in row {
             cols.push(c as u32);
         }
@@ -785,11 +809,7 @@ mod tests {
     /// Identity base matrix: `A_0 = I_k`. Each row has exactly one nonzero at
     /// the diagonal.
     fn identity(k: usize) -> SparseBinaryMatrix {
-        SparseBinaryMatrix {
-            num_rows: k,
-            num_cols: k,
-            rows: (0..k).map(|i| vec![i]).collect(),
-        }
+        SparseBinaryMatrix::new(k, k, (0..k).map(|i| vec![i]).collect())
     }
 
     /// Packed apply_a matches bool apply_a.
@@ -802,19 +822,16 @@ mod tests {
             // Build a random sparse matrix.
             let k = 1usize << k_log;
             let mut rng = TestRng::new(0xABCD + m as u64 + k_log as u64 * 37);
-            let mat = SparseBinaryMatrix {
-                num_rows: k,
-                num_cols: k,
-                // Each row picks a few random columns.
-                rows: (0..k)
-                    .map(|_| {
-                        let n_nonzero = 2 + (rng.next_u64() % 4) as usize;
-                        (0..n_nonzero)
-                            .map(|_| (rng.next_u64() as usize) % k)
-                            .collect::<Vec<_>>()
-                    })
-                    .collect(),
-            };
+            // Each row picks a few random columns.
+            let rows: Vec<Vec<usize>> = (0..k)
+                .map(|_| {
+                    let n_nonzero = 2 + (rng.next_u64() % 4) as usize;
+                    (0..n_nonzero)
+                        .map(|_| (rng.next_u64() as usize) % k)
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+            let mat = SparseBinaryMatrix::new(k, k, rows);
 
             // Random witness.
             let z: Vec<bool> = (0..(1 << m)).map(|_| rng.next_u64() & 1 == 1).collect();
@@ -877,11 +894,7 @@ mod tests {
         // A_0 = B_0 = 0, C_0 = I ⇒ a·b = 0 ⇒ z = 0.
         let k_log = 3;
         let m = 6;
-        let zero = SparseBinaryMatrix {
-            num_rows: 1 << k_log,
-            num_cols: 1 << k_log,
-            rows: vec![Vec::new(); 1 << k_log],
-        };
+        let zero = SparseBinaryMatrix::new(1 << k_log, 1 << k_log, vec![Vec::new(); 1 << k_log]);
         let r1cs = BlockR1cs {
             m,
             k_log,

--- a/crates/flock-core/src/r1cs.rs
+++ b/crates/flock-core/src/r1cs.rs
@@ -9,11 +9,10 @@
 //! boolean (`k = 2^k_log`). `C_0 = I_k` is implicit (we still carry the
 //! materialized `c_0` matrix for utilities like `satisfies`).
 
-use std::sync::Arc;
 use std::{
     array::from_fn,
     slice::{from_raw_parts, from_raw_parts_mut},
-    sync::OnceLock,
+    sync::{Arc, OnceLock},
 };
 
 use blake3::Hasher;

--- a/crates/flock-core/src/schedule.rs
+++ b/crates/flock-core/src/schedule.rs
@@ -179,11 +179,7 @@ impl TableType {
     /// docs). The boolean matrix fields are empty stubs — the real payload
     /// rides in [`TableClass::LargeField`].
     pub fn element(ty: Arc<ElementTableType>) -> Self {
-        let stub = || SparseBinaryMatrix {
-            num_rows: 0,
-            num_cols: 0,
-            rows: Vec::new(),
-        };
+        let stub = || SparseBinaryMatrix::new(0, 0, Vec::new());
         Self {
             k_log: ty.kappa() + 7,
             useful_bits: ty.k() * 128,
@@ -804,11 +800,7 @@ mod tests {
     /// Empty matrix stub — layout tests never apply the matrices, mirroring
     /// the walker-based encoders' stub practice.
     fn stub() -> SparseBinaryMatrix {
-        SparseBinaryMatrix {
-            num_rows: 0,
-            num_cols: 0,
-            rows: Vec::new(),
-        }
+        SparseBinaryMatrix::new(0, 0, Vec::new())
     }
 
     fn ty(k_log: usize, useful_bits: usize) -> TableType {
@@ -1041,11 +1033,7 @@ mod tests {
     /// as-is; the digest does not validate dimensions against `k_log`, same
     /// as the walker-encoder stub convention).
     fn matrix(rows: Vec<Vec<usize>>) -> SparseBinaryMatrix {
-        SparseBinaryMatrix {
-            num_rows: rows.len(),
-            num_cols: 512,
-            rows,
-        }
+        SparseBinaryMatrix::new(rows.len(), 512, rows)
     }
 
     /// Digest is stable across calls (cache), across identically constructed

--- a/crates/flock-core/src/union.rs
+++ b/crates/flock-core/src/union.rs
@@ -1105,11 +1105,7 @@ mod tests {
     /// Empty matrix stub — nothing here applies the matrices (same practice
     /// as the schedule.rs layout tests).
     fn stub() -> SparseBinaryMatrix {
-        SparseBinaryMatrix {
-            num_rows: 0,
-            num_cols: 0,
-            rows: Vec::new(),
-        }
+        SparseBinaryMatrix::new(0, 0, Vec::new())
     }
 
     fn ty(k_log: usize, useful_bits: usize) -> TableType {

--- a/crates/flock-core/src/verifier.rs
+++ b/crates/flock-core/src/verifier.rs
@@ -1459,17 +1459,9 @@ mod tests {
     fn non_identity_c_is_rejected_by_both_single_table_entries() {
         let k_log = 6;
         let k = 1usize << k_log;
-        let identity = SparseBinaryMatrix {
-            num_rows: k,
-            num_cols: k,
-            rows: (0..k).map(|i| vec![i]).collect(),
-        };
+        let identity = SparseBinaryMatrix::new(k, k, (0..k).map(|i| vec![i]).collect());
         // c_0 = a shift-by-one permutation: a valid matrix, not the identity.
-        let shifted = SparseBinaryMatrix {
-            num_rows: k,
-            num_cols: k,
-            rows: (0..k).map(|i| vec![(i + 1) % k]).collect(),
-        };
+        let shifted = SparseBinaryMatrix::new(k, k, (0..k).map(|i| vec![(i + 1) % k]).collect());
         let r1cs = BlockR1cs {
             m: 12,
             k_log,

--- a/crates/flock-core/tests/union_lincheck.rs
+++ b/crates/flock-core/tests/union_lincheck.rs
@@ -43,11 +43,7 @@ use zerocheck::{prove_packed_padded, verify as verify_zerocheck};
 const DOMAIN: &[u8] = b"flock-union-lincheck-test-v0";
 
 fn identity(k: usize) -> SparseBinaryMatrix {
-    SparseBinaryMatrix {
-        num_rows: k,
-        num_cols: k,
-        rows: (0..k).map(|i| vec![i]).collect(),
-    }
+    SparseBinaryMatrix::new(k, k, (0..k).map(|i| vec![i]).collect())
 }
 
 /// Random sparse `k × k` matrix supported on the useful square: rows
@@ -68,11 +64,7 @@ fn random_useful_matrix(
         }
         *row = cols.into_iter().collect();
     }
-    SparseBinaryMatrix {
-        num_rows: k,
-        num_cols: k,
-        rows,
-    }
+    SparseBinaryMatrix::new(k, k, rows)
 }
 
 /// One synthetic slot: matrices, declared count, and the semantic

--- a/crates/flock-cuda-ffi/tests/gpu_roundtrip.rs
+++ b/crates/flock-cuda-ffi/tests/gpu_roundtrip.rs
@@ -110,7 +110,7 @@ fn gpu_link_smoke() {
 // `lincheck.rs::csc_from_rows` twin (same as dump_lincheck_vectors).
 fn csc_from_rows(m: &SparseBinaryMatrix) -> (Vec<u32>, Vec<u32>) {
     let mut col_ptr = vec![0u32; m.num_cols + 1];
-    for row in &m.rows {
+    for row in m.rows.iter() {
         for &c in row {
             col_ptr[c + 1] += 1;
         }

--- a/crates/flock-prover/benches/lincheck.rs
+++ b/crates/flock-prover/benches/lincheck.rs
@@ -38,11 +38,7 @@ fn random_sparse_matrix(k: usize, nnz: usize, rng: &mut Rng) -> SparseBinaryMatr
     for row in &mut rows {
         row.sort();
     }
-    SparseBinaryMatrix {
-        num_rows: k,
-        num_cols: k,
-        rows,
-    }
+    SparseBinaryMatrix::new(k, k, rows)
 }
 
 fn main() {

--- a/crates/flock-prover/src/bin/dump_blake3_lincheck_matrices.rs
+++ b/crates/flock-prover/src/bin/dump_blake3_lincheck_matrices.rs
@@ -30,7 +30,7 @@ use flock_prover::{
 
 fn csc_from_rows(m: &SparseBinaryMatrix) -> (Vec<u32>, Vec<u32>) {
     let mut col_ptr = vec![0u32; m.num_cols + 1];
-    for row in &m.rows {
+    for row in m.rows.iter() {
         for &c in row {
             col_ptr[c + 1] += 1;
         }

--- a/crates/flock-prover/src/bin/dump_lincheck_vectors.rs
+++ b/crates/flock-prover/src/bin/dump_lincheck_vectors.rs
@@ -84,18 +84,14 @@ fn random_matrix(k: usize, nnz_per_row: usize, rng: &mut Rng) -> SparseBinaryMat
             cols
         })
         .collect();
-    SparseBinaryMatrix {
-        num_rows: k,
-        num_cols: k,
-        rows,
-    }
+    SparseBinaryMatrix::new(k, k, rows)
 }
 
 /// Flatten a sparse matrix to CSC arrays — verbatim mirror of
 /// `lincheck.rs::csc_from_rows`, so the CUDA kernel folds the same columns.
 fn csc_from_rows(m: &SparseBinaryMatrix) -> (Vec<u32>, Vec<u32>) {
     let mut col_ptr = vec![0u32; m.num_cols + 1];
-    for row in &m.rows {
+    for row in m.rows.iter() {
         for &c in row {
             col_ptr[c + 1] += 1;
         }

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -776,11 +776,7 @@ pub fn build_matrices() -> (SparseBinaryMatrix, SparseBinaryMatrix) {
     // Padding rows [USEFUL_BITS..K): A = B = []. Constraint 0·0 = z[i]
     // forces z[i] = 0 for all padding bits.
 
-    let to_mat = |rows| SparseBinaryMatrix {
-        num_rows: K,
-        num_cols: K,
-        rows,
-    };
+    let to_mat = |rows| SparseBinaryMatrix::new(K, K, rows);
     (to_mat(a_rows), to_mat(b_rows))
 }
 

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -96,7 +96,7 @@
 //!   are "free" witness bits. PCS-level openings at fixed indices will
 //!   eventually pin them to claimed public inputs.
 
-use std::{array::from_fn, mem::take, slice::from_raw_parts_mut};
+use std::{array::from_fn, mem::take, slice::from_raw_parts_mut, sync::OnceLock};
 
 use flock_core::{
     lincheck::LincheckCircuit,
@@ -780,10 +780,19 @@ pub fn build_matrices() -> (SparseBinaryMatrix, SparseBinaryMatrix) {
     (to_mat(a_rows), to_mat(b_rows))
 }
 
+/// The base matrices, built once per process. They do not depend on the
+/// batch size — `build_block_r1cs` only threads `n_blocks_log` into `m` —
+/// and [`SparseBinaryMatrix`] shares its storage, so every block R1CS,
+/// gate table, and registry in the process reads this ONE 44M-nonzero set.
+fn shared_matrices() -> &'static (SparseBinaryMatrix, SparseBinaryMatrix) {
+    static MATRICES: OnceLock<(SparseBinaryMatrix, SparseBinaryMatrix)> = OnceLock::new();
+    MATRICES.get_or_init(build_matrices)
+}
+
 /// Build a [`BlockR1cs`] batching `2^n_blocks_log` independent BLAKE3
 /// compressions. `n_blocks_log ≥ 3` is required (lincheck needs `n_outer ≥ 8`).
 pub fn build_block_r1cs(n_blocks_log: usize) -> BlockR1cs {
-    let (a_0, b_0) = build_matrices();
+    let (a_0, b_0) = shared_matrices().clone();
     build_block_r1cs_with_matrices(
         n_blocks_log,
         K_LOG,

--- a/crates/flock-prover/src/r1cs_hashes/common.rs
+++ b/crates/flock-prover/src/r1cs_hashes/common.rs
@@ -234,20 +234,12 @@ pub(crate) fn const_add_parts(k: u32, y: u32) -> (u32, u32, u32, u32) {
 /// K × K sparse matrix with no nonzero entries. Used as an `a_0`/`b_0` stub
 /// when the constraint definition lives in a `LincheckCircuit` walker.
 pub(crate) fn empty_matrix(k: usize) -> SparseBinaryMatrix {
-    SparseBinaryMatrix {
-        num_rows: k,
-        num_cols: k,
-        rows: vec![Vec::new(); k],
-    }
+    SparseBinaryMatrix::new(k, k, vec![Vec::new(); k])
 }
 
 /// K × K identity sparse matrix.
 pub(crate) fn identity(k: usize) -> SparseBinaryMatrix {
-    SparseBinaryMatrix {
-        num_rows: k,
-        num_cols: k,
-        rows: (0..k).map(|i| vec![i]).collect(),
-    }
+    SparseBinaryMatrix::new(k, k, (0..k).map(|i| vec![i]).collect())
 }
 
 /// Build a `BlockR1cs` with caller-supplied A_0, B_0 sparse matrices and

--- a/crates/flock-prover/src/r1cs_hashes/merkle_glue.rs
+++ b/crates/flock-prover/src/r1cs_hashes/merkle_glue.rs
@@ -297,11 +297,7 @@ impl SwapTable {
         a[gc] = vec![gc];
         b[gc] = vec![gc];
 
-        let m = |rows: Vec<Vec<usize>>| SparseBinaryMatrix {
-            num_rows: k,
-            num_cols: k,
-            rows,
-        };
+        let m = |rows: Vec<Vec<usize>>| SparseBinaryMatrix::new(k, k, rows);
         (m(a), m(b))
     }
 
@@ -584,11 +580,7 @@ impl BitSpreadTable {
         a[gc] = vec![gc];
         b[gc] = vec![gc];
 
-        let m = |rows: Vec<Vec<usize>>| SparseBinaryMatrix {
-            num_rows: k,
-            num_cols: k,
-            rows,
-        };
+        let m = |rows: Vec<Vec<usize>>| SparseBinaryMatrix::new(k, k, rows);
         (m(a), m(b))
     }
 
@@ -905,11 +897,7 @@ impl FamilyTransposeTileTable {
         a[gc] = vec![gc];
         b[gc] = vec![gc];
 
-        let m = |rows: Vec<Vec<usize>>| SparseBinaryMatrix {
-            num_rows: k,
-            num_cols: k,
-            rows,
-        };
+        let m = |rows: Vec<Vec<usize>>| SparseBinaryMatrix::new(k, k, rows);
         (m(a), m(b))
     }
 
@@ -1096,11 +1084,7 @@ impl PowMaskTable {
         a[gc] = vec![gc];
         b[gc] = vec![gc];
 
-        let m = |rows: Vec<Vec<usize>>| SparseBinaryMatrix {
-            num_rows: k,
-            num_cols: k,
-            rows,
-        };
+        let m = |rows: Vec<Vec<usize>>| SparseBinaryMatrix::new(k, k, rows);
         (m(a), m(b))
     }
 

--- a/crates/flock-prover/src/r1cs_hashes/sha2.rs
+++ b/crates/flock-prover/src/r1cs_hashes/sha2.rs
@@ -707,11 +707,7 @@ pub fn build_matrices() -> (SparseBinaryMatrix, SparseBinaryMatrix) {
         a_rows: &mut a_rows,
         b_rows: &mut b_rows,
     });
-    let to_mat = |rows| SparseBinaryMatrix {
-        num_rows: K,
-        num_cols: K,
-        rows,
-    };
+    let to_mat = |rows| SparseBinaryMatrix::new(K, K, rows);
     (to_mat(a_rows), to_mat(b_rows))
 }
 

--- a/crates/flock-prover/src/tower/chain.rs
+++ b/crates/flock-prover/src/tower/chain.rs
@@ -303,8 +303,10 @@ pub(super) struct ChainShape {
 
 /// The chain SHAPE per n_blocks, cached process-wide: the emission+finish
 /// (~1.4 s at m32) is statement-independent — that is the digest pin — so
-/// the tower's material proofs CLONE the cached shape (Registry + Circuit
-/// memcpy, ~an order of magnitude cheaper) instead of re-emitting it.
+/// the tower's material proofs CLONE the cached shape instead of
+/// re-emitting it. The clone is cheap: the BLAKE3 matrices behind the
+/// registry share their storage (`SparseBinaryMatrix` rows are `Arc`), so
+/// only the circuit and the slot bookkeeping are copied.
 /// `build_chain_proof`'s setup_ms honestly reflects whichever it paid.
 pub(super) fn chain_shape_cached(n_blocks: usize) -> Arc<ChainShape> {
     type Cache = Mutex<Vec<(usize, Arc<ChainShape>)>>;

--- a/crates/flock-prover/src/tower/fl_node.rs
+++ b/crates/flock-prover/src/tower/fl_node.rs
@@ -110,11 +110,12 @@ pub(super) fn chain_jagged_params(cp: &ChainProof) -> JaggedParams {
     )
 }
 
-/// The chain BLAKE3 block R1CS per nu, cached process-wide: the ~21M-nnz
-/// base is identical for every chain proof and every FL's chain-side fold
-/// materials, and the tower bench used to build ten of them. Serves the
-/// borrow-only sites; callers that STORE an R1CS (LeafOuter) still build
-/// their own.
+/// The chain BLAKE3 block R1CS per nu, cached process-wide. The base
+/// matrices are already shared by every `build_block_r1cs` call (see
+/// `r1cs_hashes::blake3`); what this cache adds is the BLOCK, and with it
+/// the lazily built CSC lincheck circuit (~178 MiB) that lives in the
+/// block's `OnceLock` — every chain proof and every FL's chain-side fold
+/// materials then read one circuit instead of rebuilding it per leaf.
 pub(super) fn chain_blake_r1cs(nu: usize) -> Arc<BlockR1cs> {
     type Cache = Mutex<Vec<(usize, Arc<BlockR1cs>)>>;
     static CACHE: OnceLock<Cache> = OnceLock::new();

--- a/crates/flock-prover/src/tower/gates_blake3.rs
+++ b/crates/flock-prover/src/tower/gates_blake3.rs
@@ -9,8 +9,8 @@ use {
 };
 
 use crate::{
-    r1cs_hashes::blake3::{Compression, io_schema},
-    tower::{F128, GateType, SLOT_WORDS, SlotWitness, TableType, fl_node::chain_blake_r1cs},
+    r1cs_hashes::blake3::{Compression, build_block_r1cs, io_schema},
+    tower::{F128, GateType, SLOT_WORDS, SlotWitness, TableType},
 };
 
 pub(super) const DOMAIN: &[u8] = b"flock-circuit-merkle-v0";
@@ -118,10 +118,7 @@ impl GateType for Blake3Gate {
     type Hint = ();
 
     fn table(&self) -> TableType {
-        // The process-wide cached block: the gate table and the leaf's
-        // lincheck circuit (`chain_blake_r1cs` again, in `build_chain_proof`)
-        // then read ONE set of matrices, and `from_block_r1cs` shares it.
-        TableType::from_block_r1cs(&chain_blake_r1cs(self.nu)).with_io_schema(io_schema())
+        TableType::from_block_r1cs(&build_block_r1cs(self.nu)).with_io_schema(io_schema())
     }
 
     fn eval(&self, inputs: &[F128], _hint: &(), outputs: &mut Vec<F128>) -> Self::Row {

--- a/crates/flock-prover/src/tower/gates_blake3.rs
+++ b/crates/flock-prover/src/tower/gates_blake3.rs
@@ -9,8 +9,8 @@ use {
 };
 
 use crate::{
-    r1cs_hashes::blake3::{Compression, build_block_r1cs, io_schema},
-    tower::{F128, GateType, SLOT_WORDS, SlotWitness, TableType},
+    r1cs_hashes::blake3::{Compression, io_schema},
+    tower::{F128, GateType, SLOT_WORDS, SlotWitness, TableType, fl_node::chain_blake_r1cs},
 };
 
 pub(super) const DOMAIN: &[u8] = b"flock-circuit-merkle-v0";
@@ -118,7 +118,10 @@ impl GateType for Blake3Gate {
     type Hint = ();
 
     fn table(&self) -> TableType {
-        TableType::from_block_r1cs(&build_block_r1cs(self.nu)).with_io_schema(io_schema())
+        // The process-wide cached block: the gate table and the leaf's
+        // lincheck circuit (`chain_blake_r1cs` again, in `build_chain_proof`)
+        // then read ONE set of matrices, and `from_block_r1cs` shares it.
+        TableType::from_block_r1cs(&chain_blake_r1cs(self.nu)).with_io_schema(io_schema())
     }
 
     fn eval(&self, inputs: &[F128], _hint: &(), outputs: &mut Vec<F128>) -> Self::Row {

--- a/crates/flock-prover/tests/verifier_roundtrip.rs
+++ b/crates/flock-prover/tests/verifier_roundtrip.rs
@@ -25,11 +25,7 @@ use {
 };
 
 fn identity(k: usize) -> SparseBinaryMatrix {
-    SparseBinaryMatrix {
-        num_rows: k,
-        num_cols: k,
-        rows: (0..k).map(|i| vec![i]).collect(),
-    }
+    SparseBinaryMatrix::new(k, k, (0..k).map(|i| vec![i]).collect())
 }
 
 /// Build an identity-`C` R1CS with identity `A_0`/`B_0` at the given shape.


### PR DESCRIPTION
## What

A chain leaf's peak memory was almost entirely the BLAKE3 base-block R1CS held several times over, not the proof. `build_block_r1cs` yields A with 27.3M and B with 17.2M nonzeros, 44.4M `usize`s at 339 MiB per copy, and a leaf kept three copies live: the shape cache's registry, the per-leaf clone of that shape, and a second `BlockR1cs` built for the lincheck circuit. Two more copies were transient during the build. The node path rebuilt the same matrices again in the child walker, the FL node, and the node.

- `SparseBinaryMatrix::rows` is now `Arc<Vec<Vec<usize>>>`, frozen by a `new` constructor that also releases push slack. `Clone` bumps a count. Readers are unchanged except five `for row in &m.rows` loops, now `m.rows.iter()`.
- The BLAKE3 base matrices are built once per process behind a `OnceLock` in `r1cs_hashes::blake3`; every `build_block_r1cs(nu)` clones the shared set, so every block, gate table, and registry in the process reads one copy.
- `chain_blake_r1cs` stays: it also shares each block's lazily built CSC lincheck circuit (~178 MiB). Its doc now says so.
- All 29 literal constructions rewritten to the constructor. Two stale comments on the old copy cost refreshed.

## What does not change

- The digest hashes matrix contents, so no registry digest, statement digest, or VK fingerprint moves. Every pinned test passes unchanged.
- Prover kernels run on the packed and CSC forms and are untouched.

## Measured

`/usr/bin/time -l` on the M4 Max, peak resident set:

| run | before | after |
| --- | --- | --- |
| `chain_leaf_ag_roundtrip` (leaf 256) | 2.52 GB | 0.84 GB |
| `examples/tower 4 256` | 12.70 GB | 4.34 GB |
| `examples/tower 4 256` prove | 18.5 s | 10.9 s |

The prove-time win is setup memcpy and matrix rebuilds that no longer happen.

## Verification

- `cargo build --workspace --all-targets` and `cargo clippy --workspace --all-targets`: zero warnings.
- `cargo test --release --workspace --exclude flock-cuda-ffi`: 593 passed, 0 failed.
- `flock-cuda-ffi/tests/gpu_roundtrip.rs` got the same one-line `.iter()` loop fix but was not compiled here; the CUDA CI should cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QM85KQp6cT7YH7p7T8szf6
