### PR TITLE
tower: nodes share the cached BLAKE3 block and its CSC lincheck circuit

### DIFF
--- a/crates/flock-prover/src/tower/fl_node.rs
+++ b/crates/flock-prover/src/tower/fl_node.rs
@@ -110,12 +110,13 @@ pub(super) fn chain_jagged_params(cp: &ChainProof) -> JaggedParams {
     )
 }
 
-/// The chain BLAKE3 block R1CS per nu, cached process-wide. The base
-/// matrices are already shared by every `build_block_r1cs` call (see
+/// The BLAKE3 block R1CS per nu, cached process-wide. The base matrices
+/// are already shared by every `build_block_r1cs` call (see
 /// `r1cs_hashes::blake3`); what this cache adds is the BLOCK, and with it
 /// the lazily built CSC lincheck circuit (~178 MiB) that lives in the
-/// block's `OnceLock` — every chain proof and every FL's chain-side fold
-/// materials then read one circuit instead of rebuilding it per leaf.
+/// block's `OnceLock`. Every chain leaf (its own nu), every FL and every
+/// recursion node (the envelope nu*) reads one circuit through here; each
+/// node's [`LeafOuter`] holds the `Arc` rather than a private copy.
 pub(super) fn chain_blake_r1cs(nu: usize) -> Arc<BlockR1cs> {
     type Cache = Mutex<Vec<(usize, Arc<BlockR1cs>)>>;
     static CACHE: OnceLock<Cache> = OnceLock::new();
@@ -978,7 +979,7 @@ pub fn build_fl_node_k(cfg: TowerConfig, cps: &[&ChainProof]) -> FlNode {
             num_lanes: outer_lanes(&union2, pcs_batch_for(&union2, pf)),
             merkle_hash: HashKind::Blake3,
         };
-        let b3_r1cs2 = build_block_r1cs(nu2);
+        let b3_r1cs2 = chain_blake_r1cs(nu2);
         let b3_lc2 = b3_r1cs2.csc_lincheck_circuit();
         let swap_r1cs2 = SwapTable::build_block_r1cs(nu2);
         let swap_lc2 = swap_r1cs2.csc_lincheck_circuit();

--- a/crates/flock-prover/src/tower/node.rs
+++ b/crates/flock-prover/src/tower/node.rs
@@ -39,7 +39,7 @@ use crate::prover::prove_fast_ligerito_union_circuit_ag;
 use crate::{
     prover::{UnionElementSlotInput, prove_fast_ligerito_union_circuit},
     r1cs_hashes::{
-        blake3::{build_block_r1cs, generate_witness_batch_major_partial_into},
+        blake3::generate_witness_batch_major_partial_into,
         fs_chain::{IV, trace_duplex},
     },
     schedule::Registry,
@@ -54,12 +54,12 @@ use crate::{
         check_real_child_region, cw, emit_ag_point_binding, emit_fold_region, emit_fs_chain,
         emit_fs_chain_partitioned, emit_jagged_fold_region, emit_lagrange_lows,
         emit_real_child_region, emit_recorded_pow_checks, env_acc_chain_base, env_acc_main_base,
-        env_app_base, env_pass_base, envelope_shape, expected_real_tail_schedule, flatten_ops,
-        fold_region_ops, jagged_fold_region_ops, labeled_bytes_payloads, leaf_boolean_lcs,
-        leaf_boolean_mats, live_element_input_from_rows, locate_and_pin_folds,
-        locate_and_pin_jagged_folds, merge_chain, outer_lanes, outer_union, outer_zc_ag, pack8,
-        pad_envelope_counts, payload_words, pcs_batch_for, read_acc_entry, replay_fold_endpoints,
-        replay_jagged_fold_endpoints, steady_reps, tower_fold_grinding,
+        env_app_base, env_pass_base, envelope_shape, expected_real_tail_schedule,
+        fl_node::chain_blake_r1cs, flatten_ops, fold_region_ops, jagged_fold_region_ops,
+        labeled_bytes_payloads, leaf_boolean_lcs, leaf_boolean_mats, live_element_input_from_rows,
+        locate_and_pin_folds, locate_and_pin_jagged_folds, merge_chain, outer_lanes, outer_union,
+        outer_zc_ag, pack8, pad_envelope_counts, payload_words, pcs_batch_for, read_acc_entry,
+        replay_fold_endpoints, replay_jagged_fold_endpoints, steady_reps, tower_fold_grinding,
     },
 };
 
@@ -2129,7 +2129,7 @@ pub fn build_node_outer_app(
             merkle_hash: HashKind::Blake3,
         };
         let t_r1cs = Instant::now();
-        let b3_r1cs2 = build_block_r1cs(nu2);
+        let b3_r1cs2 = chain_blake_r1cs(nu2);
         let b3_lc2 = b3_r1cs2.csc_lincheck_circuit();
         let swap_r1cs2 = SwapTable::build_block_r1cs(nu2);
         let swap_lc2 = swap_r1cs2.csc_lincheck_circuit();

--- a/crates/flock-prover/src/tower/query.rs
+++ b/crates/flock-prover/src/tower/query.rs
@@ -1,4 +1,4 @@
-use std::iter::repeat_n;
+use std::{iter::repeat_n, sync::Arc};
 
 use flock_core::{
     circuit::builder::{CircuitShape, SlotId},
@@ -1260,7 +1260,10 @@ pub struct LeafOuter {
     pub(super) proof: MixedProof,
     pub(super) commitment: Commitment,
     pub(super) pcs: PcsParams,
-    pub(super) b3_r1cs: BlockR1cs,
+    /// The BLAKE3 block, shared process-wide (`chain_blake_r1cs`): every
+    /// node at one envelope reads ONE block and ONE compressed lincheck
+    /// circuit instead of building and keeping its own ~170 MiB copy.
+    pub(super) b3_r1cs: Arc<BlockR1cs>,
     pub(super) swap_r1cs: BlockR1cs,
     pub(super) spread_r1cs: BlockR1cs,
     pub(super) pow_r1cs: BlockR1cs,


### PR DESCRIPTION
## What

Every FL and recursion node built its own `build_block_r1cs(nu*)` and kept it by value in its `LeafOuter`, so each node carried a private ~170 MiB CSC lincheck circuit on top of the base matrices that #50 made shared. The leaf path already reads its block through the per-nu `chain_blake_r1cs` cache, which carries the block's lazily built CSC circuit. Both node builders now go through the same cache, and `LeafOuter::b3_r1cs` holds the `Arc`. The four small node tables (swap, spread, pow, family) are unchanged.

## What does not change

- No digest moves: only ownership of an identical block changes.
- Prove kernels untouched; prove times equal within noise.

## Measured

Peak RSS, `/usr/bin/time -l` on the M4 Max, two runs each:

| tower | main | branch |
| --- | --- | --- |
| 4 x 256 | 4.01 to 4.26 GB | 3.61 to 3.69 GB |
| 8 x 256 | 5.68 to 5.70 GB | 4.37 to 4.62 GB |
| 4 x 65536 | 4.60 to 5.06 GB | 4.33 to 4.82 GB |

The saving is one compressed circuit per node, so it grows with node count. At the big-leaf size with only three nodes it sits inside the ±0.4 GB run-to-run swing of when macOS's allocator returns pages, so that row is a wash rather than a win.

## Verification

- `cargo build --workspace --all-targets` and `cargo clippy --workspace --all-targets`: zero warnings.
- `cargo test --release --workspace --exclude flock-cuda-ffi`: 593 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QM85KQp6cT7YH7p7T8szf6
