### PR TITLE
Clean up Rust import paths

### DIFF
--- a/agents/plans/2026-08-28-multilinear-extraction.md
+++ b/agents/plans/2026-08-28-multilinear-extraction.md
@@ -1,0 +1,78 @@
+# Task Plan
+
+## Mission
+
+Improve Flock's code structure and reduce duplication without changing protocol behavior.
+Complete Phase 0, then create `flock-multilinear` and migrate proven shared primitives.
+
+## Sources Of Truth
+
+- User instructions in the active Codex task.
+- Workspace CI commands in `.github/workflows/test.yml` and `.github/workflows/lint.yml`.
+- Current behavior and tests in `flock-core` and `flock-prover`.
+
+## Scope
+
+- Record repository, line-count, build, test, lint, and format baselines.
+- Compare all equality-table and multilinear-evaluation conventions.
+- Use parameters for meaningful conventions such as variable order.
+- Keep one implementation when parameter use has no measured performance cost.
+- Create a dependency-safe `flock-multilinear` crate.
+- Migrate only callers covered by parity tests in this slice.
+
+## Current State
+
+- Phase: Universal import cleanup complete.
+- Last completed: Applied the universal import style to all Rust targets, tests, benches, examples, and binaries.
+- Current result: All imports use explicit names. Standard, external, and crate imports use separate ordered groups. Repeated cfg import gates use one grouped import.
+- Next action: Commit, push, and check PR 42 CI again.
+- Open risk: The Blackwell GPU runner is offline. The user approved completion without this job.
+- Files changed: Phase 0 and Phase 1 are on PR 42.
+- Commands run: Format, native workspace check, release Clippy, release workspace tests, AVX-512 workspace check, and AVX-512 Clippy passed. Source audits found no glob or relative imports.
+
+## Checklist
+
+- [x] Record all Phase 0 baseline results.
+- [x] Classify each current equality-table and MLE implementation.
+- [x] Define explicit variable-order parameters and shape checks.
+- [x] Add `flock-multilinear` to the workspace.
+- [x] Add parity and convention tests.
+- [x] Migrate shared production callers.
+- [x] Remove duplicate covered implementations.
+- [x] Run focused tests and all local CI gates.
+- [x] Search for stale paths and old helper names.
+- [x] Rename protocol errors to specific names.
+- [x] Consolidate production imports at module scope.
+- [x] Reduce internal field visibility with compiler checks.
+- [x] Remove obsolete dead helpers and review remaining target oracles.
+- [x] Remove historical design and milestone comments.
+- [x] Run pinned proof-byte tests through the release workspace suite.
+- [x] Extract binary field types into `flock-field`.
+- [x] Extract challengers and transcript recording into `flock-transcript`.
+- [x] Forward core features and preserve the `flock-core` API through re-exports.
+- [x] Extract hash selection and compression primitives into `flock-hash`.
+- [x] Extract Merkle commitments into `flock-merkle`.
+- [x] Make Merkle construction and verification generic over `MerkleHash`.
+- [x] Keep runtime hash selection and optimized hash kernels as compatibility paths.
+- [x] Require exact equality-table iterator lengths.
+- [x] Move F128 slice kernels into `flock-field`.
+- [x] Give Merkle hashing traits to `flock-merkle`.
+- [x] Share one all-core rayon pool through `flock-parallel`.
+- [x] Use direct owner-crate imports from `flock-prover`.
+- [x] Repair stale crate paths in repository documentation.
+- [x] Remove all function-local imports from Rust code.
+- [x] Replace inline paths for structs, enums, functions, traits, and constants.
+- [x] Keep test-only imports at the top of each test module.
+- [x] Run the syntax-tree audit again and run all local CI gates.
+- [x] Remove all wildcard imports, including test preludes and public re-exports.
+- [x] Group imports as standard library, external crates, then crate modules.
+- [x] Sort external crate imports alphabetically.
+- [x] Consolidate imports that use the same cfg gate.
+- [x] Add a workspace Clippy rule against wildcard imports.
+
+## Recovery
+
+1. Reread this file.
+2. Inspect current repository state.
+3. Emit `CHECKPOINT RESTORED`.
+4. Continue from Current State.

--- a/crates/flock-core/src/aggregate.rs
+++ b/crates/flock-core/src/aggregate.rs
@@ -40,6 +40,14 @@
 //! So a leaf over two proofs folds `2 → 1`, and a `2 → 1` merge of two
 //! recursive proofs folds `4 → 1` (two inherited, two fresh).
 
+use crate::challenger::FsChallenger;
+use crate::circuit::Circuit;
+use crate::circuit::SigmaAssertion;
+use crate::element_r1cs::SparseF128Matrix;
+use crate::element_r1cs::union::VerifyError as ElementVerifyError;
+use crate::lincheck::LincheckCircuit;
+use crate::matrix_fold::bilinear;
+use crate::union::UnionInstance;
 use serde::{Deserialize, Serialize};
 
 use crate::challenger::Challenger;
@@ -57,10 +65,7 @@ pub type TypeMatrices<'a> = (&'a SparseBinaryMatrix, &'a SparseBinaryMatrix);
 
 /// The base matrices of one element type, `(A₀, B₀)` — `F128` coefficients,
 /// not `GF(2)` supports.
-pub type ElementMatrices<'a> = (
-    &'a crate::element_r1cs::SparseF128Matrix,
-    &'a crate::element_r1cs::SparseF128Matrix,
-);
+pub type ElementMatrices<'a> = (&'a SparseF128Matrix, &'a SparseF128Matrix);
 
 /// Accumulated matrix claims: one `(A₀, B₀)` pair per boolean type, in slot
 /// order, tied to the registry they are about.
@@ -104,10 +109,7 @@ impl Accumulator {
     /// pass does not have this problem, because there A and B share a row
     /// weight and one call serves both. Kept for callers without the raw
     /// matrices; prefer `discharge`.
-    pub fn discharge_with_circuits(
-        &self,
-        circuits: &[&dyn crate::lincheck::LincheckCircuit],
-    ) -> bool {
+    pub fn discharge_with_circuits(&self, circuits: &[&dyn LincheckCircuit]) -> bool {
         if self.per_type.len() != circuits.len() {
             return false;
         }
@@ -149,16 +151,13 @@ impl Accumulator {
 
     /// The sigma group's root discharge: the folded claim against the real
     /// sigma table — `O(2^mu)`, once. `true` when no sigma was accumulated.
-    pub fn discharge_sigma(&self, circuit: &crate::circuit::Circuit) -> bool {
+    pub fn discharge_sigma(&self, circuit: &Circuit) -> bool {
         match &self.sigma {
             None => true,
             Some((digest, claim)) => {
                 *digest == circuit.digest()
-                    && crate::matrix_fold::bilinear(
-                        &claim.row,
-                        &claim.col,
-                        &crate::circuit::SigmaAssertion::matrix(circuit),
-                    ) == claim.value
+                    && bilinear(&claim.row, &claim.col, &SigmaAssertion::matrix(circuit))
+                        == claim.value
             }
         }
     }
@@ -188,7 +187,7 @@ pub enum AggregateError {
     /// target (`MatrixAssertion::check_reported`).
     Reported(VerifyError),
     /// Likewise on the element side.
-    ReportedElement(crate::element_r1cs::union::VerifyError),
+    ReportedElement(ElementVerifyError),
     /// A fold did not verify.
     Fold(matrix_fold::FoldError),
     /// The accumulated claims did not hold against the real matrices.
@@ -230,12 +229,22 @@ fn bind<Ch: Challenger>(registry: &Registry, prior: Option<&Accumulator>, ch: &m
 pub fn prove_aggregate<Ch: Challenger>(
     registry: &Registry,
     mats: &[TypeMatrices<'_>],
-    circuits: &[&dyn crate::lincheck::LincheckCircuit],
+    circuits: &[&dyn LincheckCircuit],
     assertions: &[MatrixAssertion],
     prior: Option<&Accumulator>,
     ch: &mut Ch,
 ) -> Result<(AggregateProof, Accumulator), AggregateError> {
-    prove_aggregate_classes(registry, mats, circuits, assertions, &[], &[], None, prior, ch)
+    prove_aggregate_classes(
+        registry,
+        mats,
+        circuits,
+        assertions,
+        &[],
+        &[],
+        None,
+        prior,
+        ch,
+    )
 }
 
 /// [`prove_aggregate`] over BOTH classes: the boolean assertions against
@@ -246,11 +255,11 @@ pub fn prove_aggregate<Ch: Challenger>(
 pub fn prove_aggregate_classes<Ch: Challenger>(
     registry: &Registry,
     mats: &[TypeMatrices<'_>],
-    circuits: &[&dyn crate::lincheck::LincheckCircuit],
+    circuits: &[&dyn LincheckCircuit],
     assertions: &[MatrixAssertion],
     el_mats: &[ElementMatrices<'_>],
-    el_assertions: &[(&crate::union::UnionInstance<'_>, ElementAssertion)],
-    sigma: Option<(&crate::circuit::Circuit, &[crate::circuit::SigmaAssertion])>,
+    el_assertions: &[(&UnionInstance<'_>, ElementAssertion)],
+    sigma: Option<(&Circuit, &[SigmaAssertion])>,
     prior: Option<&Accumulator>,
     ch: &mut Ch,
 ) -> Result<(AggregateProof, Accumulator), AggregateError> {
@@ -322,8 +331,7 @@ pub fn prove_aggregate_classes<Ch: Challenger>(
         per_element.push((out_a, out_b));
     }
 
-    let (sigma_fold, sigma_out) =
-        fold_sigma_prove(sigma, prior, ch)?;
+    let (sigma_fold, sigma_out) = fold_sigma_prove(sigma, prior, ch)?;
 
     Ok((
         AggregateProof {
@@ -344,7 +352,7 @@ pub fn prove_aggregate_classes<Ch: Challenger>(
 /// one claim per assertion — the same fixed order every group uses. All
 /// claims must name the SAME circuit (digest-keyed; normalisation).
 fn fold_sigma_prove<Ch: Challenger>(
-    sigma: Option<(&crate::circuit::Circuit, &[crate::circuit::SigmaAssertion])>,
+    sigma: Option<(&Circuit, &[SigmaAssertion])>,
     prior: Option<&Accumulator>,
     ch: &mut Ch,
 ) -> Result<(Option<FoldProof>, Option<([u8; 32], MatrixClaim)>), AggregateError> {
@@ -375,7 +383,7 @@ fn fold_sigma_prove<Ch: Challenger>(
     if claims.is_empty() {
         return Ok((None, None));
     }
-    let m = crate::circuit::SigmaAssertion::matrix(circuit);
+    let m = SigmaAssertion::matrix(circuit);
     let n_cols = matrix_fold::FoldMatrix::n_cols(&m);
     let combs: Vec<Vec<F128>> = claims
         .iter()
@@ -388,7 +396,7 @@ fn fold_sigma_prove<Ch: Challenger>(
 /// Element claims to fold for one type: the prior's first, then one per
 /// assertion — the same fixed order the boolean side uses.
 fn gather_element(
-    assertions: &[(&crate::union::UnionInstance<'_>, ElementAssertion)],
+    assertions: &[(&UnionInstance<'_>, ElementAssertion)],
     prior: Option<&Accumulator>,
     t: usize,
 ) -> (Vec<MatrixClaim>, Vec<MatrixClaim>) {
@@ -419,12 +427,12 @@ fn gather_element(
 pub fn fold_and_discharge(
     registry: &Registry,
     mats: &[TypeMatrices<'_>],
-    circuits: &[&dyn crate::lincheck::LincheckCircuit],
+    circuits: &[&dyn LincheckCircuit],
     assertions: &[MatrixAssertion],
 ) -> Result<(), AggregateError> {
-    let mut chp = crate::challenger::FsChallenger::new(DOMAIN);
+    let mut chp = FsChallenger::new(DOMAIN);
     let (proof, _) = prove_aggregate(registry, mats, circuits, assertions, None, &mut chp)?;
-    let mut chv = crate::challenger::FsChallenger::new(DOMAIN);
+    let mut chv = FsChallenger::new(DOMAIN);
     let acc = verify_aggregate(registry, assertions, None, &proof, &mut chv)?;
     if acc.discharge(mats) {
         Ok(())
@@ -457,8 +465,8 @@ pub fn verify_aggregate<Ch: Challenger>(
 pub fn verify_aggregate_classes<Ch: Challenger>(
     registry: &Registry,
     assertions: &[MatrixAssertion],
-    el_assertions: &[(&crate::union::UnionInstance<'_>, ElementAssertion)],
-    sigma: Option<(&crate::circuit::Circuit, &[crate::circuit::SigmaAssertion])>,
+    el_assertions: &[(&UnionInstance<'_>, ElementAssertion)],
+    sigma: Option<(&Circuit, &[SigmaAssertion])>,
     prior: Option<&Accumulator>,
     proof: &AggregateProof,
     ch: &mut Ch,
@@ -537,8 +545,8 @@ pub fn verify_aggregate_classes<Ch: Challenger>(
                 match (claims.is_empty(), pf_opt) {
                     (true, None) => None,
                     (false, Some(pf)) => {
-                        let out =
-                            matrix_fold::verify_fold(&claims, pf, ch).map_err(AggregateError::Fold)?;
+                        let out = matrix_fold::verify_fold(&claims, pf, ch)
+                            .map_err(AggregateError::Fold)?;
                         Some((digest, out))
                     }
                     _ => return Err(AggregateError::Malformed),

--- a/crates/flock-core/src/bits.rs
+++ b/crates/flock-core/src/bits.rs
@@ -9,6 +9,9 @@
 /// idiom. (It previously sat behind `#![feature(...)]`, which made the tree
 /// nightly-only, then a hard error on stable once the feature landed.) Do not
 /// "simplify" this back.
+use crate::zerocheck::univariate_skip_optimized::bit_transpose_64bytes;
+#[cfg(test)]
+use std::array::from_fn;
 #[inline(always)]
 pub fn lowest_one(x: usize) -> usize {
     x & x.wrapping_neg()
@@ -49,7 +52,7 @@ pub fn transpose_8_u64s_to_64_bytes(lanes: &[u64; 8], out: &mut [u8]) {
     // SAFETY: [u64; 8] is 64 bytes with no padding; u8 has weaker alignment.
     let input: &[u8; 64] = unsafe { &*(lanes.as_ptr() as *const [u8; 64]) };
     let out64: &mut [u8; 64] = out.try_into().expect("64-byte stripe slice");
-    crate::zerocheck::univariate_skip_optimized::bit_transpose_64bytes(input, out64);
+    bit_transpose_64bytes(input, out64);
 }
 
 #[cfg(test)]
@@ -108,7 +111,7 @@ mod tests {
             z ^ (z >> 31)
         };
         for _ in 0..100 {
-            let lanes: [u64; 8] = std::array::from_fn(|_| next());
+            let lanes: [u64; 8] = from_fn(|_| next());
             let mut fast = [0u8; 64];
             let mut oracle = [0u8; 64];
             transpose_8_u64s_to_64_bytes(&lanes, &mut fast);
@@ -116,7 +119,7 @@ mod tests {
             assert_eq!(fast, oracle);
         }
         // Edge patterns.
-        for lanes in [[0u64; 8], [u64::MAX; 8], std::array::from_fn(|i| 1u64 << i)] {
+        for lanes in [[0u64; 8], [u64::MAX; 8], from_fn(|i| 1u64 << i)] {
             let mut fast = [0u8; 64];
             let mut oracle = [0u8; 64];
             transpose_8_u64s_to_64_bytes(&lanes, &mut fast);

--- a/crates/flock-core/src/challenger.rs
+++ b/crates/flock-core/src/challenger.rs
@@ -33,6 +33,9 @@
 use crate::field::F128;
 use crate::hash::HashKind;
 use sha2::{Digest, Sha256};
+use std::array::from_fn;
+#[cfg(test)]
+use std::collections::HashSet;
 
 // `Send` supertrait: the verifier runs its PIOP/PCS replay inside a dedicated
 // single-thread rayon pool (see `verifier::verifier_pool`), so the challenger
@@ -446,8 +449,6 @@ impl Challenger for FsChallenger {
     }
 
     fn grind_pow(&mut self, bits: u32) -> u64 {
-        let kind = self.hash_kind();
-        let state_digest = self.state_digest();
         // Aggregate-aware parallelism: decide on the grind's *expected hash
         // work* (`2^bits`), not a raw bit threshold. Fold-challenge grinds are
         // individually modest — e.g. 2^15 at L0 under the per-round profiles —
@@ -465,6 +466,9 @@ impl Challenger for FsChallenger {
         // per task, small enough to keep cancellation granular once an earlier
         // task has found a match.
         const GRIND_CHUNK: u64 = 1 << 10;
+        let kind = self.hash_kind();
+        let state_digest = self.state_digest();
+
         let nonce = if bits == 0 {
             0
         } else if (1u64 << bits.min(63)) < PARALLEL_GRIND_MIN_HASHES {
@@ -671,7 +675,7 @@ fn blake3_pow_scan(state_digest: &[u8; 32], start: u64, len: u64, bits: u32) -> 
         }
         #[cfg(feature = "hash-count")]
         fs_count::POW_SHA256.fetch_add(n as u64, std::sync::atomic::Ordering::Relaxed);
-        let inputs: [&[u8; 64]; BLAKE3_POW_BATCH] = std::array::from_fn(|i| &pre[i]);
+        let inputs: [&[u8; 64]; BLAKE3_POW_BATCH] = from_fn(|i| &pre[i]);
         plat.hash_many(
             &inputs[..n],
             &IV,
@@ -859,7 +863,7 @@ mod tests {
             // catches a counter that fails to advance, or an XOF read that
             // restarts per block.
             let vals = FsChallenger::with_hash(b"d", kind).sample_f128_vec(16);
-            let unique: std::collections::HashSet<_> = vals.iter().collect();
+            let unique: HashSet<_> = vals.iter().collect();
             assert_eq!(unique.len(), vals.len(), "{kind}: squeeze stream repeats");
         }
     }

--- a/crates/flock-core/src/circuit.rs
+++ b/crates/flock-core/src/circuit.rs
@@ -70,7 +70,17 @@
 
 pub mod builder;
 
+use crate::matrix_fold::DenseMatrix;
+use crate::matrix_fold::MatrixClaim;
+use crate::matrix_fold::Weight;
+use crate::matrix_fold::bilinear;
+use crate::scratch::give_f128;
+use crate::scratch::take_f128;
+#[cfg(test)]
+use std::collections::BTreeSet;
+use std::env::var;
 use std::sync::OnceLock;
+use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 
@@ -616,13 +626,13 @@ pub fn prove_wiring<C: Challenger>(
     // Phase trace, `WIRING_TRACE=1` — the module's counterpart of `PCS_TRACE` /
     // `GKR_TRACE`, so the wiring overhead can be attributed (build w vs the
     // grand product vs the gather folds) without instrumenting the caller.
-    let trace = std::env::var("WIRING_TRACE").is_ok();
-    let t = std::time::Instant::now();
+    let trace = var("WIRING_TRACE").is_ok();
+    let t = Instant::now();
 
     // ---- w over the cell space. Gate cells read the committed buffer; public
     // cells take the statement words; dummy cells are zero (pooled buffers come
     // back dirty, so every slot is written).
-    let mut w = crate::scratch::take_f128(1usize << mu);
+    let mut w = take_f128(1usize << mu);
     for (iota, slot) in cells.slots().iter().enumerate() {
         let dst = &mut w[iota << nu..(iota + 1) << nu];
         match *slot {
@@ -648,9 +658,9 @@ pub fn prove_wiring<C: Challenger>(
     }
 
     // ---- One grand-product permutation check at f = g = w.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let (gkr, claim) = product_gkr::prove_batched(&w, &w, circuit.sigma(), ch);
-    crate::scratch::give_f128(w);
+    give_f128(w);
     if trace {
         eprintln!(
             "  [wiring] product GKR (μ = {mu}): {:7.2} ms",
@@ -661,7 +671,7 @@ pub fn prove_wiring<C: Challenger>(
     // ---- The gather: one eq-weighted row fold per gate cell-slot, O(2^ν)
     // each, landing on the packed-direct claim shape (design doc, Lemma
     // "Gather factorization").
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let eq_row = build_eq(&claim.rho[..nu]);
     let mut gather = Vec::with_capacity(cells.num_gate_slots());
     let mut claims = Vec::with_capacity(cells.num_gate_slots());
@@ -719,19 +729,19 @@ impl SigmaAssertion {
     /// The accumulator's form: a `MatrixClaim` on the sigma table reshaped
     /// `2^nu × 2^c` (`M[r, c] = s_sig[(c << nu) + r]` — the cell space's
     /// `(col << nu) | row` convention, so the point splits row-low).
-    pub fn claim(&self) -> crate::matrix_fold::MatrixClaim {
-        crate::matrix_fold::MatrixClaim {
-            row: crate::matrix_fold::Weight::eq(self.rho[..self.nu].to_vec()),
-            col: crate::matrix_fold::Weight::eq(self.rho[self.nu..].to_vec()),
+    pub fn claim(&self) -> MatrixClaim {
+        MatrixClaim {
+            row: Weight::eq(self.rho[..self.nu].to_vec()),
+            col: Weight::eq(self.rho[self.nu..].to_vec()),
             value: self.value,
         }
     }
 
     /// The sigma table in the accumulator's matrix shape, from the SAME
     /// encoding the verifier evaluates ([`product_gkr::build_s_sigma_vec`]).
-    pub fn matrix(circuit: &Circuit) -> crate::matrix_fold::DenseMatrix {
+    pub fn matrix(circuit: &Circuit) -> DenseMatrix {
         let cells = circuit.cells();
-        crate::matrix_fold::DenseMatrix {
+        DenseMatrix {
             vals: product_gkr::build_s_sigma_vec(cells.mu(), circuit.sigma()),
             n_rows_log: cells.nu(),
         }
@@ -741,7 +751,7 @@ impl SigmaAssertion {
     /// `O(2^mu)`, paid once at the root, never per node.
     pub fn check(&self, circuit: &Circuit) -> bool {
         let c = self.claim();
-        crate::matrix_fold::bilinear(&c.row, &c.col, &Self::matrix(circuit)) == self.value
+        bilinear(&c.row, &c.col, &Self::matrix(circuit)) == self.value
     }
 }
 
@@ -1104,8 +1114,7 @@ mod tests {
         let sigma = circuit.sigma();
         let cells = circuit.cells();
         assert_eq!(sigma.len(), 1 << cells.mu());
-        let wired: std::collections::BTreeSet<usize> =
-            circuit.wires().iter().flatten().copied().collect();
+        let wired: BTreeSet<usize> = circuit.wires().iter().flatten().copied().collect();
         for (x, &sx) in sigma.iter().enumerate() {
             if !wired.contains(&x) {
                 assert_eq!(sx, x, "unwired cells are fixed points");
@@ -1369,14 +1378,17 @@ mod tests {
         let mc = assertion.claim();
         let m = SigmaAssertion::matrix(&circuit);
         assert_eq!(
-            crate::matrix_fold::bilinear(&mc.row, &mc.col, &m),
+            bilinear(&mc.row, &mc.col, &m),
             mc.value,
             "the MatrixClaim form discharges — the accumulator's path"
         );
 
         let mut bad = assertion.clone();
         bad.value += F128::ONE;
-        assert!(!bad.check(&circuit), "a tampered assertion fails the discharge");
+        assert!(
+            !bad.check(&circuit),
+            "a tampered assertion fails the discharge"
+        );
 
         let mut bad_proof = proof.clone();
         bad_proof.gkr.s_sigma_eval += F128::ONE;

--- a/crates/flock-core/src/circuit/builder.rs
+++ b/crates/flock-core/src/circuit/builder.rs
@@ -33,7 +33,10 @@
 //! a *regenerated* circuit must be the SAME circuit, not merely an equivalent
 //! one.
 
+use std::any::type_name;
 use std::any::{Any, TypeId};
+use std::cmp::Reverse;
+use std::mem::take;
 
 use crate::field::F128;
 use crate::schedule::{IoDirection, Registry, TableType};
@@ -175,7 +178,7 @@ where
         let hint = hint.downcast_ref::<G::Hint>().unwrap_or_else(|| {
             panic!(
                 "gate expects a hint of type {}; use gate_hinted and supply one",
-                std::any::type_name::<G::Hint>()
+                type_name::<G::Hint>()
             )
         });
         let (outputs, row) = self.gate.eval(inputs, hint);
@@ -390,7 +393,7 @@ impl ShapeBuilder {
         if ra == rb {
             return;
         }
-        let cells = std::mem::take(&mut self.wires[rb]);
+        let cells = take(&mut self.wires[rb]);
         self.wires[ra].extend(cells);
         self.parent[rb] = ra;
     }
@@ -418,7 +421,7 @@ impl ShapeBuilder {
             })
             .collect();
         let mut order: Vec<usize> = (0..meta.len()).collect();
-        order.sort_by_key(|&i| (meta[i].0, std::cmp::Reverse(meta[i].1)));
+        order.sort_by_key(|&i| (meta[i].0, Reverse(meta[i].1)));
 
         let registry = Registry::new(
             order

--- a/crates/flock-core/src/element_r1cs.rs
+++ b/crates/flock-core/src/element_r1cs.rs
@@ -67,7 +67,10 @@ pub mod lincheck;
 pub mod union;
 pub mod zerocheck;
 
+use crate::zerocheck::univariate_skip::build_eq;
 use std::sync::OnceLock;
+#[cfg(test)]
+use std::time::Instant;
 
 use crate::challenger::Challenger;
 use crate::field::F128;
@@ -922,7 +925,7 @@ fn broadcast_add(v: &mut [F128], c: &[F128], n_log: usize) {
 /// unity over the row block). `O(2^kappa)` for the verifier.
 fn strip_constants(ty: &ElementTableType, zc: &zerocheck::Claim) -> (F128, F128) {
     let r_con = &zc.r[zc.r.len() - ty.kappa()..];
-    let eq_con = crate::zerocheck::univariate_skip::build_eq(r_con);
+    let eq_con = build_eq(r_con);
     let dot = |c: &[F128]| -> F128 {
         eq_con
             .iter()
@@ -1399,6 +1402,9 @@ mod e2e_tests {
     /// `ẑ(r')` by the lincheck's residual check.
     #[test]
     fn wrong_claim_values_are_rejected() {
+        // `ea`/`eb` feed the lincheck target, so tampering with either breaks
+        // the reduction rather than the zerocheck.
+        type Tamper = fn(&mut ElementProof);
         let mut rng = Rng::new(161803);
         let (n_log, n) = (6usize, 40usize);
         let ty = mult_gate(2);
@@ -1427,9 +1433,6 @@ mod e2e_tests {
             "wrong z_eval"
         );
 
-        // `ea`/`eb` feed the lincheck target, so tampering with either breaks
-        // the reduction rather than the zerocheck.
-        type Tamper = fn(&mut ElementProof);
         for (name, mutate) in [
             ("ea", (|p| p.zerocheck.ea += F128::ONE) as Tamper),
             ("eb", |p| p.zerocheck.eb += F128::ONE),
@@ -1572,19 +1575,19 @@ mod e2e_tests {
         let n = (1usize << n_log) - 3; // non-trivial, near-full utilization
         let z = mult_witness(&ty, n_log, n, &mut Rng::new(7));
 
-        let t_wit = std::time::Instant::now();
+        let t_wit = Instant::now();
         let (mut pa, mut pb) = ty.apply(&z, n_log);
         broadcast_add(&mut pa, ty.a_const(), n_log);
         broadcast_add(&mut pb, ty.b_const(), n_log);
         let wit_ms = t_wit.elapsed().as_secs_f64() * 1e3;
 
         let mut ch = FsChallenger::new(b"element-smoke");
-        let t_zc = std::time::Instant::now();
+        let t_zc = Instant::now();
         let (_zc_proof, zc_claim) = zerocheck::prove(pa, pb, &z, n_log + kappa, &mut ch);
         let zc_ms = t_zc.elapsed().as_secs_f64() * 1e3;
 
         let (va, vb) = strip_constants(&ty, &zc_claim);
-        let t_lc = std::time::Instant::now();
+        let t_lc = Instant::now();
         let (_lc_proof, lc_claim) = lincheck::prove(&ty, &z, n_log, &zc_claim.r, va, vb, &mut ch);
         let lc_ms = t_lc.elapsed().as_secs_f64() * 1e3;
 

--- a/crates/flock-core/src/element_r1cs/lincheck.rs
+++ b/crates/flock-core/src/element_r1cs/lincheck.rs
@@ -55,6 +55,11 @@
 //! Rounds bind the **top** remaining variable, so the challenge list reversed is
 //! the column point LSB-first — matching the rows-low witness layout.
 
+#[cfg(test)]
+use crate::element_r1cs::ElementTableBuilder;
+use crate::pcs::ring_switch::build_eq_parallel;
+#[cfg(test)]
+use crate::zerocheck::multilinear::fold_in_place_single;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -342,7 +347,7 @@ fn comb_vector(ty: &ElementTableType, alpha: F128, eq_con: &[F128]) -> Vec<F128>
 /// reducing per-column accumulators is the thing to try. Left simple: the
 /// milestone is 3× inside its target.
 fn partial_fold_rows(z: &[F128], r_row: &[F128]) -> Vec<F128> {
-    let eq_row = crate::pcs::ring_switch::build_eq_parallel(r_row);
+    let eq_row = build_eq_parallel(r_row);
     let rows = eq_row.len();
     debug_assert_eq!(z.len() % rows, 0);
     z.par_chunks(rows)
@@ -366,7 +371,7 @@ mod tests {
     fn mle_eval(table: &[F128], point: &[F128]) -> F128 {
         let mut t = table.to_vec();
         for &p in point {
-            crate::zerocheck::multilinear::fold_in_place_single(&mut t, p);
+            fold_in_place_single(&mut t, p);
         }
         t[0]
     }
@@ -597,7 +602,7 @@ mod tests {
     fn kappa_one_roundtrips() {
         let mut rng = Rng::new(31337);
         // kappa = 1: one column, a free wire (tautology row).
-        let mut b = crate::element_r1cs::ElementTableBuilder::new(1);
+        let mut b = ElementTableBuilder::new(1);
         b.free_wire(0);
         let ty = b.build().expect("free wire is valid");
         let n_log = 4usize;

--- a/crates/flock-core/src/element_r1cs/union.rs
+++ b/crates/flock-core/src/element_r1cs/union.rs
@@ -78,6 +78,15 @@
 //! fixed Boolean pattern, which is why they open as **packed-direct** claims
 //! with a `Sparse` eq tensor and no ring-switching.
 
+#[cfg(test)]
+use crate::element_r1cs::broadcast_add;
+use crate::matrix_fold::Weight;
+use crate::matrix_fold::bilinear;
+use crate::pcs::ring_switch::build_eq_parallel;
+#[cfg(test)]
+use crate::r1cs::SparseBinaryMatrix;
+#[cfg(test)]
+use crate::schedule::TableClass;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -450,11 +459,11 @@ fn slot_matrix_evals(
         .iter()
         .map(|s| {
             let kappa = s.layout.kappa;
-            let row = crate::matrix_fold::Weight::eq(r[nu..nu + kappa].to_vec());
-            let col = crate::matrix_fold::Weight::eq(r_col[..kappa].to_vec());
+            let row = Weight::eq(r[nu..nu + kappa].to_vec());
+            let col = Weight::eq(r_col[..kappa].to_vec());
             (
-                crate::matrix_fold::bilinear(&row, &col, s.ty.a_0()),
-                crate::matrix_fold::bilinear(&row, &col, s.ty.b_0()),
+                bilinear(&row, &col, s.ty.a_0()),
+                bilinear(&row, &col, s.ty.b_0()),
             )
         })
         .collect()
@@ -485,8 +494,8 @@ impl ElementAssertion {
             .zip(&self.evals)
             .map(|(s, &(va, vb))| {
                 let kappa = s.layout.kappa;
-                let row = crate::matrix_fold::Weight::eq(self.r_con[..kappa].to_vec());
-                let col = crate::matrix_fold::Weight::eq(self.r_col[..kappa].to_vec());
+                let row = Weight::eq(self.r_con[..kappa].to_vec());
+                let col = Weight::eq(self.r_col[..kappa].to_vec());
                 (
                     MatrixClaim {
                         row: row.clone(),
@@ -577,7 +586,7 @@ fn region_comb_at(
 /// (where it is zero), which is what makes the output claim an evaluation of
 /// the committed polynomial.
 fn collapse_rows(z: &[F128], r_row: &[F128], live: Option<&[usize]>) -> Vec<F128> {
-    let eq_row = crate::pcs::ring_switch::build_eq_parallel(r_row);
+    let eq_row = build_eq_parallel(r_row);
     let rows = eq_row.len();
     debug_assert_eq!(z.len() % rows, 0);
     z.par_chunks(rows)
@@ -713,23 +722,23 @@ mod tests {
         TableType {
             k_log,
             useful_bits,
-            a_0: crate::r1cs::SparseBinaryMatrix {
+            a_0: SparseBinaryMatrix {
                 num_rows: 0,
                 num_cols: 0,
                 rows: Vec::new(),
             },
-            b_0: crate::r1cs::SparseBinaryMatrix {
+            b_0: SparseBinaryMatrix {
                 num_rows: 0,
                 num_cols: 0,
                 rows: Vec::new(),
             },
-            c_0: crate::r1cs::SparseBinaryMatrix {
+            c_0: SparseBinaryMatrix {
                 num_rows: 0,
                 num_cols: 0,
                 rows: Vec::new(),
             },
             const_pin: None,
-            class: crate::schedule::TableClass::Boolean,
+            class: TableClass::Boolean,
             io_schema: Vec::new(),
         }
     }
@@ -1445,8 +1454,8 @@ dense {:6.2} [{:5.2} – {:5.2}]  support {:6.2} [{:5.2} – {:5.2}]  {:4.1}x",
         let rows = mixed_witness(&ty, nu, n, &mut rng);
 
         let (mut apply_a, mut apply_b) = ty.apply(&rows, nu);
-        crate::element_r1cs::broadcast_add(&mut apply_a, ty.a_const(), nu);
-        crate::element_r1cs::broadcast_add(&mut apply_b, ty.b_const(), nu);
+        broadcast_add(&mut apply_a, ty.a_const(), nu);
+        broadcast_add(&mut apply_b, ty.b_const(), nu);
 
         let words = ty.width() << nu;
         let mut z = vec![F128::ZERO; words];

--- a/crates/flock-core/src/element_r1cs/zerocheck.rs
+++ b/crates/flock-core/src/element_r1cs/zerocheck.rs
@@ -29,8 +29,13 @@
 //! - `ec = ẑ(r)`. Because `C = I` this is *directly* a witness evaluation, so it
 //!   leaves as a packed-direct claim with no lincheck term.
 
+use crate::scratch::give_f128;
+use crate::scratch::take_f128;
+use crate::zerocheck::multilinear::fold_in_place_single;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::mem::replace;
+use std::mem::take;
 
 use crate::challenger::Challenger;
 use crate::field::F128;
@@ -242,7 +247,7 @@ pub fn prove_with_support<C: Challenger>(
     let mut wz = match &sparse {
         Some(sup) => {
             let rows = 1usize << nu;
-            let mut w = crate::scratch::take_f128(n_words);
+            let mut w = take_f128(n_words);
             for (c, &n) in sup.live.iter().enumerate() {
                 w[c * rows..c * rows + n].copy_from_slice(&z[c * rows..c * rows + n]);
             }
@@ -282,7 +287,7 @@ pub fn prove_with_support<C: Challenger>(
                     // then fails to reconcile (a count-0 slot is exactly this
                     // case). `wz` really is zero: the witness is.
                     // O(columns), negligible.
-                    let done = std::mem::take(&mut sparse).expect("checked");
+                    let done = take(&mut sparse).expect("checked");
                     for (c, &n) in done.live.iter().enumerate() {
                         if n == 0 {
                             wa[c] = done.a_dead[c];
@@ -313,7 +318,7 @@ pub fn prove_with_support<C: Challenger>(
 
     // Recycle the folded tables (each still owns its full round-1 capacity).
     for v in [wa, wb, wz] {
-        crate::scratch::give_f128(v);
+        give_f128(v);
     }
 
     let proof = Proof { rounds, ea, eb, ec };
@@ -566,7 +571,7 @@ fn fold_low_sparse(u: &mut Vec<F128>, rho: F128, row_vars: usize, live: &[usize]
         .filter(|&(_, &n)| n > 0)
         .map(|(c, &n)| (c * pairs, c * pairs + n.div_ceil(2)))
         .collect();
-    let mut out = crate::scratch::take_f128(half);
+    let mut out = take_f128(half);
     {
         let src: &[F128] = u;
         let total = live_pairs_total(&iv);
@@ -599,8 +604,8 @@ fn fold_low_sparse(u: &mut Vec<F128>, rho: F128, row_vars: usize, live: &[usize]
             }
         }
     }
-    let old = std::mem::replace(u, out);
-    crate::scratch::give_f128(old);
+    let old = replace(u, out);
+    give_f128(old);
 }
 
 /// [`fold_low_sparse`] for the witness table, whose dead rows are genuinely
@@ -634,7 +639,7 @@ fn fold_low(u: &mut Vec<F128>, rho: F128) {
         Some(min_len) => {
             // `take_f128(half)` returns a length-`half` buffer; the map writes
             // every slot, satisfying the write-before-read contract.
-            let mut out = crate::scratch::take_f128(half);
+            let mut out = take_f128(half);
             {
                 let src: &[F128] = u;
                 out.par_iter_mut()
@@ -645,10 +650,10 @@ fn fold_low(u: &mut Vec<F128>, rho: F128) {
                         *o = a0 + rho * (src[2 * x + 1] + a0);
                     });
             }
-            let old = std::mem::replace(u, out);
-            crate::scratch::give_f128(old);
+            let old = replace(u, out);
+            give_f128(old);
         }
-        None => crate::zerocheck::multilinear::fold_in_place_single(u, rho),
+        None => fold_in_place_single(u, rho),
     }
 }
 
@@ -665,7 +670,7 @@ mod tests {
     fn mle_eval(table: &[F128], point: &[F128]) -> F128 {
         let mut t = table.to_vec();
         for &p in point {
-            crate::zerocheck::multilinear::fold_in_place_single(&mut t, p);
+            fold_in_place_single(&mut t, p);
         }
         t[0]
     }
@@ -959,7 +964,7 @@ mod tests {
             let mut a = v.clone();
             fold_low(&mut a, rho);
             let mut b = v;
-            crate::zerocheck::multilinear::fold_in_place_single(&mut b, rho);
+            fold_in_place_single(&mut b, rho);
             assert_eq!(a, b, "log_n={log_n}");
         }
     }

--- a/crates/flock-core/src/hash.rs
+++ b/crates/flock-core/src/hash.rs
@@ -13,6 +13,9 @@
 //! keep their behaviour.
 
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
 
 /// Which hash function backs a component.
 ///
@@ -51,8 +54,8 @@ impl HashKind {
     }
 }
 
-impl std::fmt::Display for HashKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for HashKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         f.write_str(self.as_str())
     }
 }

--- a/crates/flock-core/src/lib.rs
+++ b/crates/flock-core/src/lib.rs
@@ -17,6 +17,15 @@
 //! Workspace-wide Clippy `allow`s for the hand-tuned numeric kernels are
 //! declared in `[workspace.lints.clippy]` at the repo root.
 
+use crate::field::F128;
+use std::alloc::Layout;
+use std::alloc::alloc_zeroed;
+use std::alloc::handle_alloc_error;
+use std::env::var;
+use std::process::Command;
+use std::str::from_utf8;
+use std::sync::OnceLock;
+use std::thread::available_parallelism;
 pub mod aggregate;
 pub mod bits;
 pub mod challenger;
@@ -60,7 +69,7 @@ pub mod zerocheck;
 /// if no change was made (either because the env var was set or because
 /// rayon was already initialized).
 pub fn init_perf_thread_pool() -> Option<usize> {
-    if std::env::var("RAYON_NUM_THREADS").is_ok() {
+    if var("RAYON_NUM_THREADS").is_ok() {
         return None;
     }
     let n = perf_core_count();
@@ -105,8 +114,8 @@ pub(crate) fn alloc_uninit_vec<T: Copy>(n: usize) -> Vec<T> {
 }
 
 /// Compatibility shim — same as `alloc_uninit_vec::<F128>(n)`.
-pub(crate) fn alloc_uninit_f128_vec(n: usize) -> Vec<crate::field::F128> {
-    alloc_uninit_vec::<crate::field::F128>(n)
+pub(crate) fn alloc_uninit_f128_vec(n: usize) -> Vec<F128> {
+    alloc_uninit_vec::<F128>(n)
 }
 
 /// At/above this round width (in summed elements) a sumcheck round uses the full
@@ -153,9 +162,9 @@ pub(crate) fn sumcheck_round_min_len(pairs: usize, n_blocks: usize) -> Option<us
 pub(crate) const FOLD_PAR_THRESHOLD_DEFAULT: usize = 1 << 16;
 
 pub(crate) fn fold_par_threshold() -> usize {
-    static GATE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    static GATE: OnceLock<usize> = OnceLock::new();
     *GATE.get_or_init(|| {
-        std::env::var("FLOCK_FOLD_GATE")
+        var("FLOCK_FOLD_GATE")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(FOLD_PAR_THRESHOLD_DEFAULT)
@@ -194,8 +203,8 @@ pub(crate) fn fold_min_len(half: usize) -> Option<usize> {
 /// part; that module is not in this tree, so the knob preserves it rather than
 /// deleting it.
 pub(crate) fn fold_sqrt_rule() -> bool {
-    static RULE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *RULE.get_or_init(|| std::env::var("FLOCK_FOLD_RULE").is_ok_and(|v| v == "sqrt"))
+    static RULE: OnceLock<bool> = OnceLock::new();
+    *RULE.get_or_init(|| var("FLOCK_FOLD_RULE").is_ok_and(|v| v == "sqrt"))
 }
 
 /// A length-`n` all-zero vector from `alloc_zeroed` — LAZY zero pages from
@@ -206,16 +215,16 @@ pub(crate) fn alloc_zeroed_vec<T: Copy>(n: usize) -> Vec<T> {
     if n == 0 {
         return Vec::new();
     }
-    let layout = std::alloc::Layout::array::<T>(n).expect("allocation size overflows");
+    let layout = Layout::array::<T>(n).expect("allocation size overflows");
     // SAFETY:
     // - `alloc_zeroed` returns `n * size_of::<T>()` zeroed bytes with the
     //   layout's alignment (or null, handled below).
     // - T: Copy (no Drop) and the all-zero bit pattern must be a valid T —
     //   true for the plain-old-data field/word types this crate uses it for.
     unsafe {
-        let ptr = std::alloc::alloc_zeroed(layout) as *mut T;
+        let ptr = alloc_zeroed(layout) as *mut T;
         if ptr.is_null() {
-            std::alloc::handle_alloc_error(layout);
+            handle_alloc_error(layout);
         }
         Vec::from_raw_parts(ptr, n, n)
     }
@@ -244,10 +253,10 @@ pub(crate) fn perf_core_count_cached() -> usize {
 fn perf_core_count() -> usize {
     #[cfg(target_os = "macos")]
     {
-        if let Ok(out) = std::process::Command::new("sysctl")
+        if let Ok(out) = Command::new("sysctl")
             .args(["-n", "hw.perflevel0.physicalcpu"])
             .output()
-            && let Ok(s) = std::str::from_utf8(&out.stdout)
+            && let Ok(s) = from_utf8(&out.stdout)
             && let Ok(n) = s.trim().parse::<usize>()
             && n > 0
         {
@@ -265,9 +274,7 @@ fn perf_core_count() -> usize {
             return n.min(available);
         }
     }
-    std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1)
+    available_parallelism().map(|n| n.get()).unwrap_or(1)
 }
 
 /// Count distinct physical cores via `/sys` topology: one entry per unique

--- a/crates/flock-core/src/lincheck.rs
+++ b/crates/flock-core/src/lincheck.rs
@@ -121,7 +121,15 @@ use crate::field::F128;
 use crate::r1cs::SparseBinaryMatrix;
 use crate::zerocheck::multilinear::lagrange_weights_naive;
 use serde::{Deserialize, Serialize};
+#[cfg(test)]
+use std::collections::HashSet;
+use std::env::var;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::Instant;
 
 mod kernels;
 mod union;
@@ -328,8 +336,8 @@ fn csc_from_rows(m: &SparseBinaryMatrix) -> (Vec<u32>, Vec<u32>) {
 }
 
 // Compact Debug — the row arrays run to millions of entries.
-impl std::fmt::Debug for CscCircuit {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Debug for CscCircuit {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         f.debug_struct("CscCircuit")
             .field("n_cols", &self.n_cols)
             .field("nnz_a", &self.a_rows.len())
@@ -839,8 +847,7 @@ fn partial_fold_packed_z_best(
             // n_log ≥ 16; below that the L1-resident `iblock` wins. `FOLD_IBLOCK` forces
             // iblock everywhere (bench A/B).
             let n_log = m - k_log;
-            if n_log >= OBLOCK_MIN_N_LOG && !FOLD_IBLOCK.load(std::sync::atomic::Ordering::Relaxed)
-            {
+            if n_log >= OBLOCK_MIN_N_LOG && !FOLD_IBLOCK.load(Ordering::Relaxed) {
                 return partial_fold_packed_z_neon_oblock_padded(
                     z_packed,
                     m,
@@ -974,11 +981,7 @@ pub fn pack_z_lincheck(z_logical: &[bool], m: usize, k_log: usize) -> Vec<u8> {
 /// Same output as [`pack_z_lincheck`] but reads bits from an F_{2^128}-packed
 /// witness (polynomial basis: bit `i` of logical = bit `i % 128` of
 /// `z_packed_f128[i / 128]`).
-pub fn pack_z_lincheck_from_packed(
-    z_packed_f128: &[crate::field::F128],
-    m: usize,
-    k_log: usize,
-) -> Vec<u8> {
+pub fn pack_z_lincheck_from_packed(z_packed_f128: &[F128], m: usize, k_log: usize) -> Vec<u8> {
     use rayon::prelude::*;
     let k = 1usize << k_log;
     let n_total = 1usize << m;
@@ -1407,7 +1410,7 @@ fn prove_padded_inner<Ch: Challenger>(
     assert_eq!(x_ab.x_outer.len(), n_log);
 
     challenger.observe_label(b"flock-lincheck-v0");
-    let trace = std::env::var("LINCHECK_TRACE").is_ok();
+    let trace = var("LINCHECK_TRACE").is_ok();
 
     // 1. Sample α (matches verifier's order). Used to batch the two scalar
     //    consistency checks v_a, v_b into a single sumcheck.
@@ -1417,11 +1420,7 @@ fn prove_padded_inner<Ch: Challenger>(
     //    the sparse-matrix default this is the fused single-pass row-fold;
     //    per-hash circuit walkers compute the same `comb_vec` directly from
     //    the constraint graph.
-    let t = if trace {
-        Some(std::time::Instant::now())
-    } else {
-        None
-    };
+    let t = if trace { Some(Instant::now()) } else { None };
     let eq_inner = build_quirky_eq_table(x_ab.z_skip, &x_ab.x_inner_rest, k_skip);
     if let Some(t) = t {
         eprintln!(
@@ -1430,11 +1429,7 @@ fn prove_padded_inner<Ch: Challenger>(
             t.elapsed().as_secs_f64() * 1e3
         );
     }
-    let t = if trace {
-        Some(std::time::Instant::now())
-    } else {
-        None
-    };
+    let t = if trace { Some(Instant::now()) } else { None };
     let mut comb_vec = circuit.fold_alpha_batched(alpha, &eq_inner);
     if let Some(t) = t {
         eprintln!(
@@ -1455,11 +1450,7 @@ fn prove_padded_inner<Ch: Challenger>(
     }
 
     // 3. Partial fold of z at the shared outer half (length-k F128 vector).
-    let t = if trace {
-        Some(std::time::Instant::now())
-    } else {
-        None
-    };
+    let t = if trace { Some(Instant::now()) } else { None };
     let eq_x_outer = build_eq_table(&x_ab.x_outer);
     let z_vec = partial_fold_packed_z_best(z_packed, m, k_log, useful_bits, &eq_x_outer);
     if let Some(t) = t {
@@ -1502,11 +1493,7 @@ fn column_sumcheck_prove<Ch: Challenger>(
     debug_assert_eq!(comb_vec.len(), z_vec.len());
     debug_assert!(comb_vec.len().is_power_of_two());
     let inner_rest_len = comb_vec.len().trailing_zeros() as usize - k_skip;
-    let t_sumcheck_start = if trace {
-        Some(std::time::Instant::now())
-    } else {
-        None
-    };
+    let t_sumcheck_start = if trace { Some(Instant::now()) } else { None };
 
     // 5. Standard multilinear product-sumcheck over the high `inner_rest_len`
     //    bits of `i`. Each round binds the TOP remaining bit (mirrors
@@ -1646,7 +1633,7 @@ pub fn verify<Ch: Challenger>(
 
     challenger.observe_label(b"flock-lincheck-v0");
 
-    let trace = std::env::var("VERIFY_TRACE").is_ok();
+    let trace = var("VERIFY_TRACE").is_ok();
     let fmt = |s: f64| -> String {
         let ms = s * 1000.0;
         if ms < 1.0 {
@@ -1662,7 +1649,7 @@ pub fn verify<Ch: Challenger>(
     // 2. Build α-batched comb_vec via the circuit's per-block fold (same call
     //    the prover made — sparse default delegates to the fused row-fold;
     //    per-hash impls walk the constraint graph directly).
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let eq_inner = build_quirky_eq_table(x_ab.z_skip, &x_ab.x_inner_rest, k_skip);
     if trace {
         eprintln!(
@@ -1670,7 +1657,7 @@ pub fn verify<Ch: Challenger>(
             fmt(t.elapsed().as_secs_f64())
         );
     }
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut comb_vec = circuit.fold_alpha_batched(alpha, &eq_inner);
     if trace {
         eprintln!(
@@ -1682,7 +1669,7 @@ pub fn verify<Ch: Challenger>(
     // 3. Replay the multilinear product-sumcheck (inner_rest_len rounds),
     //    folding comb_vec in lockstep so we end up with the "comb_partial"
     //    vector of length 2^k_skip. Parallel fold for the early (large) rounds.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     // Constant-wire pin (mirror of prove): β sampled after α, comb gains +β at
     // the constant column, and the initial target gains +β·1 — the honest
     // all-ones constant column folds to 1. See docs/const-wire-pin.md.
@@ -1734,7 +1721,7 @@ pub fn verify<Ch: Challenger>(
     // 7. Derive output claim value via φ8 Lagrange on z_partial at z_skip.
     //    Equals ẑ_φ8(z_skip, r_rest, x_outer) when z_partial is honest;
     //    PCS catches mismatches downstream.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let lambda = lagrange_weights_naive(k_skip, r_inner_skip);
     let w = inner_product(&lambda, &proof.z_partial);
     if trace {
@@ -1839,7 +1826,7 @@ mod tests {
         let n_outer = 1usize << (m - k_log);
         assert_eq!(f.len(), 1 << m);
 
-        let lambda = crate::zerocheck::multilinear::lagrange_weights_naive(k_skip, point.z_skip);
+        let lambda = lagrange_weights_naive(k_skip, point.z_skip);
         let eq_rest = build_eq_table(&point.x_inner_rest);
         let eq_outer = build_eq_table(&point.x_outer);
         debug_assert_eq!(lambda.len(), k_skip_dim);
@@ -1896,7 +1883,7 @@ mod tests {
     /// `k × k` slots. Used for tests.
     fn random_sparse_matrix(k: usize, nnz: usize, rng: &mut Rng) -> SparseBinaryMatrix {
         let mut rows: Vec<Vec<usize>> = vec![Vec::new(); k];
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::new();
         let mut count = 0;
         while count < nnz {
             let r = (rng.next_u64() as usize) % k;

--- a/crates/flock-core/src/lincheck/union.rs
+++ b/crates/flock-core/src/lincheck/union.rs
@@ -66,6 +66,8 @@ use crate::schedule::Registry;
 use crate::union::UnionInstance;
 use crate::zerocheck::K_SKIP;
 use crate::zerocheck::multilinear::lagrange_weights_naive;
+use std::env::var;
+use std::time::Instant;
 
 use super::{
     LincheckCircuit, LincheckClaim, LincheckProof, QuirkyPoint, VerifyError, build_eq_table,
@@ -221,7 +223,7 @@ pub fn prove_union_capture_z_vec<Ch: Challenger>(
     }
 
     challenger.observe_label(b"flock-lincheck-v0");
-    let trace = std::env::var("LINCHECK_TRACE").is_ok();
+    let trace = var("LINCHECK_TRACE").is_ok();
 
     // 1. Sample α (matches verifier's order). ONE α batches the A- and
     //    B-claims for every slot (doc §"The B-claim, and batching the two
@@ -239,11 +241,7 @@ pub fn prove_union_capture_z_vec<Ch: Challenger>(
     // slot to FILL the boolean region — true for every single-type registry,
     // and for no multi-slot one.
     let single = registry.num_boolean() == 1 && registry.slots()[0].m_slot == registry.m_bool();
-    let t_comb = if trace {
-        Some(std::time::Instant::now())
-    } else {
-        None
-    };
+    let t_comb = if trace { Some(Instant::now()) } else { None };
     let mut comb_vec: Vec<F128> = if single {
         Vec::new()
     } else {
@@ -304,11 +302,7 @@ pub fn prove_union_capture_z_vec<Ch: Challenger>(
     //    single partial fold. Dummy rows are honest zeros, so folding only
     //    the DECLARED rows equals the full-capacity fold byte for byte —
     //    the row-aware dispatch makes the fold count-proportional (M6).
-    let t_fold = if trace {
-        Some(std::time::Instant::now())
-    } else {
-        None
-    };
+    let t_fold = if trace { Some(Instant::now()) } else { None };
     let eq_x_outer = build_eq_table(&x_ab.x_outer);
     let mut z_vec: Vec<F128> = if single {
         Vec::new()
@@ -772,7 +766,7 @@ pub fn verify_union_timed<Ch: Challenger>(
 ) -> Result<(LincheckClaim, f64), VerifyError> {
     let (claim, assertion) =
         verify_union_deferred(union, circuits, x_ab, v_a, v_b, proof, challenger)?;
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     assertion.check(union, circuits)?;
     Ok((claim, t.elapsed().as_secs_f64()))
 }

--- a/crates/flock-core/src/matrix_fold.rs
+++ b/crates/flock-core/src/matrix_fold.rs
@@ -57,6 +57,7 @@
 //! `(q(1), q(∞))` with `q(0)` re-derived from the running claim, and each
 //! round binds the LOW remaining variable.
 
+use crate::element_r1cs::SparseF128Matrix;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -474,7 +475,7 @@ impl FoldMatrix for SparseBinaryMatrix {
     }
 }
 
-impl FoldMatrix for crate::element_r1cs::SparseF128Matrix {
+impl FoldMatrix for SparseF128Matrix {
     fn row_marginal(&self, w: &[F128], n_rows: usize) -> Vec<F128> {
         let mut out = vec![F128::ZERO; n_rows];
         out.par_chunks_mut(G_ROW_CHUNK)

--- a/crates/flock-core/src/merkle.rs
+++ b/crates/flock-core/src/merkle.rs
@@ -46,8 +46,14 @@
 //! attacks via interpretation collision, and a production PCS commit should
 //! prepend `0x00`/`0x01` (or equivalent) before relying on it.
 
+use blake3::hazmat::Mode;
+use blake3::hazmat::merge_subtrees_non_root;
+use blake3::platform::Platform;
+use core::slice::from_raw_parts;
+use core::slice::from_raw_parts_mut;
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
+use std::slice::from_ref;
 
 pub type Hash = [u8; 32];
 
@@ -197,7 +203,7 @@ fn blake3_leaf_cv(data: &[u8]) -> Hash {
 /// BLAKE3 parent-node chaining value of two children.
 #[inline]
 fn blake3_parent_cv(left: &Hash, right: &Hash) -> Hash {
-    blake3::hazmat::merge_subtrees_non_root(left, right, blake3::hazmat::Mode::Hash)
+    merge_subtrees_non_root(left, right, Mode::Hash)
 }
 
 /// Hash one leaf of arbitrary byte length.
@@ -283,10 +289,10 @@ const BLAKE3_PARENT: u8 = 4;
 
 /// Cached SIMD platform. `Platform::detect()` is cheap but not free, and the
 /// tree build reaches the batched path once per [`BLAKE3_BATCH`] nodes.
-fn blake3_platform() -> blake3::platform::Platform {
+fn blake3_platform() -> Platform {
     use std::sync::OnceLock;
-    static PLATFORM: OnceLock<blake3::platform::Platform> = OnceLock::new();
-    *PLATFORM.get_or_init(blake3::platform::Platform::detect)
+    static PLATFORM: OnceLock<Platform> = OnceLock::new();
+    *PLATFORM.get_or_init(Platform::detect)
 }
 
 /// Inputs handed to `hash_many` per call.
@@ -333,7 +339,7 @@ fn blake3_hash_many<const N: usize>(
         // initialized, contiguous, unpadded storage — the amount `hash_many`
         // writes for `n` inputs.
         let out_bytes: &mut [u8] =
-            unsafe { core::slice::from_raw_parts_mut(outs.as_mut_ptr() as *mut u8, n * 32) };
+            unsafe { from_raw_parts_mut(outs.as_mut_ptr() as *mut u8, n * 32) };
         plat.hash_many(
             &inputs[..n],
             &BLAKE3_IV,
@@ -452,13 +458,13 @@ const BLAKE3_GROUP: usize = 1024;
 /// 2^18 tree); those are hashed serially — still SIMD-batched — and only the
 /// wide lower levels fan out.
 fn hash_pairs_level(read: &[Hash], write: &mut [Hash], kind: HashKind) {
+    const SERIAL_LEVEL_NODES: usize = 1024;
     #[cfg(feature = "hash-count")]
     hash_count::PAIR_CALLS.fetch_add(write.len() as u64, std::sync::atomic::Ordering::Relaxed);
     // SAFETY: `Hash` is `[u8; 32]`, so a slice of `n` hashes is exactly `32n`
     // initialized bytes with no padding.
-    let read_bytes: &[u8] =
-        unsafe { core::slice::from_raw_parts(read.as_ptr() as *const u8, read.len() * 32) };
-    const SERIAL_LEVEL_NODES: usize = 1024;
+    let read_bytes: &[u8] = unsafe { from_raw_parts(read.as_ptr() as *const u8, read.len() * 32) };
+
     let serial = write.len() <= SERIAL_LEVEL_NODES;
 
     match kind {
@@ -633,12 +639,7 @@ pub fn cap_layer(tree: &[Hash], num_leaves: usize, c: usize) -> &[Hash] {
 /// `log2(num_leaves) − c` hashes. `c = 0` is the classic root-anchored path.
 ///
 /// Verify with [`verify_merkle_proof_capped`].
-pub fn merkle_proof_capped(
-    tree: &[Hash],
-    num_leaves: usize,
-    index: usize,
-    c: usize,
-) -> Vec<Hash> {
+pub fn merkle_proof_capped(tree: &[Hash], num_leaves: usize, index: usize, c: usize) -> Vec<Hash> {
     assert!(num_leaves.is_power_of_two() && num_leaves > 0);
     assert!(index < num_leaves);
     assert_eq!(tree.len(), 2 * num_leaves - 1);
@@ -720,7 +721,7 @@ pub fn verify_merkle_proof(
     kind: HashKind,
 ) -> bool {
     verify_merkle_proof_capped(
-        std::slice::from_ref(root),
+        from_ref(root),
         1usize << proof.len(),
         leaf_hash,
         index,
@@ -784,7 +785,7 @@ mod tests {
         );
         assert_eq!(
             hash_pair(&l, &r, HashKind::Blake3),
-            blake3::hazmat::merge_subtrees_non_root(&l, &r, blake3::hazmat::Mode::Hash)
+            merge_subtrees_non_root(&l, &r, Mode::Hash)
         );
         // Deliberately NOT `blake3::hash` — that is the root finalization, and
         // interior tree nodes must not be root hashes.
@@ -1144,10 +1145,14 @@ mod tests {
                 let leaf_hash = hash_leaf(&data[i * leaf_size..(i + 1) * leaf_size], kind);
                 let path = merkle_proof_capped(&tree, n_leaves, i, d);
                 assert!(path.is_empty());
-                assert!(verify_merkle_proof_capped(cap, n_leaves, &leaf_hash, i, &path, kind));
+                assert!(verify_merkle_proof_capped(
+                    cap, n_leaves, &leaf_hash, i, &path, kind
+                ));
                 let mut wrong = leaf_hash;
                 wrong[0] ^= 1;
-                assert!(!verify_merkle_proof_capped(cap, n_leaves, &wrong, i, &path, kind));
+                assert!(!verify_merkle_proof_capped(
+                    cap, n_leaves, &wrong, i, &path, kind
+                ));
             }
         }
     }
@@ -1187,13 +1192,24 @@ mod tests {
             let i = 5usize;
             let leaf_hash = hash_leaf(&data[i * leaf_size..(i + 1) * leaf_size], kind);
             let path = merkle_proof_capped(&tree, n_leaves, i, c);
-            assert!(verify_merkle_proof_capped(cap, n_leaves, &leaf_hash, i, &path, kind));
+            assert!(verify_merkle_proof_capped(
+                cap, n_leaves, &leaf_hash, i, &path, kind
+            ));
             // Wrong index (same cap node, sibling half).
-            assert!(!verify_merkle_proof_capped(cap, n_leaves, &leaf_hash, i ^ 1, &path, kind));
+            assert!(!verify_merkle_proof_capped(
+                cap,
+                n_leaves,
+                &leaf_hash,
+                i ^ 1,
+                &path,
+                kind
+            ));
             // Tampered sibling.
             let mut bad = path.clone();
             bad[0][0] ^= 1;
-            assert!(!verify_merkle_proof_capped(cap, n_leaves, &leaf_hash, i, &bad, kind));
+            assert!(!verify_merkle_proof_capped(
+                cap, n_leaves, &leaf_hash, i, &bad, kind
+            ));
             // The other hash kind.
             let other = match kind {
                 HashKind::Sha256 => HashKind::Blake3,
@@ -1201,7 +1217,9 @@ mod tests {
                 #[allow(unreachable_patterns)]
                 _ => continue,
             };
-            assert!(!verify_merkle_proof_capped(cap, n_leaves, &leaf_hash, i, &path, other));
+            assert!(!verify_merkle_proof_capped(
+                cap, n_leaves, &leaf_hash, i, &path, other
+            ));
         }
     }
 
@@ -1221,10 +1239,14 @@ mod tests {
             let path = merkle_proof_capped(&tree, n_leaves, i, c);
             let mut short = path.clone();
             short.pop();
-            assert!(!verify_merkle_proof_capped(cap, n_leaves, &leaf_hash, i, &short, kind));
+            assert!(!verify_merkle_proof_capped(
+                cap, n_leaves, &leaf_hash, i, &short, kind
+            ));
             let mut long = path.clone();
             long.push([0u8; 32]);
-            assert!(!verify_merkle_proof_capped(cap, n_leaves, &leaf_hash, i, &long, kind));
+            assert!(!verify_merkle_proof_capped(
+                cap, n_leaves, &leaf_hash, i, &long, kind
+            ));
         }
     }
 
@@ -1245,5 +1267,4 @@ mod tests {
         assert_eq!(cap_depth(218, 4), 4);
         assert_eq!(cap_depth(131, 8), 8);
     }
-
 }

--- a/crates/flock-core/src/ntt/additive_ntt_f128.rs
+++ b/crates/flock-core/src/ntt/additive_ntt_f128.rs
@@ -288,26 +288,12 @@ impl AdditiveNttF128 {
         num_ntts: usize,
         start_layer: usize,
     ) {
-        use rayon::prelude::*;
-        let n_total = data.len();
-        let log_d = log2_pow2(n_total / num_ntts);
-
         // Target sub-group size = 2 MB total bytes. Each position is
         // `num_ntts × 16` bytes, so positions per sub-group =
         // 2^21 / (num_ntts · 16). With num_ntts=1: 2^17 positions. With
         // num_ntts=32: 2^12 positions. (Without this scaling, sub-groups at
         // num_ntts=32 would be 64 MB and overflow L2 cache.)
         const TARGET_SUBGROUP_LOG_BYTES: usize = 21;
-        // `num_ntts` need not be a power of two (integer-lane commit). Round the
-        // lane count UP to a power of two for the cache-blocking heuristic so an
-        // integer `t` blocks exactly like the padded `2^ceil(log2 t)` (measured:
-        // this recovers the full per-lane efficiency — a floor-log2 here left
-        // t=46 with oversized 3 MB sub-groups and ~15% slower than ideal). Only
-        // affects the sub-group SIZE (a tuning knob), never correctness.
-        let log_bytes_per_position = 4 + ceil_log2(num_ntts);
-        let target_log_positions = TARGET_SUBGROUP_LOG_BYTES.saturating_sub(log_bytes_per_position);
-        let cache_n_top = log_d.saturating_sub(target_log_positions);
-
         // Parallelism floor. The cache heuristic keeps each sub-NTT ~2 MB, but
         // for a mid-size transform whose whole codeword already fits that
         // budget it yields `cache_n_top == 0` and the transform runs fully
@@ -324,6 +310,20 @@ impl AdditiveNttF128 {
         // than the ~0.04 ms of work, so those stay scalar.
         const PARALLEL_FLOOR_LOG_D: usize = 12;
         const MIN_SUB_LOG: usize = 8;
+        use rayon::prelude::*;
+        let n_total = data.len();
+        let log_d = log2_pow2(n_total / num_ntts);
+
+        // `num_ntts` need not be a power of two (integer-lane commit). Round the
+        // lane count UP to a power of two for the cache-blocking heuristic so an
+        // integer `t` blocks exactly like the padded `2^ceil(log2 t)` (measured:
+        // this recovers the full per-lane efficiency — a floor-log2 here left
+        // t=46 with oversized 3 MB sub-groups and ~15% slower than ideal). Only
+        // affects the sub-group SIZE (a tuning knob), never correctness.
+        let log_bytes_per_position = 4 + ceil_log2(num_ntts);
+        let target_log_positions = TARGET_SUBGROUP_LOG_BYTES.saturating_sub(log_bytes_per_position);
+        let cache_n_top = log_d.saturating_sub(target_log_positions);
+
         let n_top = if log_d >= PARALLEL_FLOOR_LOG_D {
             let want_subs_log = log2_pow2(rayon::current_num_threads().next_power_of_two());
             let max_n_top = log_d.saturating_sub(MIN_SUB_LOG);
@@ -522,13 +522,14 @@ impl AdditiveNttF128 {
     /// Rayon-parallel + NEON forward transform.
     #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
     pub fn forward_transform_parallel(&self, data: &mut [F128]) {
+        // For small data (or shallow layers with few large blocks), the rayon
+        // overhead exceeds the gain — fall back to the NEON single-thread path.
+        const PARALLEL_THRESHOLD_LOG: usize = 14;
         use rayon::prelude::*;
         let log_d = log2_pow2(data.len());
         assert!(log_d <= self.log_domain_size());
 
-        // For small data (or shallow layers with few large blocks), the rayon
-        // overhead exceeds the gain — fall back to the NEON single-thread path.
-        const PARALLEL_THRESHOLD_LOG: usize = 14; // 2^14 = 16K elements (256 KB)
+        // 2^14 = 16K elements (256 KB)
         if log_d <= PARALLEL_THRESHOLD_LOG {
             self.forward_transform_neon(data);
             return;
@@ -613,12 +614,12 @@ impl AdditiveNttF128 {
     /// per-layer parallel path.
     #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
     pub fn forward_transform_batched(&self, data: &mut [F128]) {
+        // Target sub-NTT size: 2^17 F_{2^128} = 2 MB. Tunable.
+        const TARGET_SUB_NTT_LOG: usize = 17;
         use rayon::prelude::*;
         let log_d = log2_pow2(data.len());
         assert!(log_d <= self.log_domain_size());
 
-        // Target sub-NTT size: 2^17 F_{2^128} = 2 MB. Tunable.
-        const TARGET_SUB_NTT_LOG: usize = 17;
         if log_d <= TARGET_SUB_NTT_LOG {
             self.forward_transform_parallel(data);
             return;

--- a/crates/flock-core/src/ntt/inv_table.rs
+++ b/crates/flock-core/src/ntt/inv_table.rs
@@ -20,6 +20,7 @@
 //! Scalar/correctness-first implementation; NEON `apply_triple` and the
 //! unrolled `ntt_and_accum` can be added if the URM hot path needs them.
 
+use crate::bits::lowest_one;
 use crate::field::F8;
 use crate::ntt::AdditiveNttGf8;
 
@@ -41,6 +42,10 @@ impl InvNttTableByteSingleGf8 {
     /// domain, `ntt_L` over the output (extension) domain. Both must have the
     /// same `k`.
     pub fn new(ntt_s: &AdditiveNttGf8, ntt_l: &AdditiveNttGf8) -> Self {
+        // Vec<F8> only promises byte alignment. Over-allocate and select a
+        // cache-line-aligned logical start so an AVX-512 row load never
+        // straddles two cache lines.
+        const TABLE_ALIGNMENT: usize = 64;
         assert_eq!(ntt_s.k(), ntt_l.k(), "ntt_S and ntt_L must share k");
         let k = ntt_s.k();
         let ell = 1usize << k;
@@ -51,10 +56,6 @@ impl InvNttTableByteSingleGf8 {
             "n_chunks must fit the i'/chunk XOR encoding"
         );
 
-        // Vec<F8> only promises byte alignment. Over-allocate and select a
-        // cache-line-aligned logical start so an AVX-512 row load never
-        // straddles two cache lines.
-        const TABLE_ALIGNMENT: usize = 64;
         let table_len = 256 * ell;
         let mut data = vec![F8::ZERO; table_len + TABLE_ALIGNMENT - 1];
         let data_offset = (TABLE_ALIGNMENT - (data.as_ptr() as usize & (TABLE_ALIGNMENT - 1)))
@@ -84,7 +85,7 @@ impl InvNttTableByteSingleGf8 {
             if (w & (w - 1)) == 0 {
                 continue; // skip powers of 2 (already written)
             }
-            let lo_bit = crate::bits::lowest_one(w);
+            let lo_bit = lowest_one(w);
             let parent = w ^ lo_bit;
             // Borrow-checker friendly: read parent + bit_v slices, then write entry.
             let (parent_off, bit_off, entry_off) = (parent * ell, lo_bit * ell, w * ell);

--- a/crates/flock-core/src/ntt/inv_table_deg4.rs
+++ b/crates/flock-core/src/ntt/inv_table_deg4.rs
@@ -28,6 +28,7 @@
 //! 192 (positions on Λ₄ = V₈ \ S) are the fresh extension that the zerocheck
 //! round-1 message uses.
 
+use crate::bits::lowest_one;
 use crate::field::F8;
 use crate::ntt::AdditiveNttGf8;
 
@@ -107,7 +108,7 @@ impl InvNttTableSToV8Gf8 {
             if (w & (w - 1)) == 0 {
                 continue; // skip powers of 2
             }
-            let lo_bit = crate::bits::lowest_one(w);
+            let lo_bit = lowest_one(w);
             let parent = w ^ lo_bit;
             let (parent_off, bit_off, entry_off) =
                 (parent * ell_out, lo_bit * ell_out, w * ell_out);

--- a/crates/flock-core/src/pcs.rs
+++ b/crates/flock-core/src/pcs.rs
@@ -35,8 +35,24 @@ pub use ring_switch::{RingSwitchProof, SparseEqTensor};
 
 use crate::challenger::Challenger;
 use crate::field::F128;
+use crate::lincheck::build_eq_table;
+use crate::merkle::cap_depth;
+use crate::merkle::cap_layer;
+#[cfg(test)]
+use crate::pcs::ligerito::ProverConfig;
+#[cfg(test)]
+use crate::pcs::ligerito::VerifierConfig;
+#[cfg(test)]
+use crate::pcs::ligerito::udr_queries;
+use crate::pcs::tensor_algebra::TensorAlgebra;
+use crate::scratch::give_f128;
+use crate::scratch::take_f128;
 use crate::zerocheck::PaddingSpec;
+use crate::zerocheck::multilinear::eq_eval_binary_x;
 use serde::{Deserialize, Serialize};
+use std::env::var;
+use std::mem::swap;
+use std::time::Instant;
 
 /// Batched opening proof: ring-switching frontend + Ligerito backend.
 /// The combined `b_combined` + target_combined feed
@@ -151,24 +167,20 @@ pub fn open_batch_mixed_ligerito_with_precomputed_s_hat_v<Ch: Challenger>(
     // prove time instead of as a verifier reject.
     assert_eq!(
         commitment.cap.len(),
-        1usize
-            << crate::merkle::cap_depth(
-                lig_config.queries[0],
-                commitment.params.k_code(),
-            ),
+        1usize << cap_depth(lig_config.queries[0], commitment.params.k_code(),),
         "commitment cap size disagrees with the opener config's L0 query count"
     );
     debug_assert_eq!(
         commitment.cap.as_slice(),
-        crate::merkle::cap_layer(
+        cap_layer(
             &prover_data.merkle_tree,
             commitment.params.n_leaves(),
-            crate::merkle::cap_depth(lig_config.queries[0], commitment.params.k_code()),
+            cap_depth(lig_config.queries[0], commitment.params.k_code()),
         ),
         "commitment cap is not the prover tree's cap layer"
     );
-    let trace = std::env::var("PCS_TRACE").is_ok();
-    let t_total = std::time::Instant::now();
+    let trace = var("PCS_TRACE").is_ok();
+    let t_total = Instant::now();
 
     assert_eq!(
         lig_config.initial_k, commitment.params.log_batch_size,
@@ -212,7 +224,7 @@ pub fn open_batch_mixed_ligerito_with_precomputed_s_hat_v<Ch: Challenger>(
         trace,
     );
 
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let ligerito_proof = ligerito::recursive_prover_with_basis_precomputed_round0_lanes(
         lig_config,
         packed_witness,
@@ -279,6 +291,7 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
     challenger: &mut Ch,
     trace: bool,
 ) -> CombinedClaim {
+    use rayon::prelude::*;
     let n_rs = x_outers.len();
     let n_pd = packed_direct.len();
     assert!(n_rs + n_pd > 0, "open_batch_mixed: need at least one claim");
@@ -291,7 +304,7 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
     challenger.observe_label(b"flock-pcs-open-batch-v0");
 
     // 1. Ring-switching for all x_outers.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let (rs_results, gammas_rs): (
         Vec<(RingSwitchProof, ring_switch::RingSwitchBatchOutput)>,
         Vec<F128>,
@@ -321,8 +334,7 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
     }
     let gammas_pd: Vec<F128> = (0..n_pd).map(|_| challenger.sample_f128()).collect();
 
-    let t = std::time::Instant::now();
-    use rayon::prelude::*;
+    let t = Instant::now();
 
     let l = if let Some((_, out)) = rs_results.first() {
         out.rs_eq_ind.len()
@@ -479,7 +491,7 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
 
     // ---- Build b_combined (γ-weighted sum of all rs_eq_ind + eq_ind) and the
     //      round-0 prime (u_0, u_2 over packed_witness · b_combined).
-    let mut b_combined: Vec<F128> = crate::scratch::take_f128(l);
+    let mut b_combined: Vec<F128> = take_f128(l);
 
     let (mut round0_u0, mut round0_u2) = if use_fast {
         let b = rs_deferred[0].0.len(); // eq_lo.len(); shared across claims (same split)
@@ -605,7 +617,7 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
                     |(x0, x2), (y0, y2)| (x0 + y0, x2 + y2),
                 );
             for v in materialized {
-                crate::scratch::give_f128(v);
+                give_f128(v);
             }
             prime
         }
@@ -654,7 +666,7 @@ fn compute_combined_basis_and_target<Ch: Challenger>(
         .map(|(p, o)| {
             // The per-claim rs_eq_ind (L F128s) dies here — recycle it.
             if let ring_switch::RsEqInd::Dense(v) = o.rs_eq_ind {
-                crate::scratch::give_f128(v);
+                give_f128(v);
             }
             p
         })
@@ -843,12 +855,17 @@ pub fn verify_opening_batch_ligerito_mixed<Ch: Challenger>(
     //    For BLAKE3 m=30: ris is 19 dims, yr is 4 dims → 19× prefix reuse.
     let log_n = commitment.params.m - LOG_PACKING;
     let eval_b_residual = |ris: &[F128], yr_log_n: usize| -> Vec<F128> {
+        // ---- Per-y assembly (parallel over yr positions; each y is independent).
+        //      y_suffix is binary (bits of y), so we use the binary-query
+        //      specializations of eval_rs_eq_finish / eq_eval — each suffix
+        //      step collapses to a single scale_vertical / scalar product.
         use crate::zerocheck::multilinear::eq_eval;
+        use rayon::prelude::*;
         let yr_len = 1usize << yr_log_n;
         let prefix_len = ris.len();
 
         // ---- RS claim prefixes ----
-        let rs_prefixes: Vec<crate::pcs::tensor_algebra::TensorAlgebra> = rs_outputs
+        let rs_prefixes: Vec<TensorAlgebra> = rs_outputs
             .iter()
             .zip(x_outers.iter())
             .map(|(_out, x_outer)| {
@@ -877,11 +894,6 @@ pub fn verify_opening_batch_ligerito_mixed<Ch: Challenger>(
             .map(|pt| eq_eval(&pt[..prefix_len], ris))
             .collect();
 
-        // ---- Per-y assembly (parallel over yr positions; each y is independent).
-        //      y_suffix is binary (bits of y), so we use the binary-query
-        //      specializations of eval_rs_eq_finish / eq_eval — each suffix
-        //      step collapses to a single scale_vertical / scalar product.
-        use rayon::prelude::*;
         debug_assert!(yr_log_n <= 32, "yr_log_n > 32 not supported by binary path");
         (0..yr_len)
             .into_par_iter()
@@ -907,12 +919,7 @@ pub fn verify_opening_batch_ligerito_mixed<Ch: Challenger>(
                     .zip(gammas_pd.iter())
                     .zip(pd_prefix_scalars.iter())
                 {
-                    sum += *g
-                        * *prefix_scalar
-                        * crate::zerocheck::multilinear::eq_eval_binary_x(
-                            &pt[prefix_len..],
-                            y_bits,
-                        );
+                    sum += *g * *prefix_scalar * eq_eval_binary_x(&pt[prefix_len..], y_bits);
                 }
                 sum
             })
@@ -1028,7 +1035,7 @@ fn scalar_claim_groups<'a>(
         match hot {
             Some(h) => cols[h] += g,
             None => {
-                for (dst, e) in cols.iter_mut().zip(crate::lincheck::build_eq_table(zc)) {
+                for (dst, e) in cols.iter_mut().zip(build_eq_table(zc)) {
                     *dst += g * e;
                 }
             }
@@ -1052,32 +1059,28 @@ pub fn open_batch_merged<Ch: Challenger>(
     lig_config: &ligerito::ProverConfig,
     challenger: &mut Ch,
 ) -> MergedOpenProof {
-    let trace = std::env::var("PCS_TRACE").is_ok();
-    let t_total = std::time::Instant::now();
+    let trace = var("PCS_TRACE").is_ok();
+    let t_total = Instant::now();
     // Belt-and-braces on the cap-depth derivation: the commit-time cap
     // (from `PcsParams::l0_cap_depth`) must be the layer the opener's
     // config implies — a config-source disagreement fails loudly here at
     // prove time instead of as a verifier reject.
     assert_eq!(
         commitment.cap.len(),
-        1usize
-            << crate::merkle::cap_depth(
-                lig_config.queries[0],
-                commitment.params.k_code(),
-            ),
+        1usize << cap_depth(lig_config.queries[0], commitment.params.k_code(),),
         "commitment cap size disagrees with the opener config's L0 query count"
     );
     debug_assert_eq!(
         commitment.cap.as_slice(),
-        crate::merkle::cap_layer(
+        cap_layer(
             &prover_data.merkle_tree,
             commitment.params.n_leaves(),
-            crate::merkle::cap_depth(lig_config.queries[0], commitment.params.k_code()),
+            cap_depth(lig_config.queries[0], commitment.params.k_code()),
         ),
         "commitment cap is not the prover tree's cap layer"
     );
     challenger.observe_label(b"flock-merged-open-v0");
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     // Element-only registries produce no ring-switched claims; skip the batch
     // entirely (the callee asserts a non-empty batch). This branch DEFINES the
     // element-only merged transcript: nothing is absorbed for the empty batch,
@@ -1167,7 +1170,7 @@ pub fn open_batch_merged<Ch: Challenger>(
 
     // The twisted weight over the dense cube (count-proportional Φ-pass;
     // zero tail past the jagged area).
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let (w, (u0, u2)) = jagged::build_merged_weight_and_prime(&params, &weight_claims, &q);
     if trace {
         eprintln!(
@@ -1179,15 +1182,15 @@ pub fn open_batch_merged<Ch: Challenger>(
 
     // ---- Merged sumcheck: Σ_d q[d]·W[d] = target, dense_log rounds, same
     // message/fold conventions as the virtual-opening sumcheck.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let (mut g_one, mut g_inf) = (target + u0, u2);
     let mut merged_rounds = Vec::with_capacity(dense_log);
     let mut rho = Vec::with_capacity(dense_log);
     let l = q.len();
-    let mut sa = crate::scratch::take_f128(l / 2);
-    let mut sb = crate::scratch::take_f128(l / 2);
-    let mut a = crate::scratch::take_f128(l / 4);
-    let mut bb = crate::scratch::take_f128(l / 4);
+    let mut sa = take_f128(l / 2);
+    let mut sb = take_f128(l / 2);
+    let mut a = take_f128(l / 4);
+    let mut bb = take_f128(l / 4);
     let mut cur = l;
     for round in 0..dense_log {
         let half = cur / 2;
@@ -1218,8 +1221,8 @@ pub fn open_batch_merged<Ch: Challenger>(
                 &mut sb[..half],
             );
         }
-        std::mem::swap(&mut a, &mut sa);
-        std::mem::swap(&mut bb, &mut sb);
+        swap(&mut a, &mut sa);
+        swap(&mut bb, &mut sb);
         cur = half;
     }
     let q_eval = if dense_log == 0 { q[0] } else { a[0] };
@@ -1230,14 +1233,14 @@ pub fn open_batch_merged<Ch: Challenger>(
             t.elapsed().as_secs_f64() * 1e3
         );
     }
-    crate::scratch::give_f128(w);
-    crate::scratch::give_f128(sa);
-    crate::scratch::give_f128(sb);
-    crate::scratch::give_f128(a);
-    crate::scratch::give_f128(bb);
+    give_f128(w);
+    give_f128(sa);
+    give_f128(sb);
+    give_f128(a);
+    give_f128(bb);
 
     // ---- Frobenius assist: proves V = Ŵ(ρ).
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let coeffs: Vec<Vec<F128>> = rs_results
         .iter()
         .map(|(_, o)| match &o.rs_eq_ind {
@@ -1269,14 +1272,13 @@ pub fn open_batch_merged<Ch: Challenger>(
             t.elapsed().as_secs_f64() * 1e3
         );
     }
-    let t_assist = std::time::Instant::now();
+    let t_assist = Instant::now();
     // The two-product multipoint replacement
     // (docs/multipoint-twisted-assist.tex): 128R + P claimed dual values +
     // one two-product sumcheck + ONE untwisted anchor, instead of a
     // per-statement assist — family K collapses, and every verifier piece
     // is a shape the recursion circuit already has.
-    let frobenius =
-        jagged::prove_multipoint_twisted(&params, &fclaims, &gclaims, &rho, challenger);
+    let frobenius = jagged::prove_multipoint_twisted(&params, &fclaims, &gclaims, &rho, challenger);
     if trace {
         eprintln!(
             "  [open_merged] coeffs + multipoint assist: {:6.2} ms (assist alone {:6.2} ms)",
@@ -1311,7 +1313,7 @@ pub fn open_batch_merged<Ch: Challenger>(
         value: q_eval,
         eq_ind: DirectEqInd::EqPoint(rho.clone()),
     };
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let inner = open_batch_mixed_ligerito_with_precomputed_s_hat_v(
         q,
         prover_data,
@@ -1366,7 +1368,7 @@ pub fn verify_batch_merged<Ch: Challenger>(
     // `VERIFY_TRACE` phase split. The Ligerito inner verify has its own
     // `LIG_VERIFY_TRACE`, but it is a small tail here — the jagged Frobenius
     // assist is the term that scales with the row/column split.
-    let trace = std::env::var("VERIFY_TRACE").is_ok();
+    let trace = var("VERIFY_TRACE").is_ok();
     let tfmt = |s: f64| -> String {
         let ms = s * 1000.0;
         if ms < 1.0 {
@@ -1376,7 +1378,7 @@ pub fn verify_batch_merged<Ch: Challenger>(
         }
     };
     challenger.observe_label(b"flock-merged-open-v0");
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut rs_outputs = Vec::with_capacity(n_rs);
     for i in 0..n_rs {
         let out = ring_switch::verify_succinct(
@@ -1427,7 +1429,7 @@ pub fn verify_batch_merged<Ch: Challenger>(
         rho.push(r);
     }
 
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let params = jagged::JaggedParams::from_heights(heights, n_log, dense_log);
     let k_cols = params.k;
     if trace {
@@ -1436,7 +1438,7 @@ pub fn verify_batch_merged<Ch: Challenger>(
             tfmt(t.elapsed().as_secs_f64())
         );
     }
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     // The claims' c_{i,j}: derived from the transcript (γ-scaled r''-eq
     // tensors → fold byte tables → linearized coefficients).
     let coeffs: Vec<Vec<F128>> = rs_outputs
@@ -1485,7 +1487,7 @@ pub fn verify_batch_merged<Ch: Challenger>(
             tfmt(t.elapsed().as_secs_f64())
         );
     }
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     #[cfg(feature = "mul-count")]
     let assist_start = crate::field::gf2_128::op_count::snapshot();
     let v = jagged::verify_multipoint_twisted(
@@ -1519,7 +1521,7 @@ pub fn verify_batch_merged<Ch: Challenger>(
         return Err(VerifyErrorOpen::VirtualOpen);
     }
 
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let pd = PackedDirectClaimRef {
         point: &rho,
         value: proof.q_eval,
@@ -1621,13 +1623,10 @@ mod tests {
 
         let recursive_ks = vec![3usize, 3, 3];
         let log_inv_rates = vec![1usize, 3, 4, 6];
-        let queries: Vec<usize> = log_inv_rates
-            .iter()
-            .map(|&r| crate::pcs::ligerito::udr_queries(r))
-            .collect();
+        let queries: Vec<usize> = log_inv_rates.iter().map(|&r| udr_queries(r)).collect();
         let grinding_bits = vec![0usize; log_inv_rates.len()];
         let n_levels = log_inv_rates.len();
-        let lig_p_cfg = crate::pcs::ligerito::ProverConfig {
+        let lig_p_cfg = ProverConfig {
             log_inv_rates: log_inv_rates.clone(),
             recursive_steps: recursive_ks.len(),
             initial_log_msg_cols: (m - LOG_PACKING) - initial_k,
@@ -1641,7 +1640,7 @@ mod tests {
             ood_samples: vec![0; n_levels],
             merkle_hash: Default::default(),
         };
-        let lig_v_cfg = crate::pcs::ligerito::VerifierConfig {
+        let lig_v_cfg = VerifierConfig {
             log_inv_rates,
             recursive_steps: recursive_ks.len(),
             initial_log_msg_cols: (m - LOG_PACKING) - initial_k,
@@ -1682,5 +1681,4 @@ mod tests {
         )
         .unwrap_or_else(|e| panic!("ligerito verify rejected honest proof: {e:?}"));
     }
-
 }

--- a/crates/flock-core/src/pcs/commit.rs
+++ b/crates/flock-core/src/pcs/commit.rs
@@ -15,10 +15,32 @@
 //! Merkle leaf is **one** F_{2^128} element = 16 bytes.
 
 use crate::field::F128;
+#[cfg(test)]
+use crate::merkle::cap_layer;
+#[cfg(test)]
+use crate::merkle::merkle_tree;
 use crate::merkle::{self, Hash, HashKind};
 use crate::ntt::AdditiveNttF128;
+use crate::pcs::ligerito::LigeritoProfile;
+use crate::pcs::ligerito::ProverConfig;
+use crate::pcs::ligerito::VerifierConfig;
+use crate::pcs::ligerito::prover_config_for;
+use crate::pcs::ligerito::udr_queries;
+use crate::pcs::ligerito::verifier_config_for;
 use crate::pcs::pack::LOG_PACKING;
+use crate::scratch::give_f128;
+use crate::scratch::take_f128;
+use crate::scratch::try_take_f128;
+use core::mem::size_of;
+use core::slice::from_raw_parts;
 use serde::{Deserialize, Serialize};
+use std::env::var_os;
+#[cfg(test)]
+use std::hint::black_box;
+use std::mem::take;
+use std::ptr::write_bytes;
+use std::thread::scope;
+use std::time::Instant;
 
 /// PCS configuration. Polynomial-basis subspace `{1, x, x², …}` for the NTT.
 ///
@@ -39,7 +61,7 @@ pub struct PcsParams {
     /// PCS opening; must agree with `log_inv_rate`
     /// (`profile.log_inv_rate() == log_inv_rate`). Defaults to `Fast`.
     #[serde(default)]
-    pub profile: crate::pcs::ligerito::LigeritoProfile,
+    pub profile: LigeritoProfile,
     /// **Integer-lane commit** (optional). `None` (the default) commits the
     /// full `2^log_batch_size` interleaved lanes — today's power-of-two
     /// scheme. `Some(t)` with `1 ≤ t ≤ 2^log_batch_size` commits exactly `t`
@@ -112,7 +134,7 @@ impl PcsParams {
     }
     /// Merkle leaf size in bytes = `num_ntts() * 16`.
     pub fn leaf_size_bytes(&self) -> usize {
-        self.num_ntts() * core::mem::size_of::<F128>()
+        self.num_ntts() * size_of::<F128>()
     }
 
     /// Ligerito prover config for these params.
@@ -124,24 +146,16 @@ impl PcsParams {
     /// recursive level cannot end up on different hashes.
     ///
     /// [`ligerito::prover_config_for`]: crate::pcs::ligerito::prover_config_for
-    pub fn ligerito_prover_config(&self) -> Result<crate::pcs::ligerito::ProverConfig, String> {
-        let mut cfg = crate::pcs::ligerito::prover_config_for(
-            self.log_msg_len(),
-            self.log_batch_size,
-            self.profile,
-        )?;
+    pub fn ligerito_prover_config(&self) -> Result<ProverConfig, String> {
+        let mut cfg = prover_config_for(self.log_msg_len(), self.log_batch_size, self.profile)?;
         cfg.merkle_hash = self.merkle_hash;
         Ok(cfg)
     }
 
     /// Verifier-side counterpart to [`Self::ligerito_prover_config`], stamped
     /// with the same Merkle hash for the same reason.
-    pub fn ligerito_verifier_config(&self) -> Result<crate::pcs::ligerito::VerifierConfig, String> {
-        let mut cfg = crate::pcs::ligerito::verifier_config_for(
-            self.log_msg_len(),
-            self.log_batch_size,
-            self.profile,
-        )?;
+    pub fn ligerito_verifier_config(&self) -> Result<VerifierConfig, String> {
+        let mut cfg = verifier_config_for(self.log_msg_len(), self.log_batch_size, self.profile)?;
         cfg.merkle_hash = self.merkle_hash;
         Ok(cfg)
     }
@@ -156,7 +170,7 @@ impl PcsParams {
     pub fn l0_queries(&self) -> usize {
         match self.ligerito_prover_config() {
             Ok(cfg) => cfg.queries[0],
-            Err(_) => crate::pcs::ligerito::udr_queries(self.log_inv_rate),
+            Err(_) => udr_queries(self.log_inv_rate),
         }
     }
 
@@ -212,7 +226,7 @@ pub struct ProverData {
 // 128 MB at m = 29) through the scratch pool instead of unmapping it.
 impl Drop for ProverData {
     fn drop(&mut self) {
-        crate::scratch::give_f128(std::mem::take(&mut self.codeword));
+        give_f128(take(&mut self.codeword));
     }
 }
 
@@ -249,7 +263,7 @@ pub fn commit(z_packed: &[F128], params: &PcsParams) -> (Commitment, ProverData)
     // `z_packed` into the lower half, and zero-fill JUST the upper half (the
     // RS-encoding zero coefficients that the NTT's first-layer butterfly will
     // read). Saves ~64 MB of memory writes at m=29 (~9 ms).
-    let codeword = crate::scratch::take_f128(codeword_len);
+    let codeword = take_f128(codeword_len);
     commit_into(z_packed, params, codeword)
 }
 
@@ -329,13 +343,14 @@ pub fn dense_lanes(dense_words: usize, log_batch_size: usize, log_dim: usize) ->
 /// words, which stays in L2), so it runs at near-memcpy speed despite the
 /// strided writes.
 pub fn lane_grid_from_lane_major(q: &[F128], log_batch_size: usize) -> Vec<F128> {
+    const TILE: usize = 64;
     use rayon::prelude::*;
 
     let lanes = 1usize << log_batch_size;
     assert!(q.len().is_multiple_of(lanes), "dense stack must fill lanes");
     let d = q.len() >> log_batch_size;
-    let mut grid = crate::scratch::take_f128(q.len());
-    const TILE: usize = 64; // positions per tile
+    let mut grid = take_f128(q.len());
+    // positions per tile
     grid.par_chunks_mut(TILE * lanes)
         .enumerate()
         .for_each(|(tile, out)| {
@@ -376,7 +391,7 @@ pub fn commit_lane_major(q: &[F128], params: &PcsParams) -> (Commitment, ProverD
     );
     let _ = lanes;
     let codeword_len = params.n_positions() * t;
-    let mut codeword = crate::scratch::take_f128(codeword_len);
+    let mut codeword = take_f128(codeword_len);
     replicate_lane_major_fill(&mut codeword, q, t, d);
     finalize_commit(codeword, params)
 }
@@ -386,11 +401,12 @@ pub fn commit_lane_major(q: &[F128], params: &PcsParams) -> (Commitment, ProverD
 /// q[l·D + p]`. Cache-blocked over position tiles (see
 /// [`lane_grid_from_lane_major`]).
 fn replicate_lane_major_fill(codeword: &mut [F128], q: &[F128], t: usize, d: usize) {
+    const TILE: usize = 64;
     use rayon::prelude::*;
 
     let msg_len = t * d;
     debug_assert!(codeword.len().is_multiple_of(msg_len));
-    const TILE: usize = 64; // positions per tile
+    // positions per tile
     codeword.par_chunks_mut(msg_len).for_each(|rep| {
         rep.par_chunks_mut(TILE * t)
             .enumerate()
@@ -413,10 +429,11 @@ fn replicate_lane_major_fill(codeword: &mut [F128], q: &[F128], t: usize, d: usi
 /// `forward_transform_interleaved_from_layer(…, r)`. Every slot of `codeword`
 /// is written (input contents may be stale/uninit).
 pub(crate) fn replicate_message_fill(codeword: &mut [F128], msg: &[F128]) {
+    const COPY_CHUNK: usize = 1 << 16;
     use rayon::prelude::*;
     let msg_len = msg.len();
     debug_assert!(codeword.len().is_multiple_of(msg_len));
-    const COPY_CHUNK: usize = 1 << 16;
+
     // Fast finer-grained path only when the chunk size divides `msg_len` (so a
     // COPY_CHUNK-aligned slice never straddles a replica boundary). On the
     // integer-lane commit `msg_len = t · 2^log_dim` is not a power of two, but
@@ -442,8 +459,8 @@ pub(crate) fn replicate_message_fill(codeword: &mut [F128], msg: &[F128]) {
 /// Shared tail of [`commit`] / [`commit_into`]: interleaved forward additive
 /// NTT (RS-encode every lane) then the initial Merkle tree over codeword rows.
 fn finalize_commit(mut codeword: Vec<F128>, params: &PcsParams) -> (Commitment, ProverData) {
-    let timing = std::env::var_os("FLOCK_COMMIT_TIMING").is_some();
-    let t_ntt = std::time::Instant::now();
+    let timing = var_os("FLOCK_COMMIT_TIMING").is_some();
+    let t_ntt = Instant::now();
     // ---- Interleaved forward additive NTT: 2^log_batch_size independent
     // sub-NTTs with shared twiddles. Each sub-NTT operates on its lane of the
     // SoA buffer. The first `log_inv_rate` layers were pre-applied by the
@@ -460,24 +477,23 @@ fn finalize_commit(mut codeword: Vec<F128>, params: &PcsParams) -> (Commitment, 
             t_ntt.elapsed().as_secs_f64() * 1e3
         );
     }
-    let t_merkle = std::time::Instant::now();
+    let t_merkle = Instant::now();
 
     // ---- Merkle commitment: one leaf per codeword position = num_ntts F128.
     // Zero-copy: cast the codeword Vec<F128> directly to &[u8]. F128 is
     // repr(C, align(16)) with two u64s laid out little-endian — same bytes
     // as the explicit lo.to_le_bytes() + hi.to_le_bytes() serialization.
     let codeword_bytes: &[u8] = unsafe {
-        core::slice::from_raw_parts(
+        from_raw_parts(
             codeword.as_ptr() as *const u8,
-            codeword.len() * core::mem::size_of::<F128>(),
+            codeword.len() * size_of::<F128>(),
         )
     };
     // Initial tree: one leaf per codeword position, each containing the
     // row-batch lanes (num_ntts F_{2^128} values = 2^log_batch_size). This is
     // Ligerito's L0 commitment.
     let merkle_tree = merkle::merkle_tree(codeword_bytes, params.n_leaves(), params.merkle_hash);
-    let cap =
-        merkle::cap_layer(&merkle_tree, params.n_leaves(), params.l0_cap_depth()).to_vec();
+    let cap = merkle::cap_layer(&merkle_tree, params.n_leaves(), params.l0_cap_depth()).to_vec();
     if timing {
         eprintln!(
             "[commit-timing] merkle: {:.2} ms",
@@ -530,7 +546,7 @@ pub fn prefault_codeword_during<R>(
     params: &PcsParams,
     generate: impl FnOnce() -> R,
 ) -> (Option<Vec<F128>>, R) {
-    if rayon::current_num_threads() <= 1 || std::env::var_os("FLOCK_NO_PREFAULT").is_some() {
+    if rayon::current_num_threads() <= 1 || var_os("FLOCK_NO_PREFAULT").is_some() {
         // Truly single-threaded (or explicitly disabled): no extra OS thread;
         // commit allocates inline. FLOCK_NO_PREFAULT lets benchmarks A/B the
         // offload and keeps fixed-thread-count sweeps honest.
@@ -539,18 +555,18 @@ pub fn prefault_codeword_during<R>(
     let codeword_len = params.n_positions() * params.num_ntts();
     // Warm path: a pooled buffer is already resident — there is nothing to
     // pre-fault, and commit_into writes every slot itself. Skip the thread.
-    if let Some(buf) = crate::scratch::try_take_f128(codeword_len) {
+    if let Some(buf) = try_take_f128(codeword_len) {
         return (Some(buf), generate());
     }
     // Cold path: allocate + first-touch on a background-QoS thread, hidden
     // under witness generation. (commit_into rewrites all slots, so the
     // zero values themselves don't matter — the page faults do.)
-    std::thread::scope(|s| {
+    scope(|s| {
         let h = s.spawn(move || {
             set_background_qos();
             let mut buf: Vec<F128> = crate::alloc_uninit_f128_vec(codeword_len);
             unsafe {
-                std::ptr::write_bytes(buf.as_mut_ptr(), 0u8, codeword_len);
+                write_bytes(buf.as_mut_ptr(), 0u8, codeword_len);
             }
             buf
         });
@@ -661,16 +677,10 @@ mod tests {
                 pd.codeword, oracle,
                 "codeword mismatch at m={m} r={log_inv_rate}"
             );
-            let oracle_bytes: &[u8] = unsafe {
-                core::slice::from_raw_parts(oracle.as_ptr() as *const u8, oracle.len() * 16)
-            };
-            let oracle_tree =
-                crate::merkle::merkle_tree(oracle_bytes, params.n_leaves(), params.merkle_hash);
-            let oracle_cap = crate::merkle::cap_layer(
-                &oracle_tree,
-                params.n_leaves(),
-                params.l0_cap_depth(),
-            );
+            let oracle_bytes: &[u8] =
+                unsafe { from_raw_parts(oracle.as_ptr() as *const u8, oracle.len() * 16) };
+            let oracle_tree = merkle_tree(oracle_bytes, params.n_leaves(), params.merkle_hash);
+            let oracle_cap = cap_layer(&oracle_tree, params.n_leaves(), params.l0_cap_depth());
             assert_eq!(
                 commitment.cap, oracle_cap,
                 "cap mismatch at m={m} r={log_inv_rate}"
@@ -776,18 +786,13 @@ mod tests {
 
                 // Root is the Merkle tree over t-wide leaves of pd_t.codeword.
                 let bytes: &[u8] = unsafe {
-                    core::slice::from_raw_parts(
+                    from_raw_parts(
                         pd_t.codeword.as_ptr() as *const u8,
                         pd_t.codeword.len() * 16,
                     )
                 };
-                let tree =
-                    crate::merkle::merkle_tree(bytes, t_params.n_leaves(), t_params.merkle_hash);
-                let cap = crate::merkle::cap_layer(
-                    &tree,
-                    t_params.n_leaves(),
-                    t_params.l0_cap_depth(),
-                );
+                let tree = merkle_tree(bytes, t_params.n_leaves(), t_params.merkle_hash);
+                let cap = cap_layer(&tree, t_params.n_leaves(), t_params.l0_cap_depth());
                 assert_eq!(cap, _c_t.cap, "cap must be over t-wide leaves");
             }
         }
@@ -898,14 +903,13 @@ mod tests {
             // num_ntts F128 wide. Timed under the default hash (SHA-256) — this
             // probe compares lane counts, not hashes, and has no `PcsParams` in
             // scope; use `HashKind::Blake3` here to re-measure the other one.
-            let bytes: &[u8] =
-                unsafe { core::slice::from_raw_parts(buf.as_ptr() as *const u8, buf.len() * 16) };
+            let bytes: &[u8] = unsafe { from_raw_parts(buf.as_ptr() as *const u8, buf.len() * 16) };
             let mut best_merkle = f64::INFINITY;
             for _ in 0..n_runs {
                 let t = Instant::now();
                 let tree = merkle::merkle_tree(bytes, n_positions, HashKind::default());
                 best_merkle = best_merkle.min(t.elapsed().as_secs_f64() * 1e3);
-                std::hint::black_box(tree.last());
+                black_box(tree.last());
             }
             (best_ntt, best_merkle)
         };
@@ -978,7 +982,7 @@ mod tests {
             let (commitment, prover_data) = commit(&z_packed, &params);
             assert_eq!(prover_data.codeword.len(), params.codeword_len_f128());
             assert_eq!(
-                crate::merkle::cap_layer(
+                cap_layer(
                     &prover_data.merkle_tree,
                     params.n_leaves(),
                     params.l0_cap_depth(),

--- a/crates/flock-core/src/pcs/jagged.rs
+++ b/crates/flock-core/src/pcs/jagged.rs
@@ -79,7 +79,19 @@
 use crate::challenger::Challenger;
 use crate::field::F128;
 use crate::lincheck::build_eq_table;
+use crate::pcs::ring_switch::fold_one_slot;
+use crate::scratch::take_f128;
 use serde::{Deserialize, Serialize};
+use std::env::var;
+#[cfg(test)]
+use std::hint::black_box;
+#[cfg(test)]
+use std::mem::size_of;
+use std::mem::swap;
+use std::sync::OnceLock;
+#[cfg(test)]
+use std::time::Duration;
+use std::time::Instant;
 
 /// Configuration of a jagged function: the (zero-padded to `2^k`) column
 /// heights, summarized as the cumulative-height prefix sums.
@@ -296,6 +308,10 @@ fn generate_f_and_claim(
     z_row: &[F128],
     z_col: &[F128],
 ) -> (Vec<F128>, F128, F128, F128) {
+    // ~1 MB chunks: one binary search amortized over 64K elements. CHUNK is
+    // even and len is a power of two ≥ 2, so message pairs never straddle
+    // chunks.
+    const CHUNK: usize = 1 << 16;
     use rayon::prelude::*;
     let len = 1usize << params.m;
     let area = params.area() as usize;
@@ -316,10 +332,6 @@ fn generate_f_and_claim(
         return (b, q[0] * bi, F128::ZERO, F128::ZERO);
     }
 
-    // ~1 MB chunks: one binary search amortized over 64K elements. CHUNK is
-    // even and len is a power of two ≥ 2, so message pairs never straddle
-    // chunks.
-    const CHUNK: usize = 1 << 16;
     let (v, g_one, g_inf) = b
         .par_chunks_mut(CHUNK)
         .enumerate()
@@ -414,6 +426,9 @@ fn generate_f_and_claim_blocked(
     z_col: &[F128],
     d: usize,
 ) -> (Vec<F128>, F128, F128, F128) {
+    // Sub-range within a block pair; keeps the task count high when there are
+    // few pairs (32 pairs × 8 sub-ranges at M = 30).
+    const SUB: usize = 1 << 14;
     use rayon::prelude::*;
     let len = 1usize << params.m;
     assert!(d >= 1 && d <= len / 2 && d.is_power_of_two());
@@ -423,9 +438,6 @@ fn generate_f_and_claim_blocked(
     let prefix = &params.col_prefix_sums;
     let mut b = crate::alloc_uninit_f128_vec(len);
 
-    // Sub-range within a block pair; keeps the task count high when there are
-    // few pairs (32 pairs × 8 sub-ranges at M = 30).
-    const SUB: usize = 1 << 14;
     let (v, g_one, g_inf) = b
         .par_chunks_mut(2 * d)
         .enumerate()
@@ -547,8 +559,8 @@ pub(crate) fn prove_main<C: Challenger>(
                 &mut sb[..half],
             );
         }
-        std::mem::swap(&mut a, &mut sa);
-        std::mem::swap(&mut bb, &mut sb);
+        swap(&mut a, &mut sa);
+        swap(&mut bb, &mut sb);
         cur = half;
     }
 
@@ -1181,7 +1193,7 @@ fn fold_partials(
             gather(b, slot);
         }
     }
-    std::mem::swap(p, out);
+    swap(p, out);
     debug_assert_eq!(p.len(), blocks.n_blocks(layer + 1));
 }
 
@@ -1587,26 +1599,10 @@ pub(crate) fn build_merged_weight_and_prime(
     claims: &[MergedWeightClaim<'_>],
     q: &[F128],
 ) -> (Vec<F128>, (F128, F128)) {
-    use rayon::prelude::*;
-    let area = params.area() as usize;
-    let n_total = 1usize << params.m;
     enum ColSide<'a> {
         Fold(Vec<F128>, &'a [F128]),
         Combined(&'a [F128]),
     }
-    let tabs: Vec<(Vec<F128>, ColSide<'_>)> = claims
-        .iter()
-        .map(|c| match c {
-            MergedWeightClaim::Folded { z_row, z_col, table } => {
-                (build_eq_table(z_row), ColSide::Fold(build_eq_table(z_col), *table))
-            }
-            MergedWeightClaim::Scalar { z_row, cols } => {
-                (build_eq_table(z_row), ColSide::Combined(cols))
-            }
-        })
-        .collect();
-    assert_eq!(q.len(), n_total);
-    let mut w = crate::scratch::take_f128(n_total);
     // Segmented fill (the JaggedWeight lesson): per chunk, ONE cursor into
     // `col_prefix_sums`, then per column segment a claim-OUTER sweep — the
     // column factor hoisted, rows read sequentially, and one claim's 64 KB
@@ -1616,6 +1612,29 @@ pub(crate) fn build_merged_weight_and_prime(
     // pass (CHUNK is even, so element pairs never straddle chunks); the
     // dead tail past the area contributes zero on both sides.
     const CHUNK: usize = 1 << 14;
+    use rayon::prelude::*;
+    let area = params.area() as usize;
+    let n_total = 1usize << params.m;
+
+    let tabs: Vec<(Vec<F128>, ColSide<'_>)> = claims
+        .iter()
+        .map(|c| match c {
+            MergedWeightClaim::Folded {
+                z_row,
+                z_col,
+                table,
+            } => (
+                build_eq_table(z_row),
+                ColSide::Fold(build_eq_table(z_col), *table),
+            ),
+            MergedWeightClaim::Scalar { z_row, cols } => {
+                (build_eq_table(z_row), ColSide::Combined(cols))
+            }
+        })
+        .collect();
+    assert_eq!(q.len(), n_total);
+    let mut w = take_f128(n_total);
+
     let ps = &params.col_prefix_sums;
     let prime = w
         .par_chunks_mut(CHUNK)
@@ -1647,13 +1666,11 @@ pub(crate) fn build_merged_weight_and_prime(
                             let c_hoist = eq_c[col];
                             if first_claim {
                                 for (slot, &r) in dst.iter_mut().zip(rows) {
-                                    *slot =
-                                        crate::pcs::ring_switch::fold_one_slot(r * c_hoist, tab);
+                                    *slot = fold_one_slot(r * c_hoist, tab);
                                 }
                             } else {
                                 for (slot, &r) in dst.iter_mut().zip(rows) {
-                                    *slot +=
-                                        crate::pcs::ring_switch::fold_one_slot(r * c_hoist, tab);
+                                    *slot += fold_one_slot(r * c_hoist, tab);
                                 }
                             }
                         }
@@ -1759,13 +1776,14 @@ fn frobenius_statements(
     bounds: &[(u64, u64, u32)],
     prover: Option<(&AssistBlocks, &[[F128; 4]], usize)>,
 ) -> Vec<FrobeniusStatement> {
-    use rayon::prelude::*;
-    let m = params.m;
-    let sparse = assist_sparse_transitions();
     enum SpecCols<'b> {
         Point(Vec<F128>),
         Weights(&'b [F128]),
     }
+    use rayon::prelude::*;
+    let m = params.m;
+    let sparse = assist_sparse_transitions();
+
     let mut specs: Vec<(Vec<F128>, SpecCols<'_>, F128)> = Vec::new();
     for claim in claims {
         assert_eq!(claim.coeffs.len(), 128);
@@ -1897,8 +1915,8 @@ pub fn prove_frobenius_assist<C: Challenger>(
     use rayon::prelude::*;
     let m = params.m;
     assert_eq!(rho.len(), m);
-    let trace = std::env::var("PCS_TRACE").is_ok();
-    let t = std::time::Instant::now();
+    let trace = var("PCS_TRACE").is_ok();
+    let t = Instant::now();
     let sparse = assist_sparse_transitions();
     let bounds = assist_boundaries(params);
     let blocks = AssistBlocks::new(&bounds, m);
@@ -1908,7 +1926,14 @@ pub fn prove_frobenius_assist<C: Challenger>(
     let lo = params.n.clamp(1, m + 1);
     let tail = assist_shared_tail_blocked(&blocks, rho, &sparse, m, lo);
     let lo_off = blocks.off[lo];
-    let mut sts = frobenius_statements(params, claims, groups, rho, &bounds, Some((&blocks, &tail, lo)));
+    let mut sts = frobenius_statements(
+        params,
+        claims,
+        groups,
+        rho,
+        &bounds,
+        Some((&blocks, &tail, lo)),
+    );
     if trace {
         eprintln!(
             "    [frobenius] statements + suffix rows (x{}, {} low + {} shared blocks vs {} dense): {:6.2} ms",
@@ -1919,7 +1944,7 @@ pub fn prove_frobenius_assist<C: Challenger>(
             t.elapsed().as_secs_f64() * 1e3
         );
     }
-    let t = std::time::Instant::now();
+    let t = Instant::now();
 
     let v = sts
         .par_iter()
@@ -2041,7 +2066,7 @@ pub fn verify_frobenius_assist<C: Challenger>(
     // verify, so its three phases are worth separating: the transcript replay,
     // building the 128·K statements (a `2^k`-column `eq` table each), and the
     // per-statement `W(σ)` walk + boundary DP.
-    let trace = std::env::var("VERIFY_TRACE").is_ok();
+    let trace = var("VERIFY_TRACE").is_ok();
     let tfmt = |s: f64| -> String {
         let ms = s * 1000.0;
         if ms < 1.0 {
@@ -2053,7 +2078,7 @@ pub fn verify_frobenius_assist<C: Challenger>(
     challenger.observe_label(b"flock-frobenius-assist-v0");
     challenger.observe_f128(proof.v);
 
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut claim = proof.v;
     let mut sigma = Vec::with_capacity(2 * (m + 1));
     for &(g_one, g_inf) in &proof.rounds {
@@ -2073,7 +2098,7 @@ pub fn verify_frobenius_assist<C: Challenger>(
 
     let bounds = assist_boundaries(params);
     let blocks = AssistBlocks::new(&bounds, m);
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let sts = frobenius_statements(params, claims, groups, rho, &bounds, None);
     if trace {
         eprintln!(
@@ -2087,7 +2112,7 @@ pub fn verify_frobenius_assist<C: Challenger>(
     // tree descent shared by all statements; each statement then pays a
     // plain weighted dot. Same field products as the per-statement ascent
     // ([`assist_w_at_blocked`]), reassociated, so `w` is bit-identical.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let eq_cols = assist_eq_at_blocked(&blocks, &sigma, m);
     if trace {
         eprintln!(
@@ -2097,7 +2122,7 @@ pub fn verify_frobenius_assist<C: Challenger>(
             tfmt(t.elapsed().as_secs_f64())
         );
     }
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let expect = sts
         .par_iter()
         .map(|st| {
@@ -2198,7 +2223,7 @@ pub fn verify_with_assist<C: Challenger>(
 /// Images of the `F₂`-basis under square root (`x ↦ x^{2^127}`, the inverse
 /// Frobenius) — square root is `F₂`-linear, so this table defines the map.
 fn sqrt_basis() -> &'static [F128; 128] {
-    static T: std::sync::OnceLock<[F128; 128]> = std::sync::OnceLock::new();
+    static T: OnceLock<[F128; 128]> = OnceLock::new();
     T.get_or_init(|| {
         let mut t = [F128::ZERO; 128];
         for (b, slot) in t.iter_mut().enumerate() {
@@ -2265,16 +2290,14 @@ fn twisted_eq_at(gpow: &[F128], rho_pows: &[Vec<F128>], x: &[F128]) -> F128 {
 /// endpoint factor.
 fn eq_at(a: &[F128], b: &[F128]) -> F128 {
     debug_assert_eq!(a.len(), b.len());
-    a.iter()
-        .zip(b)
-        .fold(F128::ONE, |acc, (&x, &y)| {
-            acc * (x * y + (F128::ONE + x) * (F128::ONE + y))
-        })
+    a.iter().zip(b).fold(F128::ONE, |acc, (&x, &y)| {
+        acc * (x * y + (F128::ONE + x) * (F128::ONE + y))
+    })
 }
 
 /// Basis images of `x ↦ x^{2^{-j}}` for every `j` (level 0 = identity).
 fn inv_frob_basis() -> &'static Vec<[F128; 128]> {
-    static T: std::sync::OnceLock<Vec<[F128; 128]>> = std::sync::OnceLock::new();
+    static T: OnceLock<Vec<[F128; 128]>> = OnceLock::new();
     T.get_or_init(|| {
         let mut levels: Vec<[F128; 128]> = Vec::with_capacity(128);
         let mut cur = [F128::ZERO; 128];
@@ -2562,11 +2585,12 @@ fn build_combined_weight_and_msg(
     sides: &[(F128, Vec<F128>, &[F128])],
     partner: &[F128],
 ) -> (Vec<F128>, (F128, F128)) {
+    const CH: usize = 1 << 14;
     use rayon::prelude::*;
     let mut a = vec![F128::ZERO; 1usize << params.m];
     let pfx = &params.col_prefix_sums;
     let n_cols = pfx.len() - 1;
-    const CH: usize = 1 << 14;
+
     let msg = a
         .par_chunks_mut(CH)
         .zip(partner.par_chunks(CH))
@@ -2640,14 +2664,18 @@ pub fn prove_multipoint_twisted<C: Challenger>(
         assert_eq!(claim.coeffs.len(), 128);
     }
     for g in groups {
-        assert_eq!(g.cols.len(), 1usize << params.k, "group cols must be dense over 2^k columns");
+        assert_eq!(
+            g.cols.len(),
+            1usize << params.k,
+            "group cols must be dense over 2^k columns"
+        );
     }
     let n_rs = claims.len();
     let n_g = groups.len();
     assert!(n_rs + n_g > 0, "multipoint over zero claims");
-    let trace = std::env::var("PCS_TRACE").is_ok();
+    let trace = var("PCS_TRACE").is_ok();
 
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     // The inverse-Frobenius points exist only for the twisted (RS) side.
     let rho_pows = (n_rs > 0).then(|| rho_inverse_powers(rho));
     let values = match &rho_pows {
@@ -2683,7 +2711,7 @@ pub fn prove_multipoint_twisted<C: Challenger>(
 
     // The dense vectors: e = eq(ρ,·) (the groups' partner), g = L_γ(e) via
     // one byte-table pass (the RS partner), and the two combined weights.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let eq_rho = super::ring_switch::build_eq_parallel(rho);
     let mut pairs: Vec<ProductPair> = Vec::with_capacity(2);
     let mut msg0 = (F128::ZERO, F128::ZERO);
@@ -2735,7 +2763,7 @@ pub fn prove_multipoint_twisted<C: Challenger>(
     // and summed across the active products. The final fold never runs —
     // nothing reads the folded scalars; the anchor assist reproves the
     // endpoint.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut rounds = Vec::with_capacity(m);
     let mut point = Vec::with_capacity(m);
     let (mut g_one, mut g_inf) = msg0;
@@ -2769,12 +2797,16 @@ pub fn prove_multipoint_twisted<C: Challenger>(
     // baked into the coefficients (RS claim i: γ^{128 i}·ĝ(ρ''); group k:
     // γ^{128 R + k}·eq(ρ,ρ'')), so the accept check is a plain equality
     // against the running claim and no extra scalar travels.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let g_at = match &rho_pows {
         Some(rp) => twisted_eq_at(&gpow, rp, &point),
         None => F128::ZERO,
     };
-    let e_at = if n_g > 0 { eq_at(rho, &point) } else { F128::ZERO };
+    let e_at = if n_g > 0 {
+        eq_at(rho, &point)
+    } else {
+        F128::ZERO
+    };
     let anchor_coeffs: Vec<Vec<F128>> = (0..n_rs)
         .map(|i| {
             let mut c = vec![F128::ZERO; 128];
@@ -2796,8 +2828,7 @@ pub fn prove_multipoint_twisted<C: Challenger>(
         .enumerate()
         .map(|(k, g)| (*g, gpow[128 * n_rs + k] * e_at))
         .collect();
-    let anchor =
-        prove_frobenius_assist(params, &anchor_claims, &anchor_groups, &point, challenger);
+    let anchor = prove_frobenius_assist(params, &anchor_claims, &anchor_groups, &point, challenger);
     if trace {
         eprintln!(
             "    [multipoint] anchor assist (x{} + x{}): {:6.2} ms",
@@ -2886,7 +2917,11 @@ pub fn verify_multipoint_twisted<C: Challenger>(
         return None;
     }
     for g in groups {
-        assert_eq!(g.cols.len(), 1usize << params.k, "group cols must be dense over 2^k columns");
+        assert_eq!(
+            g.cols.len(),
+            1usize << params.k,
+            "group cols must be dense over 2^k columns"
+        );
     }
     let n_rs = claims.len();
     let n_g = groups.len();
@@ -2936,7 +2971,11 @@ pub fn verify_multipoint_twisted<C: Challenger>(
     } else {
         F128::ZERO
     };
-    let e_at = if n_g > 0 { eq_at(rho, &point) } else { F128::ZERO };
+    let e_at = if n_g > 0 {
+        eq_at(rho, &point)
+    } else {
+        F128::ZERO
+    };
     let anchor_coeffs: Vec<Vec<F128>> = (0..n_rs)
         .map(|i| {
             let mut c = vec![F128::ZERO; 128];
@@ -3121,13 +3160,14 @@ pub(crate) fn fold_and_round_oop_par(
     ao: &mut [F128],
     bo: &mut [F128],
 ) -> (F128, F128) {
-    use rayon::prelude::*;
-    debug_assert_eq!(a.len(), 2 * ao.len());
-    debug_assert!(a.len() >= 4);
     // Output chunk of `CO`; the aligned input chunk is `2*CO` (output is half
     // the input). Slice/`chunks_exact` iteration — no per-element bounds checks —
     // so the reduction scales like the fold (~6× vs ~2.6× for indexed access).
     const CO: usize = 1 << 13;
+    use rayon::prelude::*;
+    debug_assert_eq!(a.len(), 2 * ao.len());
+    debug_assert!(a.len() >= 4);
+
     ao.par_chunks_mut(CO)
         .zip(bo.par_chunks_mut(CO))
         .zip(a.par_chunks(2 * CO))
@@ -3393,10 +3433,10 @@ mod tests {
         let mut best = f64::INFINITY;
         for _ in 0..12 {
             let mut fs = FsChallenger::new(b"frobenius-assist-bench");
-            let t = std::time::Instant::now();
+            let t = Instant::now();
             let proof = prove_frobenius_assist(&params, &claims, &[], &rho, &mut fs);
             best = best.min(t.elapsed().as_secs_f64() * 1e3);
-            std::hint::black_box(proof);
+            black_box(proof);
         }
         println!("frobenius assist prove (256 stmts, 368 cols, m = 23): {best:.2} ms (min of 12)");
     }
@@ -3606,27 +3646,27 @@ mod tests {
             let mut kept = None;
             for _ in 0..3 {
                 let mut fs = FsChallenger::new(b"multipoint-bench");
-                let t = std::time::Instant::now();
+                let t = Instant::now();
                 let proof = prove_multipoint_twisted(&params, &claims, &[], &rho, &mut fs);
                 best = best.min(t.elapsed().as_secs_f64() * 1e3);
                 kept = Some(proof);
             }
             let proof = kept.unwrap();
-            let t = std::time::Instant::now();
+            let t = Instant::now();
             let mut fv = FsChallenger::new(b"multipoint-bench");
             let v = verify_multipoint_twisted(&params, &claims, &[], &rho, &proof, &mut fv)
                 .expect("bench proof verifies");
             let verify_ms = t.elapsed().as_secs_f64() * 1e3;
-            std::hint::black_box(v);
+            black_box(v);
 
             let assist = if run_assist {
                 let mut best_a = f64::INFINITY;
                 for _ in 0..3 {
                     let mut fa = FsChallenger::new(b"assist-bench");
-                    let t = std::time::Instant::now();
+                    let t = Instant::now();
                     let p = prove_frobenius_assist(&params, &claims, &[], &rho, &mut fa);
                     best_a = best_a.min(t.elapsed().as_secs_f64() * 1e3);
-                    std::hint::black_box(p);
+                    black_box(p);
                 }
                 format!("{best_a:6.2} ms")
             } else {
@@ -4159,6 +4199,7 @@ mod tests {
     #[test]
     #[ignore = "heavy benchmark; run explicitly with --release --ignored --nocapture"]
     fn runtime_m25() {
+        const REPS: usize = 3;
         use std::time::Instant;
 
         // Match the full-prover profile (P-core pool) for an apples-to-apples ratio.
@@ -4182,14 +4223,12 @@ mod tests {
         let z_row = sample_vec(&mut rc, n);
         let z_col = sample_vec(&mut rc, k);
 
-        let mb = (len * std::mem::size_of::<F128>()) as f64 / (1024.0 * 1024.0);
+        let mb = (len * size_of::<F128>()) as f64 / (1024.0 * 1024.0);
         eprintln!("\n[jagged runtime] m={m} ({len} F128 = {mb:.0} MB), n={n}, k={k}, cols={cols}");
 
-        const REPS: usize = 3;
-
         // --- Phase 1: B-vector + claim generation, serial vs parallel-fused. ---
-        let mut t_gen_ser = std::time::Duration::MAX;
-        let mut t_gen_par = std::time::Duration::MAX;
+        let mut t_gen_ser = Duration::MAX;
+        let mut t_gen_par = Duration::MAX;
         let (mut b, mut v) = (Vec::new(), F128::ZERO);
         for _ in 0..REPS {
             // Serial reference: column-major build + separate v reduction.
@@ -4210,7 +4249,7 @@ mod tests {
                 vs += *qi * *bi;
             }
             t_gen_ser = t_gen_ser.min(t0.elapsed());
-            std::hint::black_box(&bs);
+            black_box(&bs);
 
             // Parallel fused helper (the production path; also emits round 1's
             // message, so it does slightly more work than the serial baseline).
@@ -4227,7 +4266,7 @@ mod tests {
         // min over REPS to suppress thermal / allocator variance. ---
 
         // Serial: in-place fold; unfused = msg pass + fold pass, fused = both in one.
-        let run_serial = |fused: bool| -> std::time::Duration {
+        let run_serial = |fused: bool| -> Duration {
             let mut a = q.clone();
             let mut bb = b.clone();
             let mut ch = FsChallenger::new(b"flock-jagged-bench");
@@ -4254,12 +4293,12 @@ mod tests {
                     fold_in_place_pair(&mut a, &mut bb, r);
                 }
             }
-            std::hint::black_box(a[0]);
+            black_box(a[0]);
             t.elapsed()
         };
 
         // Parallel: rayon kernels, ping-pong between two out-of-place buffers.
-        let run_par = |fused: bool| -> std::time::Duration {
+        let run_par = |fused: bool| -> Duration {
             let mut a = q.clone(); // len N
             let mut bb = b.clone();
             let mut sa = vec![F128::ZERO; len / 2];
@@ -4296,18 +4335,18 @@ mod tests {
                 } else {
                     fold_oop_par(&a[..cur], &bb[..cur], r, &mut sa[..half], &mut sb[..half]);
                 }
-                std::mem::swap(&mut a, &mut sa);
-                std::mem::swap(&mut bb, &mut sb);
+                swap(&mut a, &mut sa);
+                swap(&mut bb, &mut sb);
                 cur = half;
             }
-            std::hint::black_box(a[0]);
+            black_box(a[0]);
             t.elapsed()
         };
 
-        let mut s_unf = std::time::Duration::MAX;
-        let mut s_fus = std::time::Duration::MAX;
-        let mut p_unf = std::time::Duration::MAX;
-        let mut p_fus = std::time::Duration::MAX;
+        let mut s_unf = Duration::MAX;
+        let mut s_fus = Duration::MAX;
+        let mut p_unf = Duration::MAX;
+        let mut p_fus = Duration::MAX;
         for _ in 0..REPS {
             s_unf = s_unf.min(run_serial(false));
             s_fus = s_fus.min(run_serial(true));
@@ -4319,12 +4358,10 @@ mod tests {
         let point: Vec<F128> = (0..m).map(|_| rc.sample_f128()).collect();
         let t2 = Instant::now();
         let beta = f_hat_t(&params, &z_row, &z_col, &point);
-        std::hint::black_box(beta);
+        black_box(beta);
         let t_ver = t2.elapsed();
 
-        let ratio = |unf: std::time::Duration, fus: std::time::Duration| {
-            unf.as_secs_f64() / fus.as_secs_f64()
-        };
+        let ratio = |unf: Duration, fus: Duration| unf.as_secs_f64() / fus.as_secs_f64();
         eprintln!("  threads: {}", rayon::current_num_threads());
         eprintln!(
             "  f̂_t-gen (B + claim) serial {:>8.1?} → parallel {:>8.1?}   ({:.2}x)",
@@ -4386,7 +4423,7 @@ mod tests {
         let z_row = sample_vec(&mut rc, n);
         let z_col = sample_vec(&mut rc, k);
 
-        let best3 = |f: &mut dyn FnMut() -> std::time::Duration| (0..3).map(|_| f()).min().unwrap();
+        let best3 = |f: &mut dyn FnMut() -> Duration| (0..3).map(|_| f()).min().unwrap();
 
         // Warm-up (thread pool + page faults).
         let mut ch = FsChallenger::new(b"flock-jagged-bits30");
@@ -4396,12 +4433,12 @@ mod tests {
         let t_prove = best3(&mut || {
             let mut ch = FsChallenger::new(b"flock-jagged-bits30");
             let t = Instant::now();
-            std::hint::black_box(prove(&params, &q, &z_row, &z_col, &mut ch));
+            black_box(prove(&params, &q, &z_row, &z_col, &mut ch));
             t.elapsed()
         });
 
         // Main + assist, and keep one transcript for the verifier runs.
-        let mut t_both = std::time::Duration::MAX;
+        let mut t_both = Duration::MAX;
         let mut kept = None;
         for _ in 0..3 {
             let mut ch = FsChallenger::new(b"flock-jagged-bits30");
@@ -4416,9 +4453,7 @@ mod tests {
         let t_verify_direct = best3(&mut || {
             let mut ch = FsChallenger::new(b"flock-jagged-bits30");
             let t = Instant::now();
-            std::hint::black_box(
-                verify(&params, &z_row, &z_col, v, &proof, &mut ch).expect("verify"),
-            );
+            black_box(verify(&params, &z_row, &z_col, v, &proof, &mut ch).expect("verify"));
             t.elapsed()
         });
 
@@ -4426,7 +4461,7 @@ mod tests {
         let t_verify_assist = best3(&mut || {
             let mut ch = FsChallenger::new(b"flock-jagged-bits30");
             let t = Instant::now();
-            std::hint::black_box(
+            black_box(
                 verify_with_assist(&params, &z_row, &z_col, v, &proof, &assist, &mut ch)
                     .expect("verify_with_assist"),
             );
@@ -4537,11 +4572,11 @@ mod tests {
                     );
                 }
                 per_round.push(t.elapsed());
-                std::mem::swap(&mut a, &mut sa);
-                std::mem::swap(&mut bb, &mut sb);
+                swap(&mut a, &mut sa);
+                swap(&mut bb, &mut sb);
                 cur = half;
             }
-            let t_rounds: std::time::Duration = per_round.iter().sum();
+            let t_rounds: Duration = per_round.iter().sum();
             let total = t_gen + t_alloc + t_rounds;
 
             eprintln!("--- trial {trial}  (total {total:.3?})");
@@ -4552,7 +4587,7 @@ mod tests {
             eprintln!("  buffer alloc    : {t_alloc:>9.3?}");
             // Fold round j reads 2·cur and writes cur elements (two arrays each).
             let round_bytes = |j: usize| 3 * (len >> j) * 16;
-            let tail: std::time::Duration = per_round[4..].iter().sum();
+            let tail: Duration = per_round[4..].iter().sum();
             for (j, d) in per_round.iter().take(4).enumerate() {
                 eprintln!(
                     "  fold+msg round {:>2}: {d:>8.3?}  ({:>5.1} GB/s of {} MB)",
@@ -4657,7 +4692,7 @@ mod tests {
             let t = Instant::now();
             let mut ch = FsChallenger::new(b"flock-assist-cmp");
             let p = prove_assist(&params, &z_row, &z_col, &z_idx, &mut ch);
-            std::hint::black_box(&p);
+            black_box(&p);
             t_single = t_single.min(t.elapsed().as_secs_f64());
         }
 
@@ -4687,7 +4722,7 @@ mod tests {
             let t = Instant::now();
             let mut ch = FsChallenger::new(b"flock-assist-cmp");
             let p = prove_frobenius_assist(&params, &claims, &[], &rho, &mut ch);
-            std::hint::black_box(&p);
+            black_box(&p);
             t_frob = t_frob.min(t.elapsed().as_secs_f64());
         }
 
@@ -4720,6 +4755,8 @@ mod tests {
     #[test]
     #[ignore = "diagnostic; run with --release --ignored --nocapture"]
     fn scaling_diag() {
+        const REPS: usize = 6;
+        const CHUNK: usize = 1 << 13;
         use rayon::prelude::*;
         use std::time::{Duration, Instant};
         let _ = crate::init_perf_thread_pool();
@@ -4737,8 +4774,8 @@ mod tests {
             lo: 0x9E37,
             hi: 0x1234,
         };
-        const REPS: usize = 6;
-        const CHUNK: usize = 1 << 13; // coarse: 8K outputs / task
+
+        // coarse: 8K outputs / task
 
         let bench = |f: &mut dyn FnMut()| {
             let mut t = Duration::MAX;
@@ -4809,10 +4846,10 @@ mod tests {
 
         // --- real round message (contiguous a+b read): round_msg vs round_msg_par ---
         let ts = bench(&mut || {
-            std::hint::black_box(round_msg(&a, &b));
+            black_box(round_msg(&a, &b));
         });
         let tp_fine = bench(&mut || {
-            std::hint::black_box(round_msg_par(&a, &b));
+            black_box(round_msg_par(&a, &b));
         });
         // Coarse reduction: per-chunk local accumulator, then combine.
         let tp_coarse = bench(&mut || {
@@ -4828,7 +4865,7 @@ mod tests {
                     },
                 )
                 .reduce(|| (F128::ZERO, F128::ZERO), |(p, q), (s, t)| (p + s, q + t));
-            std::hint::black_box(acc);
+            black_box(acc);
         });
         let rd_bytes = len * 16 * 2; // read all of a and b
         eprintln!(
@@ -4860,7 +4897,7 @@ mod tests {
                     (g1, gi)
                 })
                 .reduce(|| (F128::ZERO, F128::ZERO), |(p, q), (s, t)| (p + s, q + t));
-            std::hint::black_box(acc);
+            black_box(acc);
         });
         eprintln!(
             "  round_msg par.slice(chunks_exact)   {:>7.1?} ({:>4.0} GB/s)  {:.2}x",
@@ -4900,8 +4937,8 @@ mod tests {
                         &mut sb[..half_r],
                     );
                 }
-                std::mem::swap(&mut av, &mut sa);
-                std::mem::swap(&mut bv, &mut sb);
+                swap(&mut av, &mut sa);
+                swap(&mut bv, &mut sb);
                 round_t[rd + 1] = round_t[rd + 1].min(t.elapsed());
                 cur = half_r;
             }
@@ -4917,8 +4954,8 @@ mod tests {
             tail,
             100.0 * tail.as_secs_f64() / total.as_secs_f64()
         );
-        std::hint::black_box(&out);
-        std::hint::black_box(&dst);
+        black_box(&out);
+        black_box(&dst);
     }
 
     #[test]

--- a/crates/flock-core/src/pcs/ligerito.rs
+++ b/crates/flock-core/src/pcs/ligerito.rs
@@ -30,11 +30,27 @@
 //!    c. Else: commit f^{i+2}, open f^{i+1}, induce next basis, glue.
 
 use crate::challenger::Challenger;
+#[cfg(test)]
+use crate::challenger::FsChallenger;
+#[cfg(any(test, feature = "unsound-challenger"))]
+use crate::challenger::RandomChallenger;
+use crate::field::f128_slice::fold_pairs;
 use crate::field::{F128, F256Unreduced};
 use crate::lincheck::build_eq_table;
 use crate::merkle::{self, Hash, HashKind};
 use crate::ntt::additive_ntt_f128::AdditiveNttF128;
+use crate::pcs::LOG_PACKING;
+use crate::scratch::give_f128;
+use crate::scratch::take_f128;
+#[cfg(test)]
+use crate::zerocheck::multilinear::eq_eval;
+use core::mem::size_of;
+use core::slice::from_raw_parts;
 use serde::{Deserialize, Serialize};
+use std::env::var;
+use std::mem::take;
+use std::time::Duration;
+use std::time::Instant;
 
 // ===================================================================
 // Config
@@ -401,7 +417,7 @@ pub fn prover_config_for(
     log_batch_size: usize,
     profile: LigeritoProfile,
 ) -> Result<ProverConfig, String> {
-    let m = log_n + crate::pcs::LOG_PACKING;
+    let m = log_n + LOG_PACKING;
     let toml = embedded_security_config(m, profile).ok_or_else(|| {
         format!(
             "no security config registered for (m={m}, profile={}). \
@@ -430,7 +446,7 @@ pub fn verifier_config_for(
     log_batch_size: usize,
     profile: LigeritoProfile,
 ) -> Result<VerifierConfig, String> {
-    let m = log_n + crate::pcs::LOG_PACKING;
+    let m = log_n + LOG_PACKING;
     let toml = embedded_security_config(m, profile).ok_or_else(|| {
         format!(
             "no security config registered for (m={m}, profile={})",
@@ -1163,7 +1179,7 @@ impl LigeritoSecurityConfig {
         target_security_bits: usize,
     ) -> Result<Self, String> {
         let log_n = m
-            .checked_sub(crate::pcs::LOG_PACKING)
+            .checked_sub(LOG_PACKING)
             .ok_or_else(|| format!("m ({m}) < LOG_PACKING (7)"))?;
         let initial_k = 6usize;
         let prover = default_config(log_n, initial_k, log_inv_rate).map_err(|e| e.to_string())?;
@@ -1260,7 +1276,7 @@ impl LigeritoSecurityConfig {
             LigeritoProfile::Fast | LigeritoProfile::Secure => 0,
         };
         let log_n = m
-            .checked_sub(crate::pcs::LOG_PACKING)
+            .checked_sub(LOG_PACKING)
             .ok_or_else(|| format!("m ({m}) < LOG_PACKING (7)"))?;
         let initial_k = 6usize;
 
@@ -1547,12 +1563,16 @@ pub struct LigeritoProof {
 
 impl LigeritoProof {
     pub fn size_bytes(&self) -> usize {
-        const ELEM: usize = core::mem::size_of::<F128>();
+        const ELEM: usize = size_of::<F128>();
         let level_bytes = |p: &RecursiveProof| -> usize {
             p.opened_rows.iter().map(|r| r.len() * ELEM).sum::<usize>() + p.merkle_proof.len() * 32
         };
         let mut total = self.initial_cap.len() * 32;
-        total += self.recursive_caps.iter().map(|c| c.len() * 32).sum::<usize>();
+        total += self
+            .recursive_caps
+            .iter()
+            .map(|c| c.len() * 32)
+            .sum::<usize>();
         total += level_bytes(&self.initial_proof);
         for p in &self.recursive_proofs {
             total += level_bytes(p);
@@ -1573,7 +1593,7 @@ impl LigeritoProof {
 
     /// Print a per-component breakdown of the proof size to stderr.
     pub fn print_size_breakdown(&self) {
-        const ELEM: usize = core::mem::size_of::<F128>();
+        const ELEM: usize = size_of::<F128>();
         let kb = |b: usize| {
             if b >= 1024 * 1024 {
                 format!("{:.2} MB", b as f64 / 1024.0 / 1024.0)
@@ -1585,8 +1605,7 @@ impl LigeritoProof {
         };
 
         let roots_b = 32
-            * (self.initial_cap.len()
-                + self.recursive_caps.iter().map(|c| c.len()).sum::<usize>());
+            * (self.initial_cap.len() + self.recursive_caps.iter().map(|c| c.len()).sum::<usize>());
         let init_opened: usize = self
             .initial_proof
             .opened_rows
@@ -1857,6 +1876,18 @@ pub(crate) fn induce_sumcheck_evaluate_at_residual(
     ris_for_basis: &[F128],
     yr_log_n: usize,
 ) -> Vec<F128> {
+    // Per-query precomputation: Ŵ_k(q) for all k, then split into prefix
+    // product (fixed scalar) and suffix Ŵ values (varied per y).
+    struct PerQuery {
+        prefix_prod: F128,
+        suffix_w: Vec<F128>, // length = yr_log_n
+    }
+    // This runs once per recursion level over tiny verify-sized inputs
+    // (`queries` ≈ tens; `yr_len` ≤ 2^5 since the residual folds to ≤5 bits), so
+    // a rayon dispatch per level costs more than the field work itself (measured
+    // ~0.47 ms serial vs ~0.75 ms parallel for the whole residual eval at m=30).
+    // Stay serial below the crossover — mirror of merkle.rs's `SERIAL_LEVEL_NODES`.
+    const PAR_FLOOR: usize = 1024;
     use crate::lincheck::build_eq_table;
     use rayon::prelude::*;
     assert_eq!(ris_for_basis.len() + yr_log_n, log_msg_cols);
@@ -1892,12 +1923,6 @@ pub(crate) fn induce_sumcheck_evaluate_at_residual(
 
     let prefix_len = ris_for_basis.len();
 
-    // Per-query precomputation: Ŵ_k(q) for all k, then split into prefix
-    // product (fixed scalar) and suffix Ŵ values (varied per y).
-    struct PerQuery {
-        prefix_prod: F128,
-        suffix_w: Vec<F128>, // length = yr_log_n
-    }
     let compute_query = |&q: &usize| -> PerQuery {
         let q_field = F128::new(q as u64, 0);
         // Compute s_k(q_field) recursively, then normalize by 1/s_k(v_k).
@@ -1926,12 +1951,7 @@ pub(crate) fn induce_sumcheck_evaluate_at_residual(
             suffix_w,
         }
     };
-    // This runs once per recursion level over tiny verify-sized inputs
-    // (`queries` ≈ tens; `yr_len` ≤ 2^5 since the residual folds to ≤5 bits), so
-    // a rayon dispatch per level costs more than the field work itself (measured
-    // ~0.47 ms serial vs ~0.75 ms parallel for the whole residual eval at m=30).
-    // Stay serial below the crossover — mirror of merkle.rs's `SERIAL_LEVEL_NODES`.
-    const PAR_FLOOR: usize = 1024;
+
     let per_query: Vec<PerQuery> = if n_queries > PAR_FLOOR {
         queries.par_iter().map(compute_query).collect()
     } else {
@@ -2342,7 +2362,7 @@ pub(crate) struct LigeroWitness {
 // pool when a level's witness is replaced/dropped.
 impl Drop for LigeroWitness {
     fn drop(&mut self) {
-        crate::scratch::give_f128(std::mem::take(&mut self.mat));
+        give_f128(take(&mut self.mat));
     }
 }
 
@@ -2350,8 +2370,8 @@ impl Drop for LigeroWitness {
 // packed witness `f` and the γ-combined basis) — recycle both on drop.
 impl Drop for SumcheckProver {
     fn drop(&mut self) {
-        crate::scratch::give_f128(std::mem::take(&mut self.f));
-        crate::scratch::give_f128(std::mem::take(&mut self.combined_basis));
+        give_f128(take(&mut self.f));
+        give_f128(take(&mut self.combined_basis));
     }
 }
 
@@ -2399,20 +2419,16 @@ pub(crate) fn ligero_commit(
     // replicas of `poly` (same write cost as copy + zero-fill) and start the
     // transform past those layers — see `pcs::commit::replicate_message_fill`.
     let codeword_len = block_len * num_interleaved;
-    let mut mat = crate::scratch::take_f128(codeword_len);
+    let mut mat = take_f128(codeword_len);
     super::commit::replicate_message_fill(&mut mat, poly);
 
     // RS-encode every lane in one call (each lane is one independent NTT).
     ntt.forward_transform_interleaved_from_layer(&mut mat, num_interleaved, log_inv_rate);
 
     // Merkle over rows. One leaf = `num_interleaved` consecutive F128 = 16·num_interleaved bytes.
-    let leaf_size_bytes = num_interleaved * core::mem::size_of::<F128>();
-    let data_bytes: &[u8] = unsafe {
-        core::slice::from_raw_parts(
-            mat.as_ptr() as *const u8,
-            mat.len() * core::mem::size_of::<F128>(),
-        )
-    };
+    let leaf_size_bytes = num_interleaved * size_of::<F128>();
+    let data_bytes: &[u8] =
+        unsafe { from_raw_parts(mat.as_ptr() as *const u8, mat.len() * size_of::<F128>()) };
     debug_assert_eq!(data_bytes.len(), block_len * leaf_size_bytes);
     let tree = merkle::merkle_tree(data_bytes, block_len, kind);
 
@@ -2489,12 +2505,12 @@ impl RoundQuad {
 /// Uses a SINGLE combined basis poly. (Previously took `&[Vec<F128>]` and
 /// summed at every pair index; collapsing to one basis happens at glue time.)
 fn round_msg_lsb(f: &[F128], b: &[F128]) -> SumcheckMessage {
+    const PAR_THRESHOLD: usize = 4096;
     use rayon::prelude::*;
     let n = f.len();
     debug_assert!(n.is_power_of_two() && n >= 2);
     debug_assert_eq!(b.len(), n);
 
-    const PAR_THRESHOLD: usize = 4096;
     let half = n / 2;
     if half < PAR_THRESHOLD {
         let mut u_0 = F128::ZERO;
@@ -2539,12 +2555,12 @@ fn round_msg_lsb(f: &[F128], b: &[F128]) -> SumcheckMessage {
 /// pair. Bit-identical to the unfused path: F128 sums are exact and order-
 /// independent, so `y == mle_eval_inline(f, z)`.
 fn round_msg_and_eval_lsb(f: &[F128], b: &[F128]) -> (SumcheckMessage, F128) {
+    const PAR_THRESHOLD: usize = 4096;
     use rayon::prelude::*;
     let n = f.len();
     debug_assert!(n.is_power_of_two() && n >= 2);
     debug_assert_eq!(b.len(), n);
 
-    const PAR_THRESHOLD: usize = 4096;
     let half = n / 2;
     let term = |j: usize| -> (F128, F128, F128) {
         let f0 = f[2 * j];
@@ -2582,13 +2598,13 @@ fn round_msg_and_eval_lsb(f: &[F128], b: &[F128]) -> (SumcheckMessage, F128) {
 /// production path uses `fold_and_msg_lsb` instead.
 #[cfg(test)]
 fn partial_eval_lsb_one(evals: &mut Vec<F128>, r: F128) {
+    const PAR_THRESHOLD: usize = 4096;
     use rayon::prelude::*;
     let n = evals.len();
     debug_assert!(n.is_power_of_two() && n >= 2);
     let half = n / 2;
     let one_plus_r = F128::ONE + r;
 
-    const PAR_THRESHOLD: usize = 4096;
     if half < PAR_THRESHOLD {
         for j in 0..half {
             let v0 = evals[2 * j];
@@ -2623,6 +2639,11 @@ fn partial_eval_lsb_one(evals: &mut Vec<F128>, r: F128) {
 /// Returns `(folded_f, folded_b, next_msg)` where `next_msg = round_msg_lsb
 /// (folded_f, folded_b)`. Bit-identical to the unfused sequence.
 fn fold_and_msg_lsb(f: &[F128], b: &[F128], r: F128) -> (Vec<F128>, Vec<F128>, SumcheckMessage) {
+    const PAR_THRESHOLD: usize = 4096;
+    // Parallel path: `half` is a power of two ≥ PAR_THRESHOLD and CHUNK is a
+    // power of two, so every chunk has even length and starts at an even
+    // global index — message pairs (2k, 2k+1) never straddle a chunk boundary.
+    const CHUNK: usize = 2048;
     use rayon::prelude::*;
     let n = f.len();
     debug_assert!(n.is_power_of_two() && n >= 2);
@@ -2630,7 +2651,6 @@ fn fold_and_msg_lsb(f: &[F128], b: &[F128], r: F128) -> (Vec<F128>, Vec<F128>, S
     let half = n / 2;
     let one_plus_r = F128::ONE + r;
 
-    const PAR_THRESHOLD: usize = 4096;
     if half < PAR_THRESHOLD {
         let mut nf = Vec::with_capacity(half);
         let mut nb = Vec::with_capacity(half);
@@ -2653,10 +2673,6 @@ fn fold_and_msg_lsb(f: &[F128], b: &[F128], r: F128) -> (Vec<F128>, Vec<F128>, S
         return (nf, nb, SumcheckMessage { u_0, u_2 });
     }
 
-    // Parallel path: `half` is a power of two ≥ PAR_THRESHOLD and CHUNK is a
-    // power of two, so every chunk has even length and starts at an even
-    // global index — message pairs (2k, 2k+1) never straddle a chunk boundary.
-    const CHUNK: usize = 2048;
     // On x86_64, pull the fold outputs from the prewarmed scratch pool (the
     // prover gives the previous round's buffers back in `SumcheckProver::fold`),
     // so the initial sumcheck reuses resident pages instead of faulting ~128 MB
@@ -2682,8 +2698,8 @@ fn fold_and_msg_lsb(f: &[F128], b: &[F128], r: F128) -> (Vec<F128>, Vec<F128>, S
             let mut u0 = F128::ZERO;
             let mut u2 = F128::ZERO;
             // Fold this slice, then pair up the just-folded values for the msg.
-            crate::field::f128_slice::fold_pairs(f, base, fc, r);
-            crate::field::f128_slice::fold_pairs(b, base, bc, r);
+            fold_pairs(f, base, fc, r);
+            fold_pairs(b, base, bc, r);
             let mut k = 0;
             while k + 1 < len {
                 let f0 = fc[k];
@@ -2730,6 +2746,32 @@ fn fold_and_msg_blocked(
     d: usize,
     live_in: usize,
 ) -> (Vec<F128>, Vec<F128>, SumcheckMessage) {
+    // Source runs for output block `c`, offset `o`, length `len`.
+    fn src(
+        v: &[F128],
+        d: usize,
+        live_in: usize,
+        c: usize,
+        o: usize,
+        len: usize,
+    ) -> (&[F128], Option<&[F128]>) {
+        let lo = &v[2 * c * d + o..2 * c * d + o + len];
+        let hi = (2 * c + 1 < live_in).then(|| &v[(2 * c + 1) * d + o..(2 * c + 1) * d + o + len]);
+        (lo, hi)
+    }
+    // Each task owns one PAIR of output blocks — the unit the next round's
+    // message pairs over — so fold and message fuse into a single pass. The
+    // inner nesting keeps the parallelism fine-grained even in late rounds,
+    // where there are few block pairs but each is still large.
+    //
+    // Tasks past the live prefix are skipped ENTIRELY: their inputs are zero,
+    // so their outputs and message terms are zero, and the next round knows
+    // not to read them. That is the payoff of the high-bit-lane layout — the
+    // committed stack's zero tail is whole lanes, so `2^initial_k − t` of the
+    // L0 fold's blocks are known-zero up front (~36% of this round's work at
+    // t = 37 of 64). The final round leaves `live_out == 1`, so nothing dead
+    // survives into the L1 witness.
+    const CH: usize = 2048;
     use rayon::prelude::*;
 
     if d == 1 {
@@ -2763,22 +2805,9 @@ fn fold_and_msg_blocked(
             }
         }
     };
-    // Source runs for output block `c`, offset `o`, length `len`.
-    fn src(
-        v: &[F128],
-        d: usize,
-        live_in: usize,
-        c: usize,
-        o: usize,
-        len: usize,
-    ) -> (&[F128], Option<&[F128]>) {
-        let lo = &v[2 * c * d + o..2 * c * d + o + len];
-        let hi = (2 * c + 1 < live_in).then(|| &v[(2 * c + 1) * d + o..(2 * c + 1) * d + o + len]);
-        (lo, hi)
-    }
 
-    let mut nf = crate::scratch::take_f128(half);
-    let mut nb = crate::scratch::take_f128(half);
+    let mut nf = take_f128(half);
+    let mut nb = take_f128(half);
 
     if blocks_out == 1 {
         // Last blocked round: one output block, so the NEXT round pairs
@@ -2799,19 +2828,6 @@ fn fold_and_msg_blocked(
         return (nf, nb, msg);
     }
 
-    // Each task owns one PAIR of output blocks — the unit the next round's
-    // message pairs over — so fold and message fuse into a single pass. The
-    // inner nesting keeps the parallelism fine-grained even in late rounds,
-    // where there are few block pairs but each is still large.
-    //
-    // Tasks past the live prefix are skipped ENTIRELY: their inputs are zero,
-    // so their outputs and message terms are zero, and the next round knows
-    // not to read them. That is the payoff of the high-bit-lane layout — the
-    // committed stack's zero tail is whole lanes, so `2^initial_k − t` of the
-    // L0 fold's blocks are known-zero up front (~36% of this round's work at
-    // t = 37 of 64). The final round leaves `live_out == 1`, so nothing dead
-    // survives into the L1 witness.
-    const CH: usize = 2048;
     let live_tasks = live_out.div_ceil(2);
     let (u_0, u_2) = nf
         .par_chunks_mut(2 * d)
@@ -2892,6 +2908,7 @@ fn fold_and_msg_blocked_jit(
     d: usize,
     live_in: usize,
 ) -> (Vec<F128>, Vec<F128>, SumcheckMessage) {
+    const CH: usize = 1 << 11;
     use rayon::prelude::*;
 
     let n = f.len();
@@ -2902,9 +2919,8 @@ fn fold_and_msg_blocked_jit(
     let live_out = live_in.div_ceil(2).min(blocks_out);
     let one_plus_r = F128::ONE + r;
 
-    let mut nf = crate::scratch::take_f128(half);
-    let mut nb = crate::scratch::take_f128(half);
-    const CH: usize = 1 << 11;
+    let mut nf = take_f128(half);
+    let mut nb = take_f128(half);
 
     // Combine one aligned run with an optionally-dead `hi`.
     let comb = |out: &mut [F128], lo: &[F128], hi: Option<&[F128]>| match hi {
@@ -3138,13 +3154,14 @@ impl SumcheckProver {
     /// Combine the introduced basis into `combined_basis` with separation α.
     /// `combined_basis[j] += α · b_new[j]` (pointwise), `T_r += α · h_new`.
     pub fn glue(&mut self, alpha: F128) {
+        const PAR_THRESHOLD: usize = 4096;
         use rayon::prelude::*;
         let (b_new, h_new) = self
             .pending_glue
             .take()
             .expect("glue without introduce_new");
         assert_eq!(b_new.len(), self.combined_basis.len());
-        const PAR_THRESHOLD: usize = 4096;
+
         if self.combined_basis.len() < PAR_THRESHOLD {
             for (acc, &v) in self.combined_basis.iter_mut().zip(b_new.iter()) {
                 *acc += alpha * v;
@@ -3254,15 +3271,15 @@ pub fn recursive_prover<Ch: Challenger>(
     claimed_value: F128,
     challenger: &mut Ch,
 ) -> LigeritoProof {
-    let trace = std::env::var("LIGERITO_TRACE").is_ok();
+    let trace = var("LIGERITO_TRACE").is_ok();
     macro_rules! tlog {
         ($($arg:tt)*) => { if trace { eprintln!($($arg)*); } }
     }
-    let t_total = std::time::Instant::now();
-    let mut t_commits = std::time::Duration::ZERO;
-    let t_induce = std::time::Duration::ZERO;
-    let t_sumcheck = std::time::Duration::ZERO;
-    let t_opens = std::time::Duration::ZERO;
+    let t_total = Instant::now();
+    let mut t_commits = Duration::ZERO;
+    let t_induce = Duration::ZERO;
+    let t_sumcheck = Duration::ZERO;
+    let t_opens = Duration::ZERO;
     let log_n = poly.len().trailing_zeros() as usize;
     let r = config.recursive_steps;
     let initial_k = config.initial_k;
@@ -3285,7 +3302,7 @@ pub fn recursive_prover<Ch: Challenger>(
     let log_inv_rate_0 = config.log_inv_rates[0];
     let log_msg_cols_0 = log_n - initial_k;
     let ntt_0 = AdditiveNttF128::standard(log_msg_cols_0 + log_inv_rate_0);
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let wtns_0 = ligero_commit(
         poly,
         log_msg_cols_0,
@@ -3331,15 +3348,15 @@ pub fn recursive_prover_with_l0<Ch: Challenger>(
     claimed_value: F128,
     challenger: &mut Ch,
 ) -> LigeritoProof {
-    let trace = std::env::var("LIGERITO_TRACE").is_ok();
+    let trace = var("LIGERITO_TRACE").is_ok();
     macro_rules! tlog {
         ($($arg:tt)*) => { if trace { eprintln!($($arg)*); } }
     }
-    let t_total = std::time::Instant::now();
-    let t_commits = std::time::Duration::ZERO;
-    let t_induce = std::time::Duration::ZERO;
-    let t_sumcheck = std::time::Duration::ZERO;
-    let t_opens = std::time::Duration::ZERO;
+    let t_total = Instant::now();
+    let t_commits = Duration::ZERO;
+    let t_induce = Duration::ZERO;
+    let t_sumcheck = Duration::ZERO;
+    let t_opens = Duration::ZERO;
 
     let log_n = poly.len().trailing_zeros() as usize;
     let r = config.recursive_steps;
@@ -3566,16 +3583,16 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
     let mut l0_live_blocks = l0_live_blocks_in;
     assert_eq!(l0_tree.len(), 2 * block_len_0 - 1);
 
-    let trace = std::env::var("LIG_PROVE_TRACE").is_ok();
-    let mut t_init_sumcheck = std::time::Duration::ZERO;
-    let mut t_commits = std::time::Duration::ZERO;
-    let mut t_opens = std::time::Duration::ZERO;
-    let mut t_induce = std::time::Duration::ZERO;
-    let mut t_sumcheck_folds = std::time::Duration::ZERO;
-    let mut t_intro_glue = std::time::Duration::ZERO;
-    let mut t_ood = std::time::Duration::ZERO;
+    let trace = var("LIG_PROVE_TRACE").is_ok();
+    let mut t_init_sumcheck = Duration::ZERO;
+    let mut t_commits = Duration::ZERO;
+    let mut t_opens = Duration::ZERO;
+    let mut t_induce = Duration::ZERO;
+    let mut t_sumcheck_folds = Duration::ZERO;
+    let mut t_intro_glue = Duration::ZERO;
+    let mut t_ood = Duration::ZERO;
 
-    let t_total = std::time::Instant::now();
+    let t_total = Instant::now();
 
     challenger.observe_label(b"flock-ligerito-basis-v0");
     challenger.observe_f128(target);
@@ -3612,7 +3629,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
         |lvl: usize| -> u32 { config.fold_grinding_bits.get(lvl).copied().unwrap_or(0) as u32 };
     let ood_count = |lvl: usize| -> usize { config.ood_samples.get(lvl).copied().unwrap_or(0) };
 
-    let _t = std::time::Instant::now();
+    let _t = Instant::now();
     let (mut sc_prover, start_msg) = match (first_msg, l0_jit_basis) {
         // JIT basis: no `2^log_n` array exists; the first fold builds the
         // half-size folded basis directly from the factored form.
@@ -3664,7 +3681,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
     assert!(n1 >= log_num_interleaved_1);
     let log_msg_cols_1 = n1 - log_num_interleaved_1;
     let log_inv_rate_1 = config.log_inv_rates[1];
-    let _t = std::time::Instant::now();
+    let _t = Instant::now();
     let ntt_1 = AdditiveNttF128::standard(log_msg_cols_1 + log_inv_rate_1);
     let f1 = sc_prover.f().to_vec();
     let wtns_1 = ligero_commit(
@@ -3678,7 +3695,11 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
     if trace {
         t_commits += _t.elapsed();
     }
-    challenger.observe_bytes(wtns_1.cap(cap_depth_of(config.queries[1], wtns_1.block_len)).as_flattened());
+    challenger.observe_bytes(
+        wtns_1
+            .cap(cap_depth_of(config.queries[1], wtns_1.block_len))
+            .as_flattened(),
+    );
 
     // OOD binding for the L1 commit: each sample evaluates f1's multilinear
     // extension at a random transcript point z ∈ F^{n1}, sends the claimed
@@ -3686,7 +3707,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
     // sumcheck (introduce + glue). Binds the prover to a single codeword of
     // the interleaved list before any of L0's queries are drawn.
     {
-        let _t = std::time::Instant::now();
+        let _t = Instant::now();
         for _ in 0..ood_count(1) {
             let z = challenger.sample_f128_vec(n1);
             // Build eq(z, ·) once and fuse the MLE eval `y = f̂1(z)` into the
@@ -3718,7 +3739,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
     let num_queries_0 = config.queries[0];
     let queries_0 = sample_queries(challenger, l0_block_len, num_queries_0);
     let alpha_0 = challenger.sample_f128_vec(ceil_log2(num_queries_0));
-    let _t = std::time::Instant::now();
+    let _t = Instant::now();
     let opened_rows_0: Vec<Vec<F128>> = queries_0.iter().map(|&q| l0_row(q).to_vec()).collect();
     let merkle_proof_0 = merkle_paths_for(l0_tree, l0_block_len, &queries_0, c_0);
     if trace {
@@ -3733,7 +3754,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
     // sparse-prefix Fᵀ-NTT path wins; the dispatcher auto-selects it (deeper
     // levels stay dense).
     let sks_vks_n1 = eval_sk_at_vks(n1);
-    let _t = std::time::Instant::now();
+    let _t = Instant::now();
     let (basis_0_induced, enforced_sum_0) = induce_sumcheck_poly_auto(
         n1,
         log_inv_rate_0,
@@ -3748,7 +3769,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
     }
 
     // Introduce + glue basis_0.
-    let _t = std::time::Instant::now();
+    let _t = Instant::now();
     let intro_msg_0 = sc_prover.introduce_new(basis_0_induced, enforced_sum_0);
     challenger.observe_f128(intro_msg_0.u_0);
     challenger.observe_f128(intro_msg_0.u_2);
@@ -3760,8 +3781,11 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
 
     // Recursive levels — same as recursive_prover_inner from here.
     let mut wtns_prev = wtns_1;
-    let mut recursive_caps: Vec<Vec<Hash>> =
-        vec![wtns_prev.cap(cap_depth_of(config.queries[1], wtns_prev.block_len)).to_vec()];
+    let mut recursive_caps: Vec<Vec<Hash>> = vec![
+        wtns_prev
+            .cap(cap_depth_of(config.queries[1], wtns_prev.block_len))
+            .to_vec(),
+    ];
     let mut recursive_proofs: Vec<RecursiveProof> = Vec::new();
     // All fold challenges in binding order (returned to the caller).
     let mut ris_all: Vec<F128> = r_lane_fold.clone();
@@ -3769,7 +3793,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
     for i in 0..r {
         let k_i = config.recursive_ks[i];
         let mut level_rs = Vec::with_capacity(k_i);
-        let _t = std::time::Instant::now();
+        let _t = Instant::now();
         for j in 0..k_i {
             // These folds fold level i+1's commitment — fold-challenge
             // grinding guards its proximity-gap term. Tapered per round:
@@ -3799,7 +3823,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
             grinding_nonces.push(nonce_last);
             let num_queries_last = config.queries[i + 1];
             let queries_last = sample_queries(challenger, wtns_prev.block_len, num_queries_last);
-            let _t = std::time::Instant::now();
+            let _t = Instant::now();
             let opened_rows_last: Vec<Vec<F128>> = queries_last
                 .iter()
                 .map(|&q| wtns_prev.row(q).to_vec())
@@ -3873,7 +3897,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
         assert!(n_next >= log_num_interleaved_next);
         let log_msg_cols_next = n_next - log_num_interleaved_next;
         let log_inv_rate_next = config.log_inv_rates[i + 2];
-        let _t = std::time::Instant::now();
+        let _t = Instant::now();
         let ntt_next = AdditiveNttF128::standard(log_msg_cols_next + log_inv_rate_next);
         let f_evals = sc_prover.f().to_vec();
         let wtns_next = ligero_commit(
@@ -3895,7 +3919,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
 
         // OOD binding for the L_{i+2} commit (same as the L1 block above).
         {
-            let _t = std::time::Instant::now();
+            let _t = Instant::now();
             for _ in 0..ood_count(i + 2) {
                 let z = challenger.sample_f128_vec(n_next);
                 let eq_z = build_eq_table(&z);
@@ -3918,7 +3942,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
         let num_queries_i = config.queries[i + 1];
         let queries_i = sample_queries(challenger, wtns_prev.block_len, num_queries_i);
         let alpha_i = challenger.sample_f128_vec(ceil_log2(num_queries_i));
-        let _t = std::time::Instant::now();
+        let _t = Instant::now();
         let opened_rows_i: Vec<Vec<F128>> = queries_i
             .iter()
             .map(|&q| wtns_prev.row(q).to_vec())
@@ -3938,7 +3962,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
         });
 
         let sks_vks_i = eval_sk_at_vks(n_next);
-        let _t = std::time::Instant::now();
+        let _t = Instant::now();
         let (basis_i_induced, enforced_sum_i) = induce_sumcheck_poly(
             n_next,
             &sks_vks_i,
@@ -3951,7 +3975,7 @@ fn recursive_prover_with_basis_impl<Ch: Challenger>(
             t_induce += _t.elapsed();
         }
 
-        let _t = std::time::Instant::now();
+        let _t = Instant::now();
         let intro_msg_i = sc_prover.introduce_new(basis_i_induced, enforced_sum_i);
         challenger.observe_f128(intro_msg_i.u_0);
         challenger.observe_f128(intro_msg_i.u_2);
@@ -3995,13 +4019,28 @@ where
     // (e.g. ring_switch::eval_rs_eq_prefix + finish_from_prefix).
     F: Fn(&[F128], usize) -> Vec<F128>,
 {
-    let trace = std::env::var("LIG_VERIFY_TRACE").is_ok();
-    let mut t_merkle = std::time::Duration::ZERO;
-    let mut t_sample_q = std::time::Duration::ZERO;
-    let mut t_enforced = std::time::Duration::ZERO;
-    let mut t_residual = std::time::Duration::ZERO;
-    let mut t_evalb = std::time::Duration::ZERO;
-    let t_start = std::time::Instant::now();
+    // OOD claims glued into the running sumcheck: each contributes
+    // `beta · Π_b eq(z_b, r_b) · eq(z_tail, ·)` at the residual.
+    struct OodCtx {
+        z: Vec<F128>,
+        ris_start: usize,
+        beta: F128,
+    }
+    // Per-level induced-basis evaluation context — small (no dense vec).
+    struct LevelCtx {
+        log_msg_cols: usize,
+        queries: Vec<usize>,
+        alpha: Vec<F128>, // ⌈log₂ Q⌉ field elements (eq-tensor combination)
+        ris_start: usize,
+        beta: F128,
+    }
+    let trace = var("LIG_VERIFY_TRACE").is_ok();
+    let mut t_merkle = Duration::ZERO;
+    let mut t_sample_q = Duration::ZERO;
+    let mut t_enforced = Duration::ZERO;
+    let mut t_residual = Duration::ZERO;
+    let mut t_evalb = Duration::ZERO;
+    let t_start = Instant::now();
 
     let initial_k = config.initial_k;
     let r = config.recursive_steps;
@@ -4048,13 +4087,7 @@ where
     }
     let mut fold_nonce_idx = 0usize;
     let mut ood_idx = 0usize;
-    // OOD claims glued into the running sumcheck: each contributes
-    // `beta · Π_b eq(z_b, r_b) · eq(z_tail, ·)` at the residual.
-    struct OodCtx {
-        z: Vec<F128>,
-        ris_start: usize,
-        beta: F128,
-    }
+
     let mut ood_ctxs: Vec<OodCtx> = Vec::new();
 
     let mut r_lane_fold = Vec::with_capacity(initial_k);
@@ -4135,13 +4168,13 @@ where
     nonce_idx += 1;
 
     let num_queries_0 = config.queries[0];
-    let _t = std::time::Instant::now();
+    let _t = Instant::now();
     let queries_0 = sample_queries(challenger, block_len_0, num_queries_0);
     if trace {
         t_sample_q += _t.elapsed();
     }
     let alpha_0 = challenger.sample_f128_vec(ceil_log2(num_queries_0));
-    let _t = std::time::Instant::now();
+    let _t = Instant::now();
     if !verify_level_opens(
         &proof.initial_cap,
         block_len_0,
@@ -4161,7 +4194,7 @@ where
     // residual evaluations are deferred to the final check (succinct path —
     // see `induce_sumcheck_evaluate_at_residual`).
     let n1 = log_n - initial_k;
-    let _t = std::time::Instant::now();
+    let _t = Instant::now();
     let enforced_sum_0 = induce_sumcheck_enforced_sum(
         &proof.initial_proof.opened_rows,
         &r_lane_fold,
@@ -4184,14 +4217,6 @@ where
     running_quad = RoundQuad::fold(&running_quad, &intro_quad_0, beta_0);
     t_r += beta_0 * enforced_sum_0;
 
-    // Per-level induced-basis evaluation context — small (no dense vec).
-    struct LevelCtx {
-        log_msg_cols: usize,
-        queries: Vec<usize>,
-        alpha: Vec<F128>, // ⌈log₂ Q⌉ field elements (eq-tensor combination)
-        ris_start: usize,
-        beta: F128,
-    }
     let mut level_ctxs: Vec<LevelCtx> = vec![LevelCtx {
         log_msg_cols: n1,
         queries: queries_0.clone(),
@@ -4274,7 +4299,7 @@ where
             let prev_block_len = 1usize << (prev_log_msg_cols + prev_log_inv_rate);
             let prev_num_interleaved = 1usize << prev_log_num_interleaved;
             let num_queries_last = config.queries[i + 1];
-            let _t = std::time::Instant::now();
+            let _t = Instant::now();
             let queries_last = sample_queries(challenger, prev_block_len, num_queries_last);
             // Basis-induction challenge for the LAST commitment. Sampled here —
             // after `yr` was observed (top of this branch) and the queries are
@@ -4284,7 +4309,7 @@ where
             if trace {
                 t_sample_q += _t.elapsed();
             }
-            let _t = std::time::Instant::now();
+            let _t = Instant::now();
             if !verify_level_opens(
                 prev_cap,
                 prev_block_len,
@@ -4334,7 +4359,7 @@ where
             let yr_len = yr.len();
             let yr_log_n = n_current;
 
-            let _t = std::time::Instant::now();
+            let _t = Instant::now();
             let induced_residuals: Vec<Vec<F128>> = level_ctxs
                 .iter()
                 .map(|ctx| {
@@ -4383,7 +4408,7 @@ where
 
             // Batch-evaluate b at all yr positions in one call so the
             // caller can amortize prefix work (e.g. ring_switch tensor prefix).
-            let _te = std::time::Instant::now();
+            let _te = Instant::now();
             let evb_vec = eval_b_residual(&ris, yr_log_n);
             if trace {
                 t_evalb += _te.elapsed();
@@ -4392,7 +4417,7 @@ where
                 return false;
             }
             let mut inner = F128::ZERO;
-            let _t = std::time::Instant::now();
+            let _t = Instant::now();
             for y in 0..yr_len {
                 let mut combined_y = evb_vec[y];
                 for (k, residual) in induced_residuals.iter().enumerate() {
@@ -4482,7 +4507,7 @@ where
         let prev_block_len = 1usize << (prev_log_msg_cols + prev_log_inv_rate);
         let prev_num_interleaved = 1usize << prev_log_num_interleaved;
         let num_queries_i = config.queries[i + 1];
-        let _t = std::time::Instant::now();
+        let _t = Instant::now();
         let queries_i = sample_queries(challenger, prev_block_len, num_queries_i);
         if trace {
             t_sample_q += _t.elapsed();
@@ -4493,7 +4518,7 @@ where
         }
         let rp = &proof.recursive_proofs[recursive_proof_idx];
         recursive_proof_idx += 1;
-        let _t = std::time::Instant::now();
+        let _t = Instant::now();
         if !verify_level_opens(
             prev_cap,
             prev_block_len,
@@ -4509,7 +4534,7 @@ where
             t_merkle += _t.elapsed();
         }
 
-        let _t = std::time::Instant::now();
+        let _t = Instant::now();
         let enforced_sum_i =
             induce_sumcheck_enforced_sum(&rp.opened_rows, &level_rs, &queries_i, &alpha_i);
         if trace {
@@ -4985,11 +5010,11 @@ fn recursive_prover_inner<Ch: Challenger>(
     eval_point: &[F128],
     claimed_value: F128,
     challenger: &mut Ch,
-    t_total: std::time::Instant,
-    mut t_commits: std::time::Duration,
-    mut t_induce: std::time::Duration,
-    mut t_sumcheck: std::time::Duration,
-    mut t_opens: std::time::Duration,
+    t_total: Instant,
+    mut t_commits: Duration,
+    mut t_induce: Duration,
+    mut t_sumcheck: Duration,
+    mut t_opens: Duration,
     trace: bool,
 ) -> LigeritoProof {
     macro_rules! tlog {
@@ -5025,7 +5050,7 @@ fn recursive_prover_inner<Ch: Challenger>(
     let log_msg_cols_1 = n1 - log_num_interleaved_1;
     let log_inv_rate_1 = config.log_inv_rates[1];
     let ntt_1 = AdditiveNttF128::standard(log_msg_cols_1 + log_inv_rate_1);
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let wtns_1 = ligero_commit(
         &f1,
         log_msg_cols_1,
@@ -5039,7 +5064,10 @@ fn recursive_prover_inner<Ch: Challenger>(
     tlog!("  [ligerito]   L1 commit: {:.2?}", t_l1);
     challenger.observe_bytes(
         wtns_1
-            .cap(cap_depth_of(udr_queries(config.log_inv_rates[1]), wtns_1.block_len))
+            .cap(cap_depth_of(
+                udr_queries(config.log_inv_rates[1]),
+                wtns_1.block_len,
+            ))
             .as_flattened(),
     );
 
@@ -5047,7 +5075,7 @@ fn recursive_prover_inner<Ch: Challenger>(
     let num_queries_0 = udr_queries(log_inv_rate_0);
     let queries_0 = sample_queries(challenger, wtns_0.block_len, num_queries_0);
     let alpha_0 = challenger.sample_f128_vec(ceil_log2(num_queries_0));
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let opened_rows_0: Vec<Vec<F128>> = queries_0.iter().map(|&q| wtns_0.row(q).to_vec()).collect();
     let merkle_proof_0 = merkle_paths_for(&wtns_0.tree, wtns_0.block_len, &queries_0, c_0);
     t_opens += t.elapsed();
@@ -5058,7 +5086,7 @@ fn recursive_prover_inner<Ch: Challenger>(
 
     // ---- Induce basis from wtns_0 opens ----
     let sks_vks_n1 = eval_sk_at_vks(n1);
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let (basis_0_induced, enforced_sum_0) = induce_sumcheck_poly_auto(
         n1,
         log_inv_rate_0,
@@ -5072,7 +5100,7 @@ fn recursive_prover_inner<Ch: Challenger>(
 
     // ---- Start sumcheck: f¹ · eq(z[initial_k..], ·) = claimed_value ----
     let eq_z_residual = build_eq_table(&eval_point[initial_k..]);
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let (mut sc_prover, start_msg) = SumcheckProver::new(f1, eq_z_residual, claimed_value);
     t_sumcheck += t.elapsed();
     challenger.observe_f128(start_msg.u_0);
@@ -5089,7 +5117,10 @@ fn recursive_prover_inner<Ch: Challenger>(
     let mut wtns_prev = wtns_1;
     let mut recursive_caps: Vec<Vec<Hash>> = vec![
         wtns_prev
-            .cap(cap_depth_of(udr_queries(config.log_inv_rates[1]), wtns_prev.block_len))
+            .cap(cap_depth_of(
+                udr_queries(config.log_inv_rates[1]),
+                wtns_prev.block_len,
+            ))
             .to_vec(),
     ];
     let mut recursive_proofs: Vec<RecursiveProof> = Vec::new();
@@ -5097,7 +5128,7 @@ fn recursive_prover_inner<Ch: Challenger>(
     for i in 0..r {
         let k_i = config.recursive_ks[i];
         let mut level_rs = Vec::with_capacity(k_i);
-        let t = std::time::Instant::now();
+        let t = Instant::now();
         for _ in 0..k_i {
             let ri = challenger.sample_f128();
             let msg = sc_prover.fold(ri);
@@ -5164,7 +5195,7 @@ fn recursive_prover_inner<Ch: Challenger>(
         let log_inv_rate_next = config.log_inv_rates[i + 2];
         let ntt_next = AdditiveNttF128::standard(log_msg_cols_next + log_inv_rate_next);
         let f_evals = sc_prover.f().to_vec();
-        let t = std::time::Instant::now();
+        let t = Instant::now();
         let wtns_next = ligero_commit(
             &f_evals,
             log_msg_cols_next,
@@ -5189,7 +5220,7 @@ fn recursive_prover_inner<Ch: Challenger>(
         let num_queries_i = udr_queries(config.log_inv_rates[i + 1]);
         let queries_i = sample_queries(challenger, wtns_prev.block_len, num_queries_i);
         let alpha_i = challenger.sample_f128_vec(ceil_log2(num_queries_i));
-        let t = std::time::Instant::now();
+        let t = Instant::now();
         let opened_rows_i: Vec<Vec<F128>> = queries_i
             .iter()
             .map(|&q| wtns_prev.row(q).to_vec())
@@ -5264,12 +5295,8 @@ fn verify_level_opens(
         if row.len() != expected_num_interleaved {
             return false;
         }
-        let bytes: &[u8] = unsafe {
-            core::slice::from_raw_parts(
-                row.as_ptr() as *const u8,
-                row.len() * core::mem::size_of::<F128>(),
-            )
-        };
+        let bytes: &[u8] =
+            unsafe { from_raw_parts(row.as_ptr() as *const u8, row.len() * size_of::<F128>()) };
         let leaf = merkle::hash_leaf(bytes, kind);
         if !merkle::verify_merkle_proof_capped(
             cap,
@@ -5920,7 +5947,7 @@ mod tests {
         let k_0 = 2;
         let log_inv_rate = 1;
 
-        let mut rng = crate::challenger::RandomChallenger::new(0x6817_D146);
+        let mut rng = RandomChallenger::new(0x6817_D146);
         let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
         let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
         let b = build_eq_table(&z);
@@ -5962,11 +5989,14 @@ mod tests {
         );
         let initial_cap = |q0: usize| -> Vec<Hash> {
             wtns_0
-                .cap(merkle::cap_depth(q0, wtns_0.block_len.trailing_zeros() as usize))
+                .cap(merkle::cap_depth(
+                    q0,
+                    wtns_0.block_len.trailing_zeros() as usize,
+                ))
                 .to_vec()
         };
 
-        let mut p_ch = crate::challenger::FsChallenger::new(b"pow-test");
+        let mut p_ch = FsChallenger::new(b"pow-test");
         let proof = recursive_prover_with_basis(
             &cfg,
             poly.clone(),
@@ -5992,9 +6022,15 @@ mod tests {
             ood_samples: vec![0; 2],
             merkle_hash: Default::default(),
         };
-        let mut v_ch = crate::challenger::FsChallenger::new(b"pow-test");
-        let ok =
-            recursive_verifier_with_basis(&v_cfg, &proof, &b, target, &initial_cap(v_cfg.queries[0]), &mut v_ch);
+        let mut v_ch = FsChallenger::new(b"pow-test");
+        let ok = recursive_verifier_with_basis(
+            &v_cfg,
+            &proof,
+            &b,
+            target,
+            &initial_cap(v_cfg.queries[0]),
+            &mut v_ch,
+        );
         assert!(
             ok,
             "verifier should accept proof with valid grinding nonces"
@@ -6003,9 +6039,15 @@ mod tests {
         // Tampering with the nonce flips the PoW check.
         let mut bad_proof = proof.clone();
         bad_proof.grinding_nonces[0] = bad_proof.grinding_nonces[0].wrapping_add(1);
-        let mut v_ch = crate::challenger::FsChallenger::new(b"pow-test");
-        let ok =
-            recursive_verifier_with_basis(&v_cfg, &bad_proof, &b, target, &initial_cap(v_cfg.queries[0]), &mut v_ch);
+        let mut v_ch = FsChallenger::new(b"pow-test");
+        let ok = recursive_verifier_with_basis(
+            &v_cfg,
+            &bad_proof,
+            &b,
+            target,
+            &initial_cap(v_cfg.queries[0]),
+            &mut v_ch,
+        );
         assert!(
             !ok,
             "verifier must reject proof with tampered grinding nonce"
@@ -6100,7 +6142,7 @@ mod tests {
 
         // Prover: 1 start message + (n-1) folds, leaving a length-2 residual.
         let (mut prover, _first) = SumcheckProver::new(f.clone(), b.clone(), h);
-        let mut ch = crate::challenger::RandomChallenger::new(0xC0FFEE);
+        let mut ch = RandomChallenger::new(0xC0FFEE);
         let mut ris: Vec<F128> = Vec::new();
         for _ in 0..(n - 1) {
             let r = ch.sample_f128();
@@ -6153,7 +6195,7 @@ mod tests {
             .fold(F128::ZERO, |a, v| a + v);
 
         let (mut prover, _first) = SumcheckProver::new(f.clone(), b1.clone(), h1);
-        let mut ch = crate::challenger::RandomChallenger::new(0xBEEF);
+        let mut ch = RandomChallenger::new(0xBEEF);
 
         // Fold once before introducing b2 (must fold at the same dim as the introduced poly).
         let r0 = ch.sample_f128();
@@ -6257,7 +6299,7 @@ mod tests {
         let block_len = msg_cols << log_inv_rate;
 
         // Single-lane (num_interleaved = 1, no v_challenges).
-        let mut ch = crate::challenger::RandomChallenger::new(0xF00DCAFE);
+        let mut ch = RandomChallenger::new(0xF00DCAFE);
         let msg: Vec<F128> = (0..msg_cols).map(|_| ch.sample_f128()).collect();
 
         // Encode via Flock's NTT (zero-pad to block_len).
@@ -6284,7 +6326,7 @@ mod tests {
         assert_eq!(basis_poly.len(), msg_cols);
 
         // Check 1: enforced_sum = Σ_i eq(α, i_bin) · c[q_i]
-        let alpha_weights: Vec<F128> = crate::lincheck::build_eq_table(&alpha)
+        let alpha_weights: Vec<F128> = build_eq_table(&alpha)
             .into_iter()
             .take(queries.len())
             .collect();
@@ -6323,7 +6365,7 @@ mod tests {
         for (si, &(log_msg, log_inv_rate, log_int, n_queries)) in shapes.iter().enumerate() {
             let block_len = 1usize << (log_msg + log_inv_rate);
             let num_interleaved = 1usize << log_int;
-            let mut ch = crate::challenger::RandomChallenger::new(0xA11CE ^ si as u64);
+            let mut ch = RandomChallenger::new(0xA11CE ^ si as u64);
             let mut queries: Vec<usize> = Vec::new();
             while queries.len() < n_queries.min(block_len) {
                 let q = (ch.sample_f128().lo as usize) % block_len;
@@ -6369,8 +6411,7 @@ mod tests {
             for &nq in &[1usize, 5, 43, 218] {
                 let n = 1usize << log_d;
                 let nq = nq.min(n);
-                let mut ch =
-                    crate::challenger::RandomChallenger::new(0xC0DE ^ (log_d * 131 + nq) as u64);
+                let mut ch = RandomChallenger::new(0xC0DE ^ (log_d * 131 + nq) as u64);
                 let ntt = AdditiveNttF128::standard(log_d);
                 let mut positions: Vec<usize> = Vec::new();
                 let mut values: Vec<F128> = Vec::new();
@@ -6406,7 +6447,7 @@ mod tests {
         let block_len = msg_cols << log_inv_rate;
         let poly_len = msg_cols * num_interleaved;
 
-        let mut ch = crate::challenger::RandomChallenger::new(0xDEAD_BEEF);
+        let mut ch = RandomChallenger::new(0xDEAD_BEEF);
         // poly[lane * msg_cols + col] convention (matches ligero_commit input).
         let poly: Vec<F128> = (0..poly_len).map(|_| ch.sample_f128()).collect();
 
@@ -6472,7 +6513,7 @@ mod tests {
         let log_inv_rate = 1;
         let num_queries = 0; // unused — kept to silence the moved literal
 
-        let mut rng = crate::challenger::RandomChallenger::new(0xCAFE_F00D);
+        let mut rng = RandomChallenger::new(0xCAFE_F00D);
         let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
         let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
 
@@ -6518,11 +6559,11 @@ mod tests {
         let _ = num_queries; // queries derived per-level from log_inv_rates now
 
         // Prove
-        let mut p_ch = crate::challenger::FsChallenger::new(b"test");
+        let mut p_ch = FsChallenger::new(b"test");
         let proof = recursive_prover(&prover_cfg, &poly, &z, v, &mut p_ch);
 
         // Verify
-        let mut v_ch = crate::challenger::FsChallenger::new(b"test");
+        let mut v_ch = FsChallenger::new(b"test");
         let ok = recursive_verifier(&verifier_cfg, &proof, &z, v, &mut v_ch);
         assert!(ok, "verifier rejected a valid proof");
     }
@@ -6551,7 +6592,7 @@ mod tests {
             n_running -= k;
         }
 
-        let mut rng = crate::challenger::RandomChallenger::new(0xBEEFCAFE);
+        let mut rng = RandomChallenger::new(0xBEEFCAFE);
         let queries_per_level: Vec<usize> = log_inv_rates.iter().map(|&r| udr_queries(r)).collect();
         eprintln!(
             "log_n={log_n}  initial_k={initial_k}  ks={:?}  log_inv_rates={:?}  queries={:?}",
@@ -6598,13 +6639,13 @@ mod tests {
         };
 
         // Time the prover, best of 3.
-        let mut best = std::time::Duration::from_secs(3600);
+        let mut best = Duration::from_secs(3600);
         let mut proof = {
-            let mut p_ch = crate::challenger::FsChallenger::new(b"size-test");
+            let mut p_ch = FsChallenger::new(b"size-test");
             recursive_prover(&cfg, &poly, &z, v, &mut p_ch)
         };
         for _ in 0..3 {
-            let mut p_ch = crate::challenger::FsChallenger::new(b"size-test");
+            let mut p_ch = FsChallenger::new(b"size-test");
             let t = Instant::now();
             proof = recursive_prover(&cfg, &poly, &z, v, &mut p_ch);
             let el = t.elapsed();
@@ -6619,7 +6660,7 @@ mod tests {
         proof.print_size_breakdown();
 
         // Smoke-check it verifies (so we know the proof is valid, not just plausibly-sized).
-        let mut v_ch = crate::challenger::FsChallenger::new(b"size-test");
+        let mut v_ch = FsChallenger::new(b"size-test");
         assert!(recursive_verifier(&v_cfg, &proof, &z, v, &mut v_ch));
         proof.size_bytes()
     }
@@ -6692,7 +6733,7 @@ mod tests {
         recursive_ks: Vec<usize>,
         log_inv_rates: Vec<usize>,
     ) -> usize {
-        const ELEM: usize = core::mem::size_of::<F128>();
+        const ELEM: usize = size_of::<F128>();
         assert_eq!(log_inv_rates.len(), recursive_ks.len() + 1);
         let r = recursive_ks.len();
         let kb = |b: usize| {
@@ -6888,7 +6929,7 @@ mod tests {
         let log_inv_rate = 1;
         let num_queries = 0;
 
-        let mut rng = crate::challenger::RandomChallenger::new(0xABCD_1234);
+        let mut rng = RandomChallenger::new(0xABCD_1234);
         let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
         let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
         let eq = build_eq_table(&z);
@@ -6933,12 +6974,12 @@ mod tests {
             merkle_hash: Default::default(),
         };
 
-        let mut p_ch = crate::challenger::FsChallenger::new(b"test-r2");
+        let mut p_ch = FsChallenger::new(b"test-r2");
         let proof = recursive_prover(&cfg, &poly, &z, v, &mut p_ch);
         assert_eq!(proof.recursive_caps.len(), 2);
         assert_eq!(proof.recursive_proofs.len(), 1);
 
-        let mut v_ch = crate::challenger::FsChallenger::new(b"test-r2");
+        let mut v_ch = FsChallenger::new(b"test-r2");
         let ok = recursive_verifier(&v_cfg, &proof, &z, v, &mut v_ch);
         assert!(ok, "R=2 verifier rejected valid proof");
     }
@@ -6951,7 +6992,7 @@ mod tests {
         let initial_k = 3;
         let k_0 = 2;
         let log_inv_rate = 1;
-        let mut rng = crate::challenger::RandomChallenger::new(0xDEED_F00D);
+        let mut rng = RandomChallenger::new(0xDEED_F00D);
         let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
         let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
         let eq = build_eq_table(&z);
@@ -6976,7 +7017,7 @@ mod tests {
             ood_samples: vec![0; 2],
             merkle_hash: Default::default(),
         };
-        let mut p_ch = crate::challenger::FsChallenger::new(b"serde");
+        let mut p_ch = FsChallenger::new(b"serde");
         let proof = recursive_prover(&cfg, &poly, &z, v, &mut p_ch);
 
         let bytes = bincode::serialize(&proof).expect("serialize");
@@ -6997,7 +7038,7 @@ mod tests {
         let k_0 = 2;
         let log_inv_rate = 1;
 
-        let mut rng = crate::challenger::RandomChallenger::new(0xBA51_CAFE);
+        let mut rng = RandomChallenger::new(0xBA51_CAFE);
         let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
         let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
         let b = build_eq_table(&z);
@@ -7035,11 +7076,14 @@ mod tests {
         );
         let initial_cap = |q0: usize| -> Vec<Hash> {
             wtns_0
-                .cap(merkle::cap_depth(q0, wtns_0.block_len.trailing_zeros() as usize))
+                .cap(merkle::cap_depth(
+                    q0,
+                    wtns_0.block_len.trailing_zeros() as usize,
+                ))
                 .to_vec()
         };
 
-        let mut p_ch = crate::challenger::FsChallenger::new(b"basis-test");
+        let mut p_ch = FsChallenger::new(b"basis-test");
         let proof = recursive_prover_with_basis(
             &cfg,
             poly.clone(),
@@ -7064,9 +7108,15 @@ mod tests {
             ood_samples: vec![0; 2],
             merkle_hash: Default::default(),
         };
-        let mut v_ch = crate::challenger::FsChallenger::new(b"basis-test");
-        let ok =
-            recursive_verifier_with_basis(&v_cfg, &proof, &b, target, &initial_cap(v_cfg.queries[0]), &mut v_ch);
+        let mut v_ch = FsChallenger::new(b"basis-test");
+        let ok = recursive_verifier_with_basis(
+            &v_cfg,
+            &proof,
+            &b,
+            target,
+            &initial_cap(v_cfg.queries[0]),
+            &mut v_ch,
+        );
         assert!(ok, "basis-based verifier rejected valid proof");
     }
 
@@ -7080,7 +7130,7 @@ mod tests {
         let block_len = 1usize << 13;
         let count = udr_queries(1); // 243 — the shipped L0 count at rate 1/2
 
-        let mut ch = crate::challenger::FsChallenger::new(b"sample-queries-test");
+        let mut ch = FsChallenger::new(b"sample-queries-test");
         let qs = sample_queries(&mut ch, block_len, count);
 
         // Exactly `count` draws. The old sampler's draw count was data-
@@ -7090,12 +7140,12 @@ mod tests {
         assert!(qs.iter().all(|&q| q < block_len));
 
         // Challenger-deterministic.
-        let mut ch2 = crate::challenger::FsChallenger::new(b"sample-queries-test");
+        let mut ch2 = FsChallenger::new(b"sample-queries-test");
         assert_eq!(sample_queries(&mut ch2, block_len, count), qs);
 
         // One `sample_f128_vec` squeeze plus a low-bit mask — nothing else.
         // This pins the transcript shape the FS chain table has to replay.
-        let mut ch3 = crate::challenger::FsChallenger::new(b"sample-queries-test");
+        let mut ch3 = FsChallenger::new(b"sample-queries-test");
         let raw = ch3.sample_f128_vec(count);
         let expected: Vec<usize> = raw
             .iter()
@@ -7125,7 +7175,7 @@ mod tests {
         let num_interleaved = 1usize << log_interleaved;
         let poly_len = (1usize << log_msg) * num_interleaved;
 
-        let mut ch = crate::challenger::RandomChallenger::new(0x0DDD_1CE5);
+        let mut ch = RandomChallenger::new(0x0DDD_1CE5);
         let poly: Vec<F128> = (0..poly_len).map(|_| ch.sample_f128()).collect();
         let ntt = AdditiveNttF128::standard(log_msg + log_inv_rate);
         let w = ligero_commit(
@@ -7263,7 +7313,7 @@ mod tests {
         let log_num_interleaved = 2;
         let num_queries = 5;
 
-        let mut rng = crate::challenger::RandomChallenger::new(0x2017_5052);
+        let mut rng = RandomChallenger::new(0x2017_5052);
         let queries: Vec<usize> = (0..num_queries).map(|i| (i * 7 + 3) % (1 << 8)).collect();
         let opened_rows: Vec<Vec<F128>> = (0..num_queries)
             .map(|_| (0..num_interleaved).map(|_| rng.sample_f128()).collect())
@@ -7341,7 +7391,7 @@ mod tests {
         let msg_cols = 1usize << log_msg_cols;
         let block_len = msg_cols << log_inv_rate;
 
-        let mut rng = crate::challenger::RandomChallenger::new(0xB19D_1235);
+        let mut rng = RandomChallenger::new(0xB19D_1235);
         // num_interleaved = 1 ⇒ no lane fold (level_rs empty) ⇒ yr == the message.
         let yr: Vec<F128> = (0..msg_cols).map(|_| rng.sample_f128()).collect();
         let ntt = AdditiveNttF128::standard(log_msg_cols + log_inv_rate);
@@ -7416,7 +7466,7 @@ mod tests {
         let k_0 = 2;
         let log_inv_rate = 1;
 
-        let mut rng = crate::challenger::RandomChallenger::new(0x52CC_2017);
+        let mut rng = RandomChallenger::new(0x52CC_2017);
         let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
         let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
         let b = build_eq_table(&z);
@@ -7454,11 +7504,14 @@ mod tests {
         );
         let initial_cap = |q0: usize| -> Vec<Hash> {
             wtns_0
-                .cap(merkle::cap_depth(q0, wtns_0.block_len.trailing_zeros() as usize))
+                .cap(merkle::cap_depth(
+                    q0,
+                    wtns_0.block_len.trailing_zeros() as usize,
+                ))
                 .to_vec()
         };
 
-        let mut p_ch = crate::challenger::FsChallenger::new(b"succ-cmp");
+        let mut p_ch = FsChallenger::new(b"succ-cmp");
         let proof = recursive_prover_with_basis(
             &cfg,
             poly.clone(),
@@ -7485,13 +7538,19 @@ mod tests {
         };
 
         // Dense verifier
-        let mut v_ch = crate::challenger::FsChallenger::new(b"succ-cmp");
-        let dense_ok =
-            recursive_verifier_with_basis(&v_cfg, &proof, &b, target, &initial_cap(v_cfg.queries[0]), &mut v_ch);
+        let mut v_ch = FsChallenger::new(b"succ-cmp");
+        let dense_ok = recursive_verifier_with_basis(
+            &v_cfg,
+            &proof,
+            &b,
+            target,
+            &initial_cap(v_cfg.queries[0]),
+            &mut v_ch,
+        );
         assert!(dense_ok, "dense verifier must accept");
 
         // Succinct verifier — batch eval_b is just eq(z, ris ++ y_bits) by construction
-        let mut v_ch2 = crate::challenger::FsChallenger::new(b"succ-cmp");
+        let mut v_ch2 = FsChallenger::new(b"succ-cmp");
         let eval_b_residual = |ris: &[F128], yr_log_n: usize| -> Vec<F128> {
             let yr_len = 1usize << yr_log_n;
             let mut point = ris.to_vec();
@@ -7505,7 +7564,7 @@ mod tests {
                             F128::ZERO
                         };
                     }
-                    crate::zerocheck::multilinear::eq_eval(&z, &point)
+                    eq_eval(&z, &point)
                 })
                 .collect()
         };
@@ -7588,7 +7647,7 @@ mod tests {
         // OOD at L1 and L2 (L0 must be 0); 3 fold-grind bits at each level.
         let (p_cfg, v_cfg) = ood_test_configs(log_n, initial_k, &ks, vec![0, 2, 2], vec![3, 3, 3]);
 
-        let mut rng = crate::challenger::RandomChallenger::new(0x00D_7E57);
+        let mut rng = RandomChallenger::new(0x00D_7E57);
         let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
         let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
         let b = build_eq_table(&z);
@@ -7610,11 +7669,14 @@ mod tests {
         );
         let initial_cap = |q0: usize| -> Vec<Hash> {
             wtns_0
-                .cap(merkle::cap_depth(q0, wtns_0.block_len.trailing_zeros() as usize))
+                .cap(merkle::cap_depth(
+                    q0,
+                    wtns_0.block_len.trailing_zeros() as usize,
+                ))
                 .to_vec()
         };
 
-        let mut p_ch = crate::challenger::FsChallenger::new(b"ood-test");
+        let mut p_ch = FsChallenger::new(b"ood-test");
         let proof = recursive_prover_with_basis(
             &p_cfg,
             poly.clone(),
@@ -7631,8 +7693,15 @@ mod tests {
         assert_eq!(proof.fold_grinding_nonces.len(), initial_k + ks[0] + ks[1]);
 
         let dense = |proof: &LigeritoProof| {
-            let mut ch = crate::challenger::FsChallenger::new(b"ood-test");
-            recursive_verifier_with_basis(&v_cfg, proof, &b, target, &initial_cap(v_cfg.queries[0]), &mut ch)
+            let mut ch = FsChallenger::new(b"ood-test");
+            recursive_verifier_with_basis(
+                &v_cfg,
+                proof,
+                &b,
+                target,
+                &initial_cap(v_cfg.queries[0]),
+                &mut ch,
+            )
         };
         let eval_b_residual = {
             let z = z.clone();
@@ -7649,13 +7718,13 @@ mod tests {
                                 F128::ZERO
                             };
                         }
-                        crate::zerocheck::multilinear::eq_eval(&z, &point)
+                        eq_eval(&z, &point)
                     })
                     .collect()
             }
         };
         let succinct = |proof: &LigeritoProof| {
-            let mut ch = crate::challenger::FsChallenger::new(b"ood-test");
+            let mut ch = FsChallenger::new(b"ood-test");
             recursive_verifier_with_basis_succinct(
                 &v_cfg,
                 proof,
@@ -7699,7 +7768,7 @@ mod tests {
     fn ligerito_fast_profile_m22_roundtrip() {
         use crate::challenger::Challenger;
         let m = 22usize;
-        let log_n = m - crate::pcs::LOG_PACKING;
+        let log_n = m - LOG_PACKING;
         let initial_k = 6;
         let p_cfg = prover_config_for(log_n, initial_k, LigeritoProfile::Fast)
             .expect("m22 fast prover config");
@@ -7709,7 +7778,7 @@ mod tests {
         assert!(p_cfg.ood_samples.iter().skip(1).any(|&s| s > 0));
         assert!(p_cfg.fold_grinding_bits.iter().any(|&g| g > 0));
 
-        let mut rng = crate::challenger::RandomChallenger::new(0xFA57_0022);
+        let mut rng = RandomChallenger::new(0xFA57_0022);
         let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
         let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
         let b = build_eq_table(&z);
@@ -7731,11 +7800,14 @@ mod tests {
         );
         let initial_cap = |q0: usize| -> Vec<Hash> {
             wtns_0
-                .cap(merkle::cap_depth(q0, wtns_0.block_len.trailing_zeros() as usize))
+                .cap(merkle::cap_depth(
+                    q0,
+                    wtns_0.block_len.trailing_zeros() as usize,
+                ))
                 .to_vec()
         };
 
-        let mut p_ch = crate::challenger::FsChallenger::new(b"m22-fast");
+        let mut p_ch = FsChallenger::new(b"m22-fast");
         let proof = recursive_prover_with_basis(
             &p_cfg,
             poly,
@@ -7746,9 +7818,16 @@ mod tests {
             &mut p_ch,
         );
 
-        let mut v_ch = crate::challenger::FsChallenger::new(b"m22-fast");
+        let mut v_ch = FsChallenger::new(b"m22-fast");
         assert!(
-            recursive_verifier_with_basis(&v_cfg, &proof, &b, target, &initial_cap(v_cfg.queries[0]), &mut v_ch),
+            recursive_verifier_with_basis(
+                &v_cfg,
+                &proof,
+                &b,
+                target,
+                &initial_cap(v_cfg.queries[0]),
+                &mut v_ch
+            ),
             "m22 fast profile proof must verify"
         );
     }
@@ -7761,7 +7840,7 @@ mod tests {
     fn ligerito_m22_roundtrip_under_blake3() {
         use crate::challenger::Challenger;
         let m = 22usize;
-        let log_n = m - crate::pcs::LOG_PACKING;
+        let log_n = m - LOG_PACKING;
         let initial_k = 6;
         let mut p_cfg = prover_config_for(log_n, initial_k, LigeritoProfile::Fast)
             .expect("m22 fast prover config");
@@ -7773,7 +7852,7 @@ mod tests {
         p_cfg.merkle_hash = HashKind::Blake3;
         v_cfg.merkle_hash = HashKind::Blake3;
 
-        let mut rng = crate::challenger::RandomChallenger::new(0xB1A5_E300);
+        let mut rng = RandomChallenger::new(0xB1A5_E300);
         let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
         let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
         let b = build_eq_table(&z);
@@ -7795,11 +7874,14 @@ mod tests {
         );
         let initial_cap = |q0: usize| -> Vec<Hash> {
             wtns_0
-                .cap(merkle::cap_depth(q0, wtns_0.block_len.trailing_zeros() as usize))
+                .cap(merkle::cap_depth(
+                    q0,
+                    wtns_0.block_len.trailing_zeros() as usize,
+                ))
                 .to_vec()
         };
 
-        let mut p_ch = crate::challenger::FsChallenger::new(b"m22-blake3");
+        let mut p_ch = FsChallenger::new(b"m22-blake3");
         let proof = recursive_prover_with_basis(
             &p_cfg,
             poly,
@@ -7810,9 +7892,16 @@ mod tests {
             &mut p_ch,
         );
 
-        let mut v_ch = crate::challenger::FsChallenger::new(b"m22-blake3");
+        let mut v_ch = FsChallenger::new(b"m22-blake3");
         assert!(
-            recursive_verifier_with_basis(&v_cfg, &proof, &b, target, &initial_cap(v_cfg.queries[0]), &mut v_ch),
+            recursive_verifier_with_basis(
+                &v_cfg,
+                &proof,
+                &b,
+                target,
+                &initial_cap(v_cfg.queries[0]),
+                &mut v_ch
+            ),
             "blake3 Merkle proof must verify"
         );
 
@@ -7820,7 +7909,7 @@ mod tests {
         // recomputed root disagrees, so it must reject.
         let mut wrong_cfg = v_cfg.clone();
         wrong_cfg.merkle_hash = HashKind::Sha256;
-        let mut w_ch = crate::challenger::FsChallenger::new(b"m22-blake3");
+        let mut w_ch = FsChallenger::new(b"m22-blake3");
         assert!(
             !recursive_verifier_with_basis(
                 &wrong_cfg,
@@ -7842,7 +7931,7 @@ mod tests {
     fn ligerito_m22_roundtrip_over_hash_matrix() {
         use crate::challenger::Challenger;
         const KINDS: [HashKind; 2] = [HashKind::Sha256, HashKind::Blake3];
-        let log_n = 22usize - crate::pcs::LOG_PACKING;
+        let log_n = 22usize - LOG_PACKING;
         let initial_k = 6;
 
         for merkle_hash in KINDS {
@@ -7853,7 +7942,7 @@ mod tests {
                 p_cfg.merkle_hash = merkle_hash;
                 v_cfg.merkle_hash = merkle_hash;
 
-                let mut rng = crate::challenger::RandomChallenger::new(0x4A11_0000);
+                let mut rng = RandomChallenger::new(0x4A11_0000);
                 let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
                 let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
                 let b = build_eq_table(&z);
@@ -7868,12 +7957,15 @@ mod tests {
                 let wtns_0 =
                     ligero_commit(&poly, log_msg_cols_0, initial_k, 1, &ntt_0, merkle_hash);
                 let initial_cap = |q0: usize| -> Vec<Hash> {
-            wtns_0
-                .cap(merkle::cap_depth(q0, wtns_0.block_len.trailing_zeros() as usize))
-                .to_vec()
-        };
+                    wtns_0
+                        .cap(merkle::cap_depth(
+                            q0,
+                            wtns_0.block_len.trailing_zeros() as usize,
+                        ))
+                        .to_vec()
+                };
 
-                let mut p_ch = crate::challenger::FsChallenger::with_hash(b"m22-matrix", fs_hash);
+                let mut p_ch = FsChallenger::with_hash(b"m22-matrix", fs_hash);
                 let proof = recursive_prover_with_basis(
                     &p_cfg,
                     poly,
@@ -7884,7 +7976,7 @@ mod tests {
                     &mut p_ch,
                 );
 
-                let mut v_ch = crate::challenger::FsChallenger::with_hash(b"m22-matrix", fs_hash);
+                let mut v_ch = FsChallenger::with_hash(b"m22-matrix", fs_hash);
                 assert!(
                     recursive_verifier_with_basis(
                         &v_cfg,
@@ -7903,7 +7995,7 @@ mod tests {
                     HashKind::Sha256 => HashKind::Blake3,
                     HashKind::Blake3 => HashKind::Sha256,
                 };
-                let mut w_ch = crate::challenger::FsChallenger::with_hash(b"m22-matrix", other_fs);
+                let mut w_ch = FsChallenger::with_hash(b"m22-matrix", other_fs);
                 assert!(
                     !recursive_verifier_with_basis(
                         &v_cfg,
@@ -7930,7 +8022,7 @@ mod tests {
         let k_0 = 2;
         let log_inv_rate = 1;
 
-        let mut rng = crate::challenger::RandomChallenger::new(0xBA51_BA51);
+        let mut rng = RandomChallenger::new(0xBA51_BA51);
         let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
         let z1: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
         let z2: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
@@ -7983,11 +8075,14 @@ mod tests {
         );
         let initial_cap = |q0: usize| -> Vec<Hash> {
             wtns_0
-                .cap(merkle::cap_depth(q0, wtns_0.block_len.trailing_zeros() as usize))
+                .cap(merkle::cap_depth(
+                    q0,
+                    wtns_0.block_len.trailing_zeros() as usize,
+                ))
                 .to_vec()
         };
 
-        let mut p_ch = crate::challenger::FsChallenger::new(b"batched");
+        let mut p_ch = FsChallenger::new(b"batched");
         let proof = recursive_prover_with_basis(
             &cfg,
             poly.clone(),
@@ -8012,9 +8107,15 @@ mod tests {
             ood_samples: vec![0; 2],
             merkle_hash: Default::default(),
         };
-        let mut v_ch = crate::challenger::FsChallenger::new(b"batched");
-        let ok =
-            recursive_verifier_with_basis(&v_cfg, &proof, &b, target, &initial_cap(v_cfg.queries[0]), &mut v_ch);
+        let mut v_ch = FsChallenger::new(b"batched");
+        let ok = recursive_verifier_with_basis(
+            &v_cfg,
+            &proof,
+            &b,
+            target,
+            &initial_cap(v_cfg.queries[0]),
+            &mut v_ch,
+        );
         assert!(ok, "batched-basis verifier rejected valid proof");
     }
 
@@ -8029,7 +8130,7 @@ mod tests {
         let k_0 = 2;
         let log_inv_rate = 1;
 
-        let mut rng = crate::challenger::RandomChallenger::new(0xACED_BEEF);
+        let mut rng = RandomChallenger::new(0xACED_BEEF);
         let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
         let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
         let eq = build_eq_table(&z);
@@ -8056,7 +8157,7 @@ mod tests {
         };
 
         // Path 1: built-in L0 commit.
-        let mut p_ch = crate::challenger::FsChallenger::new(b"l0-test");
+        let mut p_ch = FsChallenger::new(b"l0-test");
         let proof_a = recursive_prover(&cfg, &poly, &z, v, &mut p_ch);
 
         // Path 2: build L0 externally via ligero_commit, then call _with_l0.
@@ -8070,12 +8171,12 @@ mod tests {
             &ntt_0,
             HashKind::Sha256,
         );
-        let mut p_ch_b = crate::challenger::FsChallenger::new(b"l0-test");
+        let mut p_ch_b = FsChallenger::new(b"l0-test");
         let proof_b = recursive_prover_with_l0(
             &cfg,
             &poly,
-            std::mem::take(&mut wtns_0_external.mat),
-            std::mem::take(&mut wtns_0_external.tree),
+            take(&mut wtns_0_external.mat),
+            take(&mut wtns_0_external.tree),
             &z,
             v,
             &mut p_ch_b,
@@ -8112,7 +8213,7 @@ mod tests {
             ood_samples: vec![0; 2],
             merkle_hash: Default::default(),
         };
-        let mut v_ch = crate::challenger::FsChallenger::new(b"l0-test");
+        let mut v_ch = FsChallenger::new(b"l0-test");
         assert!(recursive_verifier(&v_cfg, &proof_b, &z, v, &mut v_ch));
     }
 
@@ -8126,7 +8227,7 @@ mod tests {
         let log_inv_rate = 1;
         let num_queries = 0;
 
-        let mut rng = crate::challenger::RandomChallenger::new(0xDEAD_BEEF);
+        let mut rng = RandomChallenger::new(0xDEAD_BEEF);
         let poly: Vec<F128> = (0..(1usize << log_n)).map(|_| rng.sample_f128()).collect();
         let z: Vec<F128> = (0..log_n).map(|_| rng.sample_f128()).collect();
         let eq = build_eq_table(&z);
@@ -8167,13 +8268,13 @@ mod tests {
             merkle_hash: Default::default(),
         };
 
-        let mut p_ch = crate::challenger::FsChallenger::new(b"test-mut");
+        let mut p_ch = FsChallenger::new(b"test-mut");
         let mut proof = recursive_prover(&prover_cfg, &poly, &z, v, &mut p_ch);
 
         // Mutate yr.
         proof.final_proof.yr[0] += F128::ONE;
 
-        let mut v_ch = crate::challenger::FsChallenger::new(b"test-mut");
+        let mut v_ch = FsChallenger::new(b"test-mut");
         let ok = recursive_verifier(&verifier_cfg, &proof, &z, v, &mut v_ch);
         assert!(!ok, "verifier accepted a proof with mutated yr");
     }

--- a/crates/flock-core/src/pcs/pack.rs
+++ b/crates/flock-core/src/pcs/pack.rs
@@ -21,6 +21,7 @@
 //! [DP24]: https://eprint.iacr.org/2024/504
 
 use crate::field::F128;
+use core::slice::from_raw_parts;
 
 /// `log_2` of the packing width. F_{2^128} holds 128 bits = 2^7.
 pub const LOG_PACKING: usize = 7;
@@ -38,6 +39,15 @@ pub const PACKING_WIDTH: usize = 1 << LOG_PACKING;
 /// - if `z.len() != 1 << m`
 /// - if `m < LOG_PACKING`
 pub fn pack_witness(z: &[bool], m: usize) -> Vec<F128> {
+    #[inline]
+    fn pack64(b: &[u8]) -> u64 {
+        let mut w = 0u64;
+        for (i, ch) in b.as_chunks::<8>().0.iter().enumerate() {
+            let x = u64::from_le_bytes(*ch);
+            w |= (x.wrapping_mul(0x0102_0408_1020_4080) >> 56) << (8 * i);
+        }
+        w
+    }
     use rayon::prelude::*;
     assert_eq!(z.len(), 1usize << m, "z length must be 2^m");
     assert!(
@@ -51,16 +61,8 @@ pub fn pack_witness(z: &[bool], m: usize) -> Vec<F128> {
     // byte 7 of `x * 0x0102040810204080` is Σ_r b_r·2^r (each lower product
     // byte sums distinct powers of two ≤ 0xFE — no carry into byte 7).
     // SAFETY: same length, and any &[bool] is a valid &[u8].
-    let bytes: &[u8] = unsafe { core::slice::from_raw_parts(z.as_ptr() as *const u8, z.len()) };
-    #[inline]
-    fn pack64(b: &[u8]) -> u64 {
-        let mut w = 0u64;
-        for (i, ch) in b.as_chunks::<8>().0.iter().enumerate() {
-            let x = u64::from_le_bytes(*ch);
-            w |= (x.wrapping_mul(0x0102_0408_1020_4080) >> 56) << (8 * i);
-        }
-        w
-    }
+    let bytes: &[u8] = unsafe { from_raw_parts(z.as_ptr() as *const u8, z.len()) };
+
     let one = |i_rest: usize| {
         let base = i_rest << LOG_PACKING;
         F128 {

--- a/crates/flock-core/src/pcs/ring_switch.rs
+++ b/crates/flock-core/src/pcs/ring_switch.rs
@@ -59,11 +59,19 @@
 
 use crate::bits::transpose_8x8_bits;
 use crate::challenger::Challenger;
+#[cfg(any(test, feature = "unsound-challenger"))]
+use crate::challenger::RandomChallenger;
 use crate::field::F128;
+use crate::pcs::tensor_algebra::TensorAlgebra;
+use crate::scratch::take_f128;
 use crate::zerocheck::PaddingSpec;
 use crate::zerocheck::multilinear::lagrange_weights_naive;
 use crate::zerocheck::univariate_skip::build_eq;
 use serde::{Deserialize, Serialize};
+use std::env::var;
+#[cfg(test)]
+use std::hint::black_box;
+use std::time::Instant;
 
 use super::pack::LOG_PACKING;
 
@@ -299,6 +307,8 @@ pub(crate) fn build_eq_parallel(r: &[F128]) -> Vec<F128> {
 /// merged transport's inner open to materialize `γ·eq(ρ, ·)` directly as
 /// `b_combined`.
 pub(crate) fn build_eq_scaled_parallel(r: &[F128], seed: F128) -> Vec<F128> {
+    // Threshold below which rayon dispatch overhead beats the parallel work.
+    const PAR_THRESHOLD: usize = 1 << 12;
     use rayon::prelude::*;
     let n = r.len();
     // Uninit alloc — at iter `i`, the loop reads from t[..2^i] (always written
@@ -307,8 +317,7 @@ pub(crate) fn build_eq_scaled_parallel(r: &[F128], seed: F128) -> Vec<F128> {
     // read; uninit is safe.
     let mut t = crate::alloc_uninit_f128_vec(1usize << n);
     t[0] = seed;
-    // Threshold below which rayon dispatch overhead beats the parallel work.
-    const PAR_THRESHOLD: usize = 1 << 12;
+
     for i in 0..n {
         let r_i = r[i];
         let one_minus_r = F128::ONE + r_i;
@@ -1488,10 +1497,11 @@ pub fn fold_b128_elems_naive(suffix_tensor: &[F128], eq_r_dprime: &[F128]) -> Ve
 /// Tables: 16 × 256 × 16 B = 64 KB (fits in L1+L2). Target speedup ~3× vs the
 /// `trailing_zeros` loop in `fold_b128_elems_naive`.
 pub fn fold_b128_elems(suffix_tensor: &[F128], eq_r_dprime: &[F128]) -> Vec<F128> {
+    const N_BYTES: usize = 16;
+    // bytes per F128
+    const TABLE_SIZE: usize = 256;
     use rayon::prelude::*;
     assert_eq!(eq_r_dprime.len(), 1 << LOG_PACKING);
-    const N_BYTES: usize = 16; // bytes per F128
-    const TABLE_SIZE: usize = 256;
 
     // Build the 16 byte-tables. `tables[byte_idx * 256 + value]` = the F128
     // sum of `eq_r_dprime[byte_idx*8 + bit]` over set bits in `value`.
@@ -1777,7 +1787,7 @@ pub(crate) fn fold_b128_from_table(eq_lo: &[F128], eq_hi: &[F128], tables: &[F12
     use rayon::prelude::*;
     let b = eq_lo.len();
     // Each slot is written exactly once (`*slot = acc`) before any read.
-    let mut out = crate::scratch::take_f128(b * eq_hi.len());
+    let mut out = take_f128(b * eq_hi.len());
     out.par_chunks_mut(b)
         .zip(eq_hi.par_iter())
         .for_each(|(out_block, &e_hi)| {
@@ -1884,18 +1894,6 @@ impl SparseEqTensor {
 ///
 /// O(2^live_count) time and memory, vs the dense `build_eq`'s `O(2^coords.len())`.
 pub fn build_eq_sparse(coords: &[F128]) -> SparseEqTensor {
-    let mut live_positions: Vec<usize> = Vec::with_capacity(coords.len());
-    let mut base = 0usize;
-    for (i, &c) in coords.iter().enumerate() {
-        if c == F128::ZERO {
-            // eq factor pins index bit `i` to 0 — drop it.
-        } else if c == F128::ONE {
-            base |= 1 << i; // pins index bit `i` to 1
-        } else {
-            live_positions.push(i);
-        }
-    }
-    let live_coords: Vec<F128> = live_positions.iter().map(|&i| coords[i]).collect();
     // Builder choice is size-gated, byte-identical either way (`build_eq_parallel`
     // is documented byte-identical to `build_eq`):
     //
@@ -1913,6 +1911,19 @@ pub fn build_eq_sparse(coords: &[F128]) -> SparseEqTensor {
     //   that consume them — the same reasoning as the standalone element
     //   path's dense `build_eq_parallel` build (`element_r1cs.rs`).
     const PAR_LIVE_COORDS: usize = 20;
+    let mut live_positions: Vec<usize> = Vec::with_capacity(coords.len());
+    let mut base = 0usize;
+    for (i, &c) in coords.iter().enumerate() {
+        if c == F128::ZERO {
+            // eq factor pins index bit `i` to 0 — drop it.
+        } else if c == F128::ONE {
+            base |= 1 << i; // pins index bit `i` to 1
+        } else {
+            live_positions.push(i);
+        }
+    }
+    let live_coords: Vec<F128> = live_positions.iter().map(|&i| coords[i]).collect();
+
     let live_tensor = if live_coords.len() >= PAR_LIVE_COORDS {
         build_eq_parallel(&live_coords)
     } else {
@@ -2367,13 +2378,13 @@ pub fn prove<Ch: Challenger>(
     // So packed_witness.len() = 2^(x_outer.len() - 1). Enforce that.
     assert_eq!(l, 1 << (x_outer.len() - 1));
 
-    let trace = std::env::var("PCS_TRACE").is_ok();
+    let trace = var("PCS_TRACE").is_ok();
 
     challenger.observe_label(b"flock-ring-switch-v0");
 
     // Suffix is x_outer[1..] (length m-7); first coord becomes the 7th-bit factor.
     let suffix = &x_outer[1..];
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let suffix_tensor = build_eq_parallel(suffix);
     if trace {
         eprintln!(
@@ -2385,7 +2396,7 @@ pub fn prove<Ch: Challenger>(
     debug_assert_eq!(suffix_tensor.len(), l);
 
     // Compute and send s_hat_v.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let s_hat_v = fold_1b_rows_naive(packed_witness, &suffix_tensor);
     if trace {
         eprintln!(
@@ -2404,7 +2415,7 @@ pub fn prove<Ch: Challenger>(
     let sumcheck_claim = inner_product(&s_hat_u, &eq_r_dprime);
 
     // Compute transparent multilinear rs_eq_ind.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let rs_eq_ind = fold_b128_elems(&suffix_tensor, &eq_r_dprime);
     if trace {
         eprintln!(
@@ -2476,8 +2487,24 @@ pub fn prove_batched_padded_with_precomputed<Ch: Challenger>(
     padding: &PaddingSpec,
     challenger: &mut Ch,
 ) -> (Vec<(RingSwitchProof, RingSwitchBatchOutput)>, Vec<F128>) {
+    // 1. Classify each claim. Claims whose suffix `x_outer[1..]` has at least
+    //    `SPARSE_ZERO_THRESHOLD` exactly-zero coords (e.g. the hash-chain
+    //    ẑ-claim) skip the dense kernels entirely; the rest fuse through the
+    //    existing MFR/8-wide multi-fold. Pulling sparse claims out also
+    //    restores k==2 (the MFR fast-path threshold in `fold_1b_rows_multi`)
+    //    when there are exactly two dense claims — the common case.
+    #[derive(Clone, Copy)]
+    enum Kind {
+        Dense(usize),
+        Sparse(usize),
+    }
+    struct ClaimWork {
+        s_hat_v: Vec<F128>,
+        sumcheck_claim: F128,
+        eq_r_dprime: Vec<F128>,
+    }
     assert!(!x_outers.is_empty());
-    let trace = std::env::var("PCS_TRACE").is_ok();
+    let trace = var("PCS_TRACE").is_ok();
     let n = x_outers.len();
     let l = packed_witness.len();
     for x in x_outers {
@@ -2503,17 +2530,6 @@ pub fn prove_batched_padded_with_precomputed<Ch: Challenger>(
     let has_precomputed =
         |orig: usize| -> bool { precomputed_s_hat_v.get(orig).copied().flatten().is_some() };
 
-    // 1. Classify each claim. Claims whose suffix `x_outer[1..]` has at least
-    //    `SPARSE_ZERO_THRESHOLD` exactly-zero coords (e.g. the hash-chain
-    //    ẑ-claim) skip the dense kernels entirely; the rest fuse through the
-    //    existing MFR/8-wide multi-fold. Pulling sparse claims out also
-    //    restores k==2 (the MFR fast-path threshold in `fold_1b_rows_multi`)
-    //    when there are exactly two dense claims — the common case.
-    #[derive(Clone, Copy)]
-    enum Kind {
-        Dense(usize),
-        Sparse(usize),
-    }
     let mut kinds: Vec<Kind> = Vec::with_capacity(n);
     let mut dense_suffixes: Vec<&[F128]> = Vec::new();
     let mut sparse_suffixes: Vec<&[F128]> = Vec::new();
@@ -2545,7 +2561,7 @@ pub fn prove_batched_padded_with_precomputed<Ch: Challenger>(
     // Gates the s_hat_v fold KERNEL only (the MFR split kernels need 16-wide
     // lo blocks). The rs_eq_ind below defers regardless — see the else arm.
     let use_split = l.is_multiple_of(16);
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let dense_splits: Vec<(Vec<F128>, Vec<F128>)> = if use_split {
         dense_suffixes
             .iter()
@@ -2588,7 +2604,7 @@ pub fn prove_batched_padded_with_precomputed<Ch: Challenger>(
     let sparse_needs_fold: Vec<usize> = (0..sparse_suffixes.len())
         .filter(|&s| !has_precomputed(sparse_to_orig[s]))
         .collect();
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut dense_s_hat_v: Vec<Vec<F128>> = vec![Vec::new(); dense_suffixes.len()];
     let mut sparse_s_hat_v: Vec<Vec<F128>> = vec![Vec::new(); sparse_suffixes.len()];
     // Fill precomputed slots first.
@@ -2656,13 +2672,8 @@ pub fn prove_batched_padded_with_precomputed<Ch: Challenger>(
     //    (b) Sample γ_rs after all observations (Schwartz-Zippel-sound).
     //    (c) Per claim: bake γ_k into eq_r_dprime, fold. Output rs_eq_ind
     //        already has γ_k baked in — pcs combine just adds.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
 
-    struct ClaimWork {
-        s_hat_v: Vec<F128>,
-        sumcheck_claim: F128,
-        eq_r_dprime: Vec<F128>,
-    }
     let mut work: Vec<ClaimWork> = Vec::with_capacity(n);
     for i in 0..n {
         challenger.observe_label(b"flock-ring-switch-v0");
@@ -2717,7 +2728,11 @@ pub fn prove_batched_padded_with_precomputed<Ch: Challenger>(
                         // Gate-rich circuit unions hit this. Byte-identical
                         // to the Dense fold on every consumer.
                         let sfx = &dense_suffixes[d];
-                        let n_lo = if sfx.len() >= 4 { split_n_lo(sfx.len()) } else { sfx.len() };
+                        let n_lo = if sfx.len() >= 4 {
+                            split_n_lo(sfx.len())
+                        } else {
+                            sfx.len()
+                        };
                         let (eq_lo, eq_hi) = build_eq_split(sfx, n_lo);
                         RsEqInd::DeferredDense {
                             eq_lo,
@@ -2736,7 +2751,11 @@ pub fn prove_batched_padded_with_precomputed<Ch: Challenger>(
                 // element region grows.
                 Kind::Sparse(sp) => {
                     let sfx = sparse_suffixes[sp];
-                    let n_lo = if sfx.len() >= 4 { split_n_lo(sfx.len()) } else { sfx.len() };
+                    let n_lo = if sfx.len() >= 4 {
+                        split_n_lo(sfx.len())
+                    } else {
+                        sfx.len()
+                    };
                     let (eq_lo, eq_hi) = build_eq_split(sfx, n_lo);
                     RsEqInd::DeferredDense {
                         eq_lo,
@@ -2918,10 +2937,7 @@ pub fn eval_rs_eq(z_vals: &[F128], query: &[F128], eq_r_dprime: &[F128]) -> F128
 /// (z_vals, query) pairs and returns the partially-evolved `TensorAlgebra`.
 /// Pair with [`eval_rs_eq_finish_from_prefix`] to share the prefix across
 /// many query points (e.g. residual `y_bits` positions).
-pub fn eval_rs_eq_prefix(
-    z_vals: &[F128],
-    query_prefix: &[F128],
-) -> crate::pcs::tensor_algebra::TensorAlgebra {
+pub fn eval_rs_eq_prefix(z_vals: &[F128], query_prefix: &[F128]) -> TensorAlgebra {
     use crate::pcs::tensor_algebra::TensorAlgebra;
     assert!(query_prefix.len() <= z_vals.len());
     let mut eval = TensorAlgebra::from_vertical(F128::ONE);
@@ -2938,7 +2954,7 @@ pub fn eval_rs_eq_prefix(
 /// (z, query) suffix. `z_vals_suffix` and `query_suffix` are the parts of
 /// the original `z_vals`/`query` past the prefix length.
 pub fn eval_rs_eq_finish_from_prefix(
-    prefix: &crate::pcs::tensor_algebra::TensorAlgebra,
+    prefix: &TensorAlgebra,
     z_vals_suffix: &[F128],
     query_suffix: &[F128],
     eq_r_dprime: &[F128],
@@ -2971,7 +2987,7 @@ pub fn eval_rs_eq_finish_from_prefix(
 ///
 /// `y_bits` encodes the suffix as a bitmask: bit `j` is the j-th suffix coord.
 pub fn eval_rs_eq_finish_from_prefix_binary_q(
-    prefix: &crate::pcs::tensor_algebra::TensorAlgebra,
+    prefix: &TensorAlgebra,
     z_vals_suffix: &[F128],
     y_bits: u32,
     eq_r_dprime: &[F128],
@@ -3005,7 +3021,7 @@ mod tests {
     #[test]
     fn eval_rs_eq_finish_binary_q_matches_general() {
         use crate::challenger::Challenger;
-        let mut rng = crate::challenger::RandomChallenger::new(0x_B17_0BBE);
+        let mut rng = RandomChallenger::new(0x_B17_0BBE);
         let log_n = 20usize;
         let prefix_len = 15usize;
         let suffix_len = log_n - prefix_len; // 5
@@ -3381,7 +3397,7 @@ mod tests {
     /// with the real subset-sum structure.
     #[test]
     fn linearized_coefficients_reconstruct_fold() {
-        let mut ch = crate::challenger::RandomChallenger::new(0x11EA_A12E);
+        let mut ch = RandomChallenger::new(0x11EA_A12E);
         for _ in 0..3 {
             let eq_r: Vec<F128> = (0..1 << LOG_PACKING).map(|_| ch.sample_f128()).collect();
             let tables = build_fold_byte_table(&eq_r);
@@ -3644,23 +3660,23 @@ mod tests {
 
         let iters = 20;
         let bench = |f: &dyn Fn()| {
-            let t = std::time::Instant::now();
+            let t = Instant::now();
             for _ in 0..iters {
                 f();
             }
             t.elapsed().as_secs_f64() * 1e3 / iters as f64
         };
         let t_k4 = bench(&|| {
-            std::hint::black_box(fold_1b_rows_1way_mfr(&pw, &t0));
+            black_box(fold_1b_rows_1way_mfr(&pw, &t0));
         });
         let t_8 = bench(&|| {
-            std::hint::black_box(fold_1b_rows_1way_mfr_8wide_k4(&pw, &t0));
+            black_box(fold_1b_rows_1way_mfr_8wide_k4(&pw, &t0));
         });
         let t_2k4 = bench(&|| {
-            std::hint::black_box(fold_1b_rows_2way_mfr(&pw, &t0, &t1));
+            black_box(fold_1b_rows_2way_mfr(&pw, &t0, &t1));
         });
         let t_28 = bench(&|| {
-            std::hint::black_box(fold_1b_rows_2way_mfr_8wide(&pw, &t0, &t1));
+            black_box(fold_1b_rows_2way_mfr_8wide(&pw, &t0, &t1));
         });
         eprintln!(
             "\n  [fold_1b @ m=29] 1-way: {t_k4:5.2}→{t_8:5.2} ms ({:.2}x) | 2-way: {t_2k4:5.2}→{t_28:5.2} ms ({:.2}x)\n",

--- a/crates/flock-core/src/pcs/tensor_algebra.rs
+++ b/crates/flock-core/src/pcs/tensor_algebra.rs
@@ -187,11 +187,6 @@ mod tests {
 
     #[test]
     fn transpose_bit_semantics() {
-        // bit_j(elems[i]) on input becomes bit_i(elems[j]) on output.
-        let mut rng = Rng::new(42);
-        let original = rng.ta();
-        let transposed = original.clone().transpose();
-
         fn bit(x: F128, b: usize) -> u64 {
             if b < 64 {
                 (x.lo >> b) & 1
@@ -199,6 +194,10 @@ mod tests {
                 (x.hi >> (b - 64)) & 1
             }
         }
+        // bit_j(elems[i]) on input becomes bit_i(elems[j]) on output.
+        let mut rng = Rng::new(42);
+        let original = rng.ta();
+        let transposed = original.clone().transpose();
 
         for i in 0..DEGREE {
             for j in 0..DEGREE {

--- a/crates/flock-core/src/permutation.rs
+++ b/crates/flock-core/src/permutation.rs
@@ -58,8 +58,14 @@
 //! F128-packed multilinears, and mirrors the eq-trick sumcheck verifier chain in
 //! `zerocheck.rs`.
 
+use crate::scratch::give_f128;
+use crate::scratch::take_f128;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::env::var;
+use std::mem::replace;
+use std::sync::OnceLock;
+use std::time::Instant;
 
 use crate::challenger::Challenger;
 use crate::field::F128;
@@ -252,9 +258,9 @@ const PAR_THRESHOLD_DEFAULT: usize = 1 << 14;
 /// [`PAR_THRESHOLD_DEFAULT`], overridable via `FLOCK_PERM_PAR_GATE` for tuning
 /// (mirrors `zerocheck::sparse_tail_gate`). Read once.
 fn par_threshold() -> usize {
-    static GATE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    static GATE: OnceLock<usize> = OnceLock::new();
     *GATE.get_or_init(|| {
-        std::env::var("FLOCK_PERM_PAR_GATE")
+        var("FLOCK_PERM_PAR_GATE")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(PAR_THRESHOLD_DEFAULT)
@@ -271,12 +277,12 @@ fn fold_in_place(u: &mut Vec<F128>, rho: F128) {
     if half >= par_threshold() {
         // `take_f128(half)` returns a length-`half` buffer; the map writes every
         // slot (write-before-read contract satisfied).
-        let mut out = crate::scratch::take_f128(half);
+        let mut out = take_f128(half);
         out.par_iter_mut().enumerate().for_each(|(x, o)| {
             *o = u[2 * x] * one_minus + u[2 * x + 1] * rho;
         });
-        let old = std::mem::replace(u, out);
-        crate::scratch::give_f128(old);
+        let old = replace(u, out);
+        give_f128(old);
     } else {
         for x in 0..half {
             u[x] = u[2 * x] * one_minus + u[2 * x + 1] * rho;
@@ -541,15 +547,15 @@ pub fn prove<C: Challenger>(
     let mu = n.trailing_zeros() as usize;
 
     // Phase timing (set PERM_TRACE=1). `tp` returns ms since the last reset.
-    let trace = std::env::var("PERM_TRACE").is_ok();
-    let mut t = std::time::Instant::now();
+    let trace = var("PERM_TRACE").is_ok();
+    let mut t = Instant::now();
     let mut tp = |label: &str| {
         if trace {
             eprintln!(
                 "  [perm-prove] {label:<14} {:8.3} ms",
                 t.elapsed().as_secs_f64() * 1e3
             );
-            t = std::time::Instant::now();
+            t = Instant::now();
         }
     };
 

--- a/crates/flock-core/src/product_gkr.rs
+++ b/crates/flock-core/src/product_gkr.rs
@@ -69,8 +69,18 @@
 //! (A sibling `logup_gkr` — a fractional **sum** GKR with an `a/b ⊕ c/d` gate —
 //! exists on the `recursive-verifier` branch of `flock-dev`, not ported here.)
 
+use crate::scratch::give_f128;
+use crate::scratch::take_f128;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::array::from_fn;
+use std::env::var;
+#[cfg(test)]
+use std::hint::black_box;
+use std::mem::replace;
+use std::mem::swap;
+use std::sync::OnceLock;
+use std::time::Instant;
 
 use crate::challenger::Challenger;
 use crate::field::F128;
@@ -207,9 +217,9 @@ fn build_s_id_vec(mu: usize, basis: &[F128]) -> Vec<F128> {
 const PAR_THRESHOLD_DEFAULT: usize = 1 << 16;
 
 fn par_threshold() -> usize {
-    static GATE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    static GATE: OnceLock<usize> = OnceLock::new();
     *GATE.get_or_init(|| {
-        std::env::var("FLOCK_GKR_GATE")
+        var("FLOCK_GKR_GATE")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(PAR_THRESHOLD_DEFAULT)
@@ -219,19 +229,19 @@ fn par_threshold() -> usize {
 /// Phase tracing, enabled by `GKR_TRACE=1` (mirrors `PERM_TRACE` in
 /// [`crate::permutation`]). Read once.
 fn trace_on() -> bool {
-    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ON.get_or_init(|| std::env::var("GKR_TRACE").is_ok())
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| var("GKR_TRACE").is_ok())
 }
 
 /// Print `label` with the elapsed time since `t`, then reset `t`. No-op unless
 /// [`trace_on`].
-fn tp(t: &mut std::time::Instant, label: &str) {
+fn tp(t: &mut Instant, label: &str) {
     if trace_on() {
         eprintln!(
             "  [prod-gkr] {label:<16} {:8.3} ms",
             t.elapsed().as_secs_f64() * 1e3
         );
-        *t = std::time::Instant::now();
+        *t = Instant::now();
     }
 }
 
@@ -241,15 +251,15 @@ fn fold_in_place(u: &mut Vec<F128>, rho: F128) {
     let one_minus = F128::ONE + rho;
     match crate::fold_min_len(half) {
         Some(min_len) => {
-            let mut out = crate::scratch::take_f128(half);
+            let mut out = take_f128(half);
             out.par_iter_mut()
                 .enumerate()
                 .with_min_len(min_len)
                 .for_each(|(x, o)| {
                     *o = u[2 * x] * one_minus + u[2 * x + 1] * rho;
                 });
-            let old = std::mem::replace(u, out);
-            crate::scratch::give_f128(old);
+            let old = replace(u, out);
+            give_f128(old);
         }
         None => {
             for x in 0..half {
@@ -270,7 +280,7 @@ fn fold_borrowed(src: &[F128], rho: F128) -> Vec<F128> {
     // Callers hand these back via `scratch::give_f128` once a layer is done.
     // This is resource hygiene, not a speed win — measured neutral at μ=20,
     // since the fold is bound by memory traffic rather than by the allocator.
-    let mut out = crate::scratch::take_f128(half);
+    let mut out = take_f128(half);
     match crate::fold_min_len(half) {
         Some(min_len) => {
             out.par_iter_mut()
@@ -508,7 +518,7 @@ fn prove_product<C: Challenger>(v_in: &[F128], ch: &mut C) -> (F128, Vec<LayerPr
     let mu = v_in.len().trailing_zeros() as usize;
 
     // Build all layers, v_layers[k] has 2^k entries; v_layers[mu] = v_in.
-    let mut tt = std::time::Instant::now();
+    let mut tt = Instant::now();
     let mut v_layers: Vec<Vec<F128>> = vec![Vec::new(); mu + 1];
     v_layers[mu] = v_in.to_vec();
     for k in (0..mu).rev() {
@@ -634,7 +644,7 @@ pub fn prove<C: Challenger>(
     assert!(n.is_power_of_two() && n >= 2, "need N = 2^μ ≥ 2");
     let mu = n.trailing_zeros() as usize;
 
-    let mut t = std::time::Instant::now();
+    let mut t = Instant::now();
     ch.observe_label(DOMAIN);
     let alpha = ch.sample_f128();
     let beta = ch.sample_f128();
@@ -850,7 +860,7 @@ pub fn prove_batched<C: Challenger>(
     assert!(n.is_power_of_two() && n >= 2, "need N = 2^μ ≥ 2");
     let mu = n.trailing_zeros() as usize;
 
-    let mut t = std::time::Instant::now();
+    let mut t = Instant::now();
     ch.observe_label(DOMAIN_BATCHED);
     let alpha = ch.sample_f128();
     let beta = ch.sample_f128();
@@ -918,8 +928,8 @@ pub fn prove_batched<C: Challenger>(
     // round. Pages are faulted at most once per prove — and across proves the
     // scratch pool hands the same resident buffers straight back.
     let cap = 1usize << mu.saturating_sub(2);
-    let mut cur: [Vec<F128>; 4] = std::array::from_fn(|_| crate::scratch::take_f128(cap));
-    let mut nxt: [Vec<F128>; 4] = std::array::from_fn(|_| crate::scratch::take_f128(cap));
+    let mut cur: [Vec<F128>; 4] = from_fn(|_| take_f128(cap));
+    let mut nxt: [Vec<F128>; 4] = from_fn(|_| take_f128(cap));
     for k in 0..mu {
         let lambda = ch.sample_f128();
         let h = 1usize << k;
@@ -931,7 +941,7 @@ pub fn prove_batched<C: Challenger>(
         // been folded yet, so it comes straight off the layer. Every later
         // round's message is produced by the preceding fold.
         let mut pending = if k > 0 {
-            let tr = std::time::Instant::now();
+            let tr = Instant::now();
             let (l0s, l1s) = l_layers[k + 1].split_at(h);
             let (r0s, r1s) = r_layers[k + 1].split_at(h);
             let eq = SplitEqGhash::new(&r_pt[1..k]);
@@ -952,13 +962,13 @@ pub fn prove_batched<C: Challenger>(
             rounds.push((g1, g_inf));
             r_prime.push(rho);
 
-            let mut tr = std::time::Instant::now();
+            let mut tr = Instant::now();
             // eq for round i+1; `None` on the last round, where the fold has no
             // successor message to emit.
             let eq_next = (i + 1 < k).then(|| SplitEqGhash::new(&r_pt[i + 2..k]));
             if trace_on() {
                 eq_ns += tr.elapsed().as_nanos();
-                tr = std::time::Instant::now();
+                tr = Instant::now();
             }
             if i == 0 {
                 let (l0s, l1s) = l_layers[k + 1].split_at(h);
@@ -988,7 +998,7 @@ pub fn prove_batched<C: Challenger>(
                     eq_next.as_ref(),
                 );
                 len /= 2;
-                std::mem::swap(&mut cur, &mut nxt);
+                swap(&mut cur, &mut nxt);
             }
             if trace_on() {
                 fold_ns += tr.elapsed().as_nanos();
@@ -1048,7 +1058,7 @@ pub fn prove_batched<C: Challenger>(
     observe_evals(ch, &[f_eval, g_eval, s_sigma_eval]);
     // Hand the ping-pong buffers back so the next prove reuses resident pages.
     for u in cur.into_iter().chain(nxt) {
-        crate::scratch::give_f128(u);
+        give_f128(u);
     }
     tp(&mut t, "evals");
 
@@ -1323,11 +1333,11 @@ mod tests {
             // message, whose eq spans the folded width's pairs.
             let eq_pt: Vec<F128> = (0..log_n.saturating_sub(2)).map(|_| rng.f128()).collect();
             let eq = SplitEqGhash::new(&eq_pt);
-            let mut dst: [Vec<F128>; 4] = std::array::from_fn(|_| vec![F128::ZERO; half]);
+            let mut dst: [Vec<F128>; 4] = from_fn(|_| vec![F128::ZERO; half]);
 
             let time = |iters: usize, mut run: Box<dyn FnMut()>| -> f64 {
                 run();
-                let t0 = std::time::Instant::now();
+                let t0 = Instant::now();
                 for _ in 0..iters {
                     run();
                 }
@@ -1337,10 +1347,7 @@ mod tests {
             let plain = {
                 let mut d = vec![F128::ZERO; half];
                 let s = &src;
-                time(
-                    20,
-                    Box::new(move || fold_into(std::hint::black_box(s), rho, &mut d)),
-                )
+                time(20, Box::new(move || fold_into(black_box(s), rho, &mut d)))
             };
             let fused = {
                 let s = &src;

--- a/crates/flock-core/src/proof.rs
+++ b/crates/flock-core/src/proof.rs
@@ -5,6 +5,9 @@
 //! produces these structs; the verifier consumes them.
 
 use crate::challenger::Challenger;
+use crate::circuit::WiringProof;
+use crate::element_r1cs::union::Claims;
+use crate::element_r1cs::union::Proof;
 use crate::field::F128;
 use crate::lincheck::{self, QuirkyPoint};
 use crate::pcs::{self, Commitment};
@@ -46,7 +49,7 @@ pub struct R1csProofMixedClassMerged {
     /// Boolean zerocheck + lincheck over the `M_bool` prefix subcube.
     pub boolean: Option<BooleanPiopProof>,
     /// The element-region zerocheck + lincheck.
-    pub element: Option<crate::element_r1cs::union::Proof>,
+    pub element: Option<Proof>,
     pub pcs_open: pcs::MergedOpenProof,
 }
 
@@ -62,8 +65,8 @@ pub struct R1csProofMixedClassMerged {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct R1csProofCircuitMerged {
     pub boolean: Option<BooleanPiopProof>,
-    pub element: Option<crate::element_r1cs::union::Proof>,
-    pub wiring: crate::circuit::WiringProof,
+    pub element: Option<Proof>,
+    pub wiring: WiringProof,
     pub pcs_open: pcs::MergedOpenProof,
 }
 
@@ -82,7 +85,7 @@ pub struct UnionClassClaims {
     pub boolean: Option<R1csClaim>,
     /// Element C + LC, in union word coordinates — `None` when the registry
     /// has no element types.
-    pub element: Option<crate::element_r1cs::union::Claims>,
+    pub element: Option<Claims>,
 }
 
 /// A claim of the form `ẑ(point) = value` for the witness `z`.

--- a/crates/flock-core/src/r1cs.rs
+++ b/crates/flock-core/src/r1cs.rs
@@ -10,6 +10,15 @@
 //! materialized `c_0` matrix for utilities like `satisfies`).
 
 /// Sparse boolean matrix. `rows[i]` lists the column indices where the entry is 1.
+use crate::field::F128;
+use crate::lincheck::CscCircuit;
+use crate::lincheck::QuirkyPoint;
+use crate::lincheck::SparseMatrixCircuit;
+use crate::zerocheck::PaddingSpec;
+use std::array::from_fn;
+use std::slice::from_raw_parts;
+use std::slice::from_raw_parts_mut;
+use std::sync::OnceLock;
 #[derive(Clone, Debug)]
 pub struct SparseBinaryMatrix {
     pub num_rows: usize,
@@ -81,15 +90,15 @@ pub struct BlockR1cs {
     /// (the matrices are public fields, so callers that mutate them after the
     /// cache is populated will see a stale digest — don't do that).
     #[doc(hidden)]
-    pub digest_cache: std::sync::OnceLock<[u8; 32]>,
+    pub digest_cache: OnceLock<[u8; 32]>,
     /// Lazily-cached CSC transpose of `(a_0, b_0)` for lincheck's
     /// `fold_alpha_batched` — see [`Self::csc_lincheck_circuit`]. Same
     /// stale-cache caveat as [`Self::digest_cache`].
     #[doc(hidden)]
-    pub csc_cache: std::sync::OnceLock<crate::lincheck::CscCircuit>,
+    pub csc_cache: OnceLock<CscCircuit>,
 }
 
-// Manual Clone — std::sync::OnceLock doesn't derive Clone, and a fresh cache
+// Manual Clone — OnceLock doesn't derive Clone, and a fresh cache
 // after cloning is the right behavior (recomputes lazily on first use).
 impl Clone for BlockR1cs {
     fn clone(&self) -> Self {
@@ -103,8 +112,8 @@ impl Clone for BlockR1cs {
             c_0: self.c_0.clone(),
             layout: self.layout,
             const_pin: self.const_pin,
-            digest_cache: std::sync::OnceLock::new(),
-            csc_cache: std::sync::OnceLock::new(),
+            digest_cache: OnceLock::new(),
+            csc_cache: OnceLock::new(),
         }
     }
 }
@@ -143,7 +152,7 @@ impl BlockR1cs {
 
     /// Default `LincheckCircuit` wrapping this R1CS's sparse matrices.
     /// Per-hash setups that supply a custom circuit walker bypass this.
-    pub fn sparse_lincheck_circuit(&self) -> crate::lincheck::SparseMatrixCircuit<'_> {
+    pub fn sparse_lincheck_circuit(&self) -> SparseMatrixCircuit<'_> {
         crate::lincheck::SparseMatrixCircuit::new(&self.a_0, &self.b_0)
             .with_const_pin(self.const_pin)
     }
@@ -155,10 +164,9 @@ impl BlockR1cs {
     /// over the nonzeros) out of the prove path. NOT meaningful for setups
     /// whose `BlockR1cs` carries empty matrix stubs (e.g. Keccak) — those
     /// must keep their circuit walkers.
-    pub fn csc_lincheck_circuit(&self) -> &crate::lincheck::CscCircuit {
+    pub fn csc_lincheck_circuit(&self) -> &CscCircuit {
         self.csc_cache.get_or_init(|| {
-            crate::lincheck::CscCircuit::from_matrices(&self.a_0, &self.b_0)
-                .with_const_pin(self.const_pin)
+            CscCircuit::from_matrices(&self.a_0, &self.b_0).with_const_pin(self.const_pin)
         })
     }
 
@@ -197,17 +205,17 @@ impl BlockR1cs {
     // -----------------------------------------------------------------------
 
     /// Packed `a = A · z` ∈ GF(2)^N. Output is F_{2^128}-packed (length 2^(m-7)).
-    pub fn apply_a_packed(&self, z_packed: &[crate::field::F128]) -> Vec<crate::field::F128> {
+    pub fn apply_a_packed(&self, z_packed: &[F128]) -> Vec<F128> {
         apply_block_diag_packed(&self.a_0, z_packed, self.m, self.k_log)
     }
 
     /// Packed `b = B · z`.
-    pub fn apply_b_packed(&self, z_packed: &[crate::field::F128]) -> Vec<crate::field::F128> {
+    pub fn apply_b_packed(&self, z_packed: &[F128]) -> Vec<F128> {
         apply_block_diag_packed(&self.b_0, z_packed, self.m, self.k_log)
     }
 
     /// Packed `c = C · z`.
-    pub fn apply_c_packed(&self, z_packed: &[crate::field::F128]) -> Vec<crate::field::F128> {
+    pub fn apply_c_packed(&self, z_packed: &[F128]) -> Vec<F128> {
         apply_block_diag_packed(&self.c_0, z_packed, self.m, self.k_log)
     }
 
@@ -226,14 +234,12 @@ impl BlockR1cs {
     /// prefix (padding interleaved at each block's tail). BatchMajor: the
     /// padding chunk-columns coalesce into ONE contiguous buffer suffix,
     /// expressed as a single giant block (`k_log = m`) with a useful prefix.
-    pub fn padding_spec(&self) -> crate::zerocheck::PaddingSpec {
+    pub fn padding_spec(&self) -> PaddingSpec {
         match self.layout {
-            WitnessLayout::RowMajor => crate::zerocheck::PaddingSpec::uniform(
-                self.k_log,
-                self.useful_bits,
-                1usize << self.n_log(),
-            ),
-            WitnessLayout::BatchMajor => crate::zerocheck::PaddingSpec::uniform(
+            WitnessLayout::RowMajor => {
+                PaddingSpec::uniform(self.k_log, self.useful_bits, 1usize << self.n_log())
+            }
+            WitnessLayout::BatchMajor => PaddingSpec::uniform(
                 self.m,
                 self.useful_bits.div_ceil(128) << (7 + self.n_log()),
                 1,
@@ -246,15 +252,11 @@ impl BlockR1cs {
     /// coordinates. RowMajor address order is `[inner-rest | batch]`;
     /// BatchMajor is `[dim6 | batch | chunk]` with the inner-rest coords
     /// being `[dim6, chunk…]`.
-    pub fn x_ab_from_mlv(
-        &self,
-        z_skip: crate::field::F128,
-        mlv: &[crate::field::F128],
-    ) -> crate::lincheck::QuirkyPoint {
+    pub fn x_ab_from_mlv(&self, z_skip: F128, mlv: &[F128]) -> QuirkyPoint {
         let inner_rest_len = self.k_log - self.k_skip;
         assert_eq!(mlv.len(), self.m - self.k_skip);
         match self.layout {
-            WitnessLayout::RowMajor => crate::lincheck::QuirkyPoint {
+            WitnessLayout::RowMajor => QuirkyPoint {
                 z_skip,
                 x_inner_rest: mlv[..inner_rest_len].to_vec(),
                 x_outer: mlv[inner_rest_len..].to_vec(),
@@ -268,7 +270,7 @@ impl BlockR1cs {
                 let mut x_inner_rest = Vec::with_capacity(inner_rest_len);
                 x_inner_rest.push(mlv[0]);
                 x_inner_rest.extend_from_slice(&mlv[1 + n_log..]);
-                crate::lincheck::QuirkyPoint {
+                QuirkyPoint {
                     z_skip,
                     x_inner_rest,
                     x_outer: mlv[1..1 + n_log].to_vec(),
@@ -282,12 +284,12 @@ impl BlockR1cs {
     /// See [`WitnessLayout`] for the BatchMajor point convention.
     pub fn ab_claim_point(
         &self,
-        r_inner_skip: crate::field::F128,
-        r_inner_rest: &[crate::field::F128],
-        x_outer: &[crate::field::F128],
-    ) -> crate::lincheck::QuirkyPoint {
+        r_inner_skip: F128,
+        r_inner_rest: &[F128],
+        x_outer: &[F128],
+    ) -> QuirkyPoint {
         match self.layout {
-            WitnessLayout::RowMajor => crate::lincheck::QuirkyPoint {
+            WitnessLayout::RowMajor => QuirkyPoint {
                 z_skip: r_inner_skip,
                 x_inner_rest: r_inner_rest.to_vec(),
                 x_outer: x_outer.to_vec(),
@@ -296,7 +298,7 @@ impl BlockR1cs {
                 let mut suffix = Vec::with_capacity(x_outer.len() + r_inner_rest.len() - 1);
                 suffix.extend_from_slice(x_outer);
                 suffix.extend_from_slice(&r_inner_rest[1..]);
-                crate::lincheck::QuirkyPoint {
+                QuirkyPoint {
                     z_skip: r_inner_skip,
                     x_inner_rest: vec![r_inner_rest[0]],
                     x_outer: suffix,
@@ -307,19 +309,15 @@ impl BlockR1cs {
 
     /// Address-ordered `ZClaim` point for the C claim from the zerocheck's
     /// `r_rest` (which is address-ordered in both layouts).
-    pub fn c_claim_point(
-        &self,
-        z_skip: crate::field::F128,
-        r_rest: &[crate::field::F128],
-    ) -> crate::lincheck::QuirkyPoint {
+    pub fn c_claim_point(&self, z_skip: F128, r_rest: &[F128]) -> QuirkyPoint {
         let inner_rest_len = self.k_log - self.k_skip;
         match self.layout {
-            WitnessLayout::RowMajor => crate::lincheck::QuirkyPoint {
+            WitnessLayout::RowMajor => QuirkyPoint {
                 z_skip,
                 x_inner_rest: r_rest[..inner_rest_len].to_vec(),
                 x_outer: r_rest[inner_rest_len..].to_vec(),
             },
-            WitnessLayout::BatchMajor => crate::lincheck::QuirkyPoint {
+            WitnessLayout::BatchMajor => QuirkyPoint {
                 z_skip,
                 x_inner_rest: vec![r_rest[0]],
                 x_outer: r_rest[1..].to_vec(),
@@ -383,7 +381,7 @@ impl BlockR1cs {
 
     /// Check the R1CS constraint `(A·z) ⊙ (B·z) = C·z` over GF(2) on a packed
     /// witness. Per-element check is `a & b == c` bitwise.
-    pub fn satisfies_packed(&self, z_packed: &[crate::field::F128]) -> bool {
+    pub fn satisfies_packed(&self, z_packed: &[F128]) -> bool {
         use crate::field::F128;
         assert_eq!(z_packed.len(), 1usize << (self.m - 7));
         let a = self.apply_a_packed(z_packed);
@@ -447,10 +445,10 @@ fn apply_block_diag(m_0: &SparseBinaryMatrix, z: &[bool], k_log: usize) -> Vec<b
 /// = `n_outer · k · s` bit ops.
 pub fn apply_block_diag_packed(
     m_0: &SparseBinaryMatrix,
-    z_packed: &[crate::field::F128],
+    z_packed: &[F128],
     m: usize,
     k_log: usize,
-) -> Vec<crate::field::F128> {
+) -> Vec<F128> {
     use crate::field::F128;
     use rayon::prelude::*;
 
@@ -549,10 +547,10 @@ fn flatten_csr(m: &SparseBinaryMatrix) -> (Vec<u32>, Vec<u32>) {
 /// View a block of F128s as u128 words (F128 is repr(C, align(16)) with two
 /// little-endian u64s — bit `b` of the u128 is logical bit `b` of the block).
 #[inline]
-fn as_u128s(block: &[crate::field::F128]) -> &[u128] {
+fn as_u128s(block: &[F128]) -> &[u128] {
     // SAFETY: F128 has u128's size and alignment on all supported targets;
     // the lo/hi little-endian layout matches the u128 bit order.
-    unsafe { std::slice::from_raw_parts(block.as_ptr() as *const u128, block.len()) }
+    unsafe { from_raw_parts(block.as_ptr() as *const u128, block.len()) }
 }
 
 /// Apply `M_0` (CSR form) to APPLY_STRIP = 8 consecutive blocks at once.
@@ -570,8 +568,8 @@ fn as_u128s(block: &[crate::field::F128]) -> &[u128] {
 fn apply_strip_csr(
     row_ptr: &[u32],
     cols: &[u32],
-    z_strip: &[crate::field::F128],
-    out_strip: &mut [crate::field::F128],
+    z_strip: &[F128],
+    out_strip: &mut [F128],
     f128_per_block: usize,
 ) {
     use crate::bits::transpose_8_u64s_to_64_bytes;
@@ -583,12 +581,12 @@ fn apply_strip_csr(
     // SAFETY: F128 is repr(C, align(16)) = two little-endian u64s; viewing the
     // strip as u64 words preserves bit order within each block.
     let z_u64: &[u64] =
-        unsafe { std::slice::from_raw_parts(z_strip.as_ptr() as *const u64, z_strip.len() * 2) };
+        unsafe { from_raw_parts(z_strip.as_ptr() as *const u64, z_strip.len() * 2) };
 
     // Phase 1: bit-transpose the 8 blocks to column-major bytes.
     let mut colbits = vec![0u8; k];
     for w in 0..u64_per_block {
-        let lanes: [u64; 8] = std::array::from_fn(|s| z_u64[s * u64_per_block + w]);
+        let lanes: [u64; 8] = from_fn(|s| z_u64[s * u64_per_block + w]);
         transpose_8_u64s_to_64_bytes(&lanes, &mut colbits[w * 64..w * 64 + 64]);
     }
 
@@ -650,8 +648,8 @@ fn transpose_64x64(a: &mut [u64; 64]) {
 fn apply_strip64_csr(
     row_ptr: &[u32],
     cols: &[u32],
-    z_strip: &[crate::field::F128],
-    out_strip: &mut [crate::field::F128],
+    z_strip: &[F128],
+    out_strip: &mut [F128],
     f128_per_block: usize,
 ) {
     const S: usize = 64;
@@ -661,10 +659,9 @@ fn apply_strip64_csr(
     // SAFETY: F128 is repr(C, align(16)) = two little-endian u64s; u64 views
     // preserve bit order within each block.
     let z_u64: &[u64] =
-        unsafe { std::slice::from_raw_parts(z_strip.as_ptr() as *const u64, z_strip.len() * 2) };
-    let out_u64: &mut [u64] = unsafe {
-        std::slice::from_raw_parts_mut(out_strip.as_mut_ptr() as *mut u64, out_strip.len() * 2)
-    };
+        unsafe { from_raw_parts(z_strip.as_ptr() as *const u64, z_strip.len() * 2) };
+    let out_u64: &mut [u64] =
+        unsafe { from_raw_parts_mut(out_strip.as_mut_ptr() as *mut u64, out_strip.len() * 2) };
 
     // Transpose in: colbits[j] = column j's bit across the 64 blocks.
     let mut colbits = vec![0u64; k];
@@ -700,12 +697,7 @@ fn apply_strip64_csr(
 }
 
 /// Single-block CSR kernel (tail strips whose block count < APPLY_STRIP).
-fn apply_one_block_csr(
-    row_ptr: &[u32],
-    cols: &[u32],
-    z_block: &[crate::field::F128],
-    out_block: &mut [crate::field::F128],
-) {
+fn apply_one_block_csr(row_ptr: &[u32], cols: &[u32], z_block: &[F128], out_block: &mut [F128]) {
     let z = as_u128s(z_block);
     let f128_per_block = z_block.len();
     for out_idx in 0..f128_per_block {
@@ -728,7 +720,7 @@ fn apply_one_block_csr(
 }
 
 #[inline]
-fn get_bit_packed(z_packed: &[crate::field::F128], global_bit: usize) -> bool {
+fn get_bit_packed(z_packed: &[F128], global_bit: usize) -> bool {
     let i_packed = global_bit / 128;
     let local = global_bit % 128;
     if local < 64 {
@@ -739,7 +731,7 @@ fn get_bit_packed(z_packed: &[crate::field::F128], global_bit: usize) -> bool {
 }
 
 #[inline]
-fn set_bit_packed(z_packed: &mut [crate::field::F128], global_bit: usize) {
+fn set_bit_packed(z_packed: &mut [F128], global_bit: usize) {
     let i_packed = global_bit / 128;
     let local = global_bit % 128;
     if local < 64 {
@@ -851,8 +843,8 @@ mod tests {
             c_0: identity(1 << k_log),
             layout: WitnessLayout::RowMajor,
             const_pin: None,
-            digest_cache: std::sync::OnceLock::new(),
-            csc_cache: std::sync::OnceLock::new(),
+            digest_cache: OnceLock::new(),
+            csc_cache: OnceLock::new(),
         };
         for seed in 0..4 {
             let z: Vec<bool> = (0..(1 << m)).map(|i| ((i ^ seed) & 1) == 1).collect();
@@ -880,8 +872,8 @@ mod tests {
             c_0: identity(1 << k_log),
             layout: WitnessLayout::RowMajor,
             const_pin: None,
-            digest_cache: std::sync::OnceLock::new(),
-            csc_cache: std::sync::OnceLock::new(),
+            digest_cache: OnceLock::new(),
+            csc_cache: OnceLock::new(),
         };
         let z_zero = vec![false; 1 << m];
         assert!(r1cs.satisfies(&z_zero));

--- a/crates/flock-core/src/schedule.rs
+++ b/crates/flock-core/src/schedule.rs
@@ -20,7 +20,12 @@
 //! Phase 0 landed the types and their arithmetic; the union-instance layer
 //! that wires them into the prove/verify paths lives in [`crate::union`].
 
+use crate::r1cs::BlockR1cs;
+use crate::r1cs::absorb_matrix;
+use std::cmp::Reverse;
+use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use crate::element_r1cs::ElementTableType;
 use crate::r1cs::SparseBinaryMatrix;
@@ -172,7 +177,7 @@ impl TableType {
     /// the replication count, which becomes the registry's uniform capacity
     /// `nu` (pass the r1cs's `n_log()` to [`Registry::new`] to reproduce
     /// today's geometry exactly).
-    pub fn from_block_r1cs(r1cs: &crate::r1cs::BlockR1cs) -> Self {
+    pub fn from_block_r1cs(r1cs: &BlockR1cs) -> Self {
         Self {
             k_log: r1cs.k_log,
             useful_bits: r1cs.useful_bits,
@@ -297,7 +302,7 @@ pub struct Registry {
     /// manual `Clone` resetting the cache), every field here is private and
     /// immutable after construction, so the cache can never go stale and the
     /// derived `Clone` may carry it.
-    digest_cache: std::sync::OnceLock<[u8; 32]>,
+    digest_cache: OnceLock<[u8; 32]>,
 }
 
 impl Registry {
@@ -370,7 +375,7 @@ impl Registry {
             // the cell-slot enumeration and hence σ's index space depend on
             // it).
             let used_cols = ty.used_word_cols();
-            let mut seen = std::collections::BTreeSet::new();
+            let mut seen = BTreeSet::new();
             for w in &ty.io_schema {
                 assert!(
                     w.word_col < used_cols,
@@ -387,7 +392,7 @@ impl Registry {
         // Class-major, then non-increasing capacity area = k_log descending
         // (uniform capacity). Stable, so equal-width types keep their given
         // order — and the boolean types stay a prefix of the list.
-        types.sort_by_key(|ty| (ty.is_element(), std::cmp::Reverse(ty.k_log)));
+        types.sort_by_key(|ty| (ty.is_element(), Reverse(ty.k_log)));
         let num_boolean = types.iter().filter(|ty| !ty.is_element()).count();
 
         // Pack each class from its own base, area-descending. Boolean starts
@@ -489,7 +494,7 @@ impl Registry {
             m_bool,
             m_elem,
             element_base,
-            digest_cache: std::sync::OnceLock::new(),
+            digest_cache: OnceLock::new(),
         }
     }
 
@@ -555,9 +560,9 @@ impl Registry {
                 };
                 h.update(&[present]);
                 h.update(&value.to_le_bytes());
-                crate::r1cs::absorb_matrix(&mut h, &ty.a_0);
-                crate::r1cs::absorb_matrix(&mut h, &ty.b_0);
-                crate::r1cs::absorb_matrix(&mut h, &ty.c_0);
+                absorb_matrix(&mut h, &ty.a_0);
+                absorb_matrix(&mut h, &ty.b_0);
+                absorb_matrix(&mut h, &ty.c_0);
                 // Element payload appends ONLY when present — see above.
                 if let Some(el) = ty.element_type() {
                     h.update(ELEMENT_CLASS_LABEL);
@@ -915,8 +920,8 @@ mod tests {
             c_0: stub(),
             layout: WitnessLayout::BatchMajor,
             const_pin: None,
-            digest_cache: std::sync::OnceLock::new(),
-            csc_cache: std::sync::OnceLock::new(),
+            digest_cache: OnceLock::new(),
+            csc_cache: OnceLock::new(),
         };
 
         assert_eq!(reg.m_total(), r1cs.m);

--- a/crates/flock-core/src/scratch.rs
+++ b/crates/flock-core/src/scratch.rs
@@ -18,6 +18,9 @@
 //! e.g. after the last prove of a batch.
 
 use crate::field::F128;
+use core::mem::size_of;
+use std::env::var_os;
+use std::ptr::write_bytes;
 use std::sync::Mutex;
 
 static POOL: Mutex<Vec<Vec<F128>>> = Mutex::new(Vec::new());
@@ -78,7 +81,7 @@ pub(crate) fn try_take_f128(n: usize) -> Option<Vec<F128>> {
     if let Some(i) = best {
         let mut v = pool.swap_remove(i);
         drop(pool);
-        if std::env::var_os("FLOCK_POOL_TRACE").is_some() {
+        if var_os("FLOCK_POOL_TRACE").is_some() {
             eprintln!(
                 "      [pool] take_f128 n=2^{:.1} cap=2^{:.1} ({}x)",
                 (n as f64).log2(),
@@ -93,7 +96,7 @@ pub(crate) fn try_take_f128(n: usize) -> Option<Vec<F128>> {
         unsafe { v.set_len(n) };
         return Some(v);
     }
-    if std::env::var_os("FLOCK_POOL_TRACE").is_some() {
+    if var_os("FLOCK_POOL_TRACE").is_some() {
         eprintln!(
             "      [pool] take_f128 n=2^{:.1} MISS (fresh)",
             (n as f64).log2()
@@ -280,7 +283,7 @@ fn prewarm_sets(sets: &[(usize, usize, usize)]) {
     use rayon::prelude::*;
     let mut bufs: Vec<Vec<F128>> = Vec::new();
     let mut budget = PREWARM_BUDGET_BYTES;
-    let w = core::mem::size_of::<F128>();
+    let w = size_of::<F128>();
     for &(m, n_large, n_small) in sets {
         if m < 7 {
             continue;
@@ -301,7 +304,7 @@ fn prewarm_sets(sets: &[(usize, usize, usize)]) {
     bufs.par_iter_mut().for_each(|b| {
         b.par_chunks_mut(1 << 16).for_each(|chunk| {
             // SAFETY: F128 is plain bytes (no Drop); zero is a valid pattern.
-            unsafe { std::ptr::write_bytes(chunk.as_mut_ptr(), 0u8, chunk.len()) }
+            unsafe { write_bytes(chunk.as_mut_ptr(), 0u8, chunk.len()) }
         });
     });
     for b in bufs {

--- a/crates/flock-core/src/union.rs
+++ b/crates/flock-core/src/union.rs
@@ -33,10 +33,23 @@ use crate::challenger::Challenger;
 use crate::field::F128;
 use crate::lincheck::QuirkyPoint;
 use crate::pcs::Commitment;
-use crate::schedule::{Instance, Registry, TableType};
+use crate::pcs::dense_lanes;
+#[cfg(test)]
+use crate::pcs::jagged::JaggedParams;
 #[cfg(test)]
 use crate::schedule::TableClass;
+use crate::schedule::{Instance, Registry, TableType};
+use crate::scratch::take_f128;
+#[cfg(test)]
+use crate::zerocheck::PaddingRun;
 use crate::zerocheck::{K_SKIP, PaddingSpec};
+use core::mem::take;
+use core::ops::Range;
+use std::iter::repeat_n;
+#[cfg(test)]
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::OnceLock;
 
 /// Floor of the committed dense-stack size, as a bit-variable count: the
 /// smallest embedded Ligerito security config is `m22` (`2^15` packed
@@ -165,7 +178,7 @@ impl<'r> UnionInstance<'r> {
 
     /// Word range of the element region inside the padded union buffers.
     /// Empty when there are no element types.
-    pub fn element_word_range(&self) -> core::ops::Range<usize> {
+    pub fn element_word_range(&self) -> Range<usize> {
         if !self.has_element() {
             return 0..0;
         }
@@ -347,7 +360,7 @@ impl<'r> UnionInstance<'r> {
     /// rotates).
     pub fn commit_lanes(&self, log_batch_size: usize) -> Option<usize> {
         let log_dim = self.dense_m() - 7 - log_batch_size;
-        let t = crate::pcs::dense_lanes(self.dense_words(), log_batch_size, log_dim);
+        let t = dense_lanes(self.dense_words(), log_batch_size, log_dim);
         (t < 1usize << log_batch_size).then_some(t)
     }
 
@@ -420,7 +433,7 @@ impl<'r> UnionInstance<'r> {
         // ~3.1 ms. The loop below writes `[0, dense_words)` exactly, so only
         // the power-of-two pad tail needs zeroing.
         let dense = self.dense_words();
-        let mut q = crate::scratch::take_f128(self.committed_words());
+        let mut q = take_f128(self.committed_words());
         q[dense..]
             .par_chunks_mut(1 << 16)
             .for_each(|c| c.fill(F128::ZERO));
@@ -535,7 +548,7 @@ impl<'r> UnionInstance<'r> {
         let mut suffix = Vec::with_capacity(x_outer.len() + r_inner_rest.len() - 1 + frozen);
         suffix.extend_from_slice(x_outer);
         suffix.extend_from_slice(&r_inner_rest[1..]);
-        suffix.extend(std::iter::repeat_n(F128::ZERO, frozen));
+        suffix.extend(repeat_n(F128::ZERO, frozen));
         QuirkyPoint {
             z_skip: r_inner_skip,
             x_inner_rest: vec![r_inner_rest[0]],
@@ -552,7 +565,7 @@ impl<'r> UnionInstance<'r> {
         let frozen = self.boolean_frozen_high();
         let mut x_outer = Vec::with_capacity(r_rest.len() - 1 + frozen);
         x_outer.extend_from_slice(&r_rest[1..]);
-        x_outer.extend(std::iter::repeat_n(F128::ZERO, frozen));
+        x_outer.extend(repeat_n(F128::ZERO, frozen));
         QuirkyPoint {
             z_skip,
             x_inner_rest: vec![r_rest[0]],
@@ -632,7 +645,7 @@ impl<'r> UnionInstance<'r> {
     // -----------------------------------------------------------------------
 
     /// Word range of slot `t`'s aligned block in the padded union buffers.
-    pub fn slot_word_range(&self, t: usize) -> core::ops::Range<usize> {
+    pub fn slot_word_range(&self, t: usize) -> Range<usize> {
         let slot = &self.registry().slots()[t];
         let start = slot.offset >> 7;
         start..start + (1usize << (slot.m_slot - 7))
@@ -656,19 +669,14 @@ impl<'r> UnionInstance<'r> {
     pub fn take_witness_buffers(
         &self,
         padding_unread: bool,
-    ) -> (
-        Vec<F128>,
-        Vec<F128>,
-        Vec<F128>,
-        crate::union::WitnessBufMode,
-    ) {
+    ) -> (Vec<F128>, Vec<F128>, Vec<F128>, WitnessBufMode) {
         let len = self.packed_len();
         if padding_unread {
             return (
-                crate::scratch::take_f128(len),
-                crate::scratch::take_f128(len),
-                crate::scratch::take_f128(len),
-                crate::union::WitnessBufMode::PooledDirty,
+                take_f128(len),
+                take_f128(len),
+                take_f128(len),
+                WitnessBufMode::PooledDirty,
             );
         }
         if self.dense_words() * 2 <= len {
@@ -676,19 +684,15 @@ impl<'r> UnionInstance<'r> {
                 crate::alloc_zeroed_vec(len),
                 crate::alloc_zeroed_vec(len),
                 crate::alloc_zeroed_vec(len),
-                crate::union::WitnessBufMode::FreshZeroed,
+                WitnessBufMode::FreshZeroed,
             );
         }
-        let mut bufs = [
-            crate::scratch::take_f128(len),
-            crate::scratch::take_f128(len),
-            crate::scratch::take_f128(len),
-        ];
+        let mut bufs = [take_f128(len), take_f128(len), take_f128(len)];
         for buf in &mut bufs {
             self.zero_gaps(buf);
         }
         let [z, a, b] = bufs;
-        (z, a, b, crate::union::WitnessBufMode::PooledZeroed)
+        (z, a, b, WitnessBufMode::PooledZeroed)
     }
 
     /// A fully zeroed padded union buffer from the scratch pool — resident
@@ -696,7 +700,7 @@ impl<'r> UnionInstance<'r> {
     fn take_zeroed_buffer(&self) -> Vec<F128> {
         use rayon::prelude::*;
 
-        let mut buf = crate::scratch::take_f128(self.packed_len());
+        let mut buf = take_f128(self.packed_len());
         buf.par_chunks_mut(1 << 16).for_each(|c| c.fill(F128::ZERO));
         buf
     }
@@ -734,16 +738,17 @@ impl<'r> UnionInstance<'r> {
         b: &'d mut [F128],
         elide_padding_writes: bool,
     ) -> Vec<SlotWitnessDest<'d>> {
-        for buf in [&*z, &*a, &*b] {
-            assert_eq!(buf.len(), self.packed_len(), "padded buffer length");
-        }
         /// Carve `words` off `rest` after skipping `skip`, keeping the
         /// caller's lifetime (`mem::take` hands the borrow over wholesale).
         fn carve<'d>(rest: &mut &'d mut [F128], skip: usize, words: usize) -> &'d mut [F128] {
-            let (head, tail) = core::mem::take(rest).split_at_mut(skip + words);
+            let (head, tail) = take(rest).split_at_mut(skip + words);
             *rest = tail;
             &mut head[skip..]
         }
+        for buf in [&*z, &*a, &*b] {
+            assert_eq!(buf.len(), self.packed_len(), "padded buffer length");
+        }
+
         let (mut zr, mut ar, mut br) = (z, a, b);
         let mut cursor = 0usize;
         let mut dests = Vec::with_capacity(self.registry().num_types());
@@ -1005,8 +1010,8 @@ pub struct SlotWitnessDest<'d> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::r1cs::{BlockR1cs, WitnessLayout};
     use crate::r1cs::SparseBinaryMatrix;
+    use crate::r1cs::{BlockR1cs, WitnessLayout};
 
     /// Empty matrix stub — nothing here applies the matrices (same practice
     /// as the schedule.rs layout tests).
@@ -1043,8 +1048,8 @@ mod tests {
             c_0: stub(),
             layout: WitnessLayout::BatchMajor,
             const_pin: None,
-            digest_cache: std::sync::OnceLock::new(),
-            csc_cache: std::sync::OnceLock::new(),
+            digest_cache: OnceLock::new(),
+            csc_cache: OnceLock::new(),
         }
     }
 
@@ -1350,11 +1355,8 @@ mod tests {
         assert!(q[cursor..].iter().all(|w| *w == F128::ZERO), "pad tail");
         // unrank ≡ compaction: every dense index maps back to the padded
         // word it was copied from.
-        let params = crate::pcs::jagged::JaggedParams::from_heights(
-            &union.jagged_heights(),
-            union.n_log(),
-            union.dense_m() - 7,
-        );
+        let params =
+            JaggedParams::from_heights(&union.jagged_heights(), union.n_log(), union.dense_m() - 7);
         for e in 0..union.dense_words() as u64 {
             let (row, col) = params.unrank(e);
             assert_eq!(q[e as usize], z[(col << 3) + row], "unrank at {e}");
@@ -1605,9 +1607,7 @@ mod tests {
         for y in 0..k {
             b.free_wire(y);
         }
-        TableType::element(std::sync::Arc::new(
-            b.build().expect("free wires are valid"),
-        ))
+        TableType::element(Arc::new(b.build().expect("free wires are valid")))
     }
 
     /// A boolean-only registry's `boolean_padding_spec` IS its `padding_spec`
@@ -1709,7 +1709,7 @@ mod tests {
         // The padding run-list: an explicit zero run for the class gap, and
         // the element slot's two runs exactly like a boolean slot's.
         let runs = union.padding_spec();
-        let cols = |n_blocks, useful| crate::zerocheck::PaddingRun {
+        let cols = |n_blocks, useful| PaddingRun {
             k_log: 7 + 3,
             useful_bits_per_block: useful,
             n_blocks,
@@ -1852,11 +1852,8 @@ mod tests {
         assert!(q[cursor..].iter().all(|w| *w == F128::ZERO), "pad tail");
 
         // unrank ≡ compaction across the class boundary too.
-        let params = crate::pcs::jagged::JaggedParams::from_heights(
-            &union.jagged_heights(),
-            union.n_log(),
-            union.dense_m() - 7,
-        );
+        let params =
+            JaggedParams::from_heights(&union.jagged_heights(), union.n_log(), union.dense_m() - 7);
         for e in 0..union.dense_words() as u64 {
             let (row, col) = params.unrank(e);
             assert_eq!(q[e as usize], z[(col << 3) + row], "unrank at {e}");

--- a/crates/flock-core/src/verifier.rs
+++ b/crates/flock-core/src/verifier.rs
@@ -4,12 +4,33 @@
 //! witness commitment.
 
 use crate::challenger::Challenger;
+use crate::circuit::Circuit;
+use crate::circuit::WiringError;
+use crate::circuit::WiringProof;
+use crate::circuit::verify_wiring;
+use crate::element_r1cs::union::Claims;
+use crate::element_r1cs::union::ElementAssertion;
+use crate::element_r1cs::union::Proof;
+use crate::element_r1cs::union::VerifyError as ElementVerifyError;
+use crate::element_r1cs::union::verify_deferred;
 use crate::field::F128;
 use crate::lincheck;
+use crate::pcs::MergedOpenProof;
+use crate::pcs::PcsParams;
+use crate::pcs::VerifyErrorOpen;
 use crate::pcs::{self, Commitment};
+use crate::proof::BooleanPiopProof;
+use crate::proof::R1csProofCircuitMerged;
+use crate::proof::R1csProofMergedLigerito;
+use crate::proof::R1csProofMixedClassMerged;
+use crate::proof::UnionClassClaims;
+use crate::proof::bind_statement;
 use crate::proof::{R1csClaim, R1csProofLigerito, ZClaim};
 use crate::r1cs::BlockR1cs;
+use crate::union::UnionInstance;
 use crate::zerocheck;
+use std::env::var;
+use std::time::Instant;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum VerifyError {
@@ -20,13 +41,13 @@ pub enum VerifyError {
     /// The jagged-path batched opening rejected (see [`verify_ligerito_jagged`]).
     PcsOpen(pcs::VerifyErrorOpen),
     /// The element-region PIOP rejected.
-    Element(crate::element_r1cs::union::VerifyError),
+    Element(ElementVerifyError),
     /// A mixed-class proof carries a class sub-proof the registry has no type
     /// for, or omits one it does — the statement and the proof disagree on
     /// which PIOPs ran.
     ClassMismatch,
     /// The wiring (copy-constraint) argument rejected.
-    Wiring(crate::circuit::WiringError),
+    Wiring(WiringError),
     /// The circuit and the union instance are not the same statement: a
     /// different registry, or gate counts that are not the union's declared
     /// counts. A rejection, not a panic — both come from the caller.
@@ -75,7 +96,7 @@ fn verifier_threads() -> usize {
     use std::sync::OnceLock;
     static N: OnceLock<usize> = OnceLock::new();
     *N.get_or_init(|| {
-        std::env::var("FLOCK_VERIFY_THREADS")
+        var("FLOCK_VERIFY_THREADS")
             .ok()
             .and_then(|v| v.parse::<usize>().ok())
             .filter(|&n| n > 0)
@@ -107,7 +128,7 @@ pub fn verify_ligerito<Ch: Challenger>(
     commitment: &Commitment,
     proof: &R1csProofLigerito,
     lincheck_circuit: &dyn lincheck::LincheckCircuit,
-    pcs_params: &crate::pcs::PcsParams,
+    pcs_params: &PcsParams,
     challenger: &mut Ch,
 ) -> Result<R1csClaim, VerifyError> {
     let (ab, c) = verify_core(
@@ -140,14 +161,14 @@ pub fn verify_ligerito_timed<Ch: Challenger>(
     commitment: &Commitment,
     proof: &R1csProofLigerito,
     lincheck_circuit: &dyn lincheck::LincheckCircuit,
-    pcs_params: &crate::pcs::PcsParams,
+    pcs_params: &PcsParams,
     challenger: &mut Ch,
 ) -> Result<(R1csClaim, VerifyPhaseTimings), VerifyError> {
     use std::time::Instant;
     // PIOP replay (bind + zerocheck + lincheck) on the 1-thread pool.
     let (ab, c, zerocheck_s, lincheck_s) =
         verifier_pool().install(|| -> Result<(ZClaim, ZClaim, f64, f64), VerifyError> {
-            crate::proof::bind_statement(challenger, r1cs, commitment);
+            bind_statement(challenger, r1cs, commitment);
             let t0 = Instant::now();
             let zc_claim = zerocheck::verify(r1cs.m, &proof.zerocheck, challenger)
                 .map_err(VerifyError::Zerocheck)?;
@@ -182,7 +203,7 @@ pub fn verify_ligerito_timed<Ch: Challenger>(
             Ok((ab, c, zerocheck_s, lincheck_s))
         })?;
 
-    let t0 = std::time::Instant::now();
+    let t0 = Instant::now();
     verify_claims_ligerito(
         commitment,
         &[ab.clone(), c.clone()],
@@ -213,7 +234,7 @@ enum UnionVerifyBinding<'a> {
     /// The circuit binding: [`UnionVerifyBinding::Mixed`] plus the circuit
     /// digest and the public words.
     Circuit {
-        circuit: &'a crate::circuit::Circuit,
+        circuit: &'a Circuit,
         public: &'a [F128],
     },
 }
@@ -225,11 +246,11 @@ enum UnionVerifyBinding<'a> {
 /// on `commitment.params.num_lanes`, which the shared body's
 /// params-equality check pins to the count-derived value).
 pub fn verify_ligerito_union<Ch: Challenger>(
-    union: &crate::union::UnionInstance<'_>,
+    union: &UnionInstance<'_>,
     circuits: &[&dyn lincheck::LincheckCircuit],
     commitment: &Commitment,
-    proof: &crate::proof::R1csProofMergedLigerito,
-    pcs_params: &crate::pcs::PcsParams,
+    proof: &R1csProofMergedLigerito,
+    pcs_params: &PcsParams,
     challenger: &mut Ch,
 ) -> Result<R1csClaim, VerifyError> {
     // Mirror of the prove-side guard: this entry consumes `R1csClaim` —
@@ -242,8 +263,8 @@ pub fn verify_ligerito_union<Ch: Challenger>(
     // Repackage as a boolean-only mixed-class proof and run the one shared
     // verify body (the two-body split died with the jagged transport). The
     // clone is a few hundred KB against a multi-ms verify.
-    let mixed = crate::proof::R1csProofMixedClassMerged {
-        boolean: Some(crate::proof::BooleanPiopProof {
+    let mixed = R1csProofMixedClassMerged {
+        boolean: Some(BooleanPiopProof {
             zerocheck: proof.zerocheck.clone(),
             lincheck: proof.lincheck.clone(),
         }),
@@ -267,15 +288,15 @@ pub fn verify_ligerito_union<Ch: Challenger>(
 /// transport carries the same way it carries the element class's.
 #[allow(clippy::too_many_arguments)]
 pub fn verify_ligerito_union_circuit<Ch: Challenger>(
-    union: &crate::union::UnionInstance<'_>,
-    circuit: &crate::circuit::Circuit,
+    union: &UnionInstance<'_>,
+    circuit: &Circuit,
     public: &[F128],
     circuits: &[&dyn lincheck::LincheckCircuit],
     commitment: &Commitment,
-    proof: &crate::proof::R1csProofCircuitMerged,
-    pcs_params: &crate::pcs::PcsParams,
+    proof: &R1csProofCircuitMerged,
+    pcs_params: &PcsParams,
     challenger: &mut Ch,
-) -> Result<crate::proof::UnionClassClaims, VerifyError> {
+) -> Result<UnionClassClaims, VerifyError> {
     if !circuit.check_instance(union) || public.len() != circuit.num_public() {
         return Err(VerifyError::CircuitMismatch);
     }
@@ -330,15 +351,15 @@ pub fn verify_ligerito_union_circuit<Ch: Challenger>(
 /// accumulating must use [`verify_ligerito_union_circuit`].
 #[allow(clippy::too_many_arguments)]
 pub fn verify_ligerito_union_circuit_deferred<Ch: Challenger>(
-    union: &crate::union::UnionInstance<'_>,
-    circuit: &crate::circuit::Circuit,
+    union: &UnionInstance<'_>,
+    circuit: &Circuit,
     public: &[F128],
     circuits: &[&dyn lincheck::LincheckCircuit],
     commitment: &Commitment,
-    proof: &crate::proof::R1csProofCircuitMerged,
-    pcs_params: &crate::pcs::PcsParams,
+    proof: &R1csProofCircuitMerged,
+    pcs_params: &PcsParams,
     challenger: &mut Ch,
-) -> Result<(crate::proof::UnionClassClaims, DeferredMatrixWork), VerifyError> {
+) -> Result<(UnionClassClaims, DeferredMatrixWork), VerifyError> {
     if !circuit.check_instance(union) || public.len() != circuit.num_public() {
         return Err(VerifyError::CircuitMismatch);
     }
@@ -379,14 +400,14 @@ pub fn verify_ligerito_union_circuit_deferred<Ch: Challenger>(
 /// The merged transport's verification, shared by the mixed-class and circuit
 /// entries: the boolean pair ring-switched, everything else packed-direct.
 fn verify_merged_opening<Ch: Challenger>(
-    union: &crate::union::UnionInstance<'_>,
+    union: &UnionInstance<'_>,
     commitment: &Commitment,
-    claims: &crate::proof::UnionClassClaims,
+    claims: &UnionClassClaims,
     packed_direct_points: &[(Vec<F128>, F128)],
-    pcs_open: &crate::pcs::MergedOpenProof,
-    pcs_params: &crate::pcs::PcsParams,
+    pcs_open: &MergedOpenProof,
+    pcs_params: &PcsParams,
     challenger: &mut Ch,
-) -> Result<crate::proof::UnionClassClaims, VerifyError> {
+) -> Result<UnionClassClaims, VerifyError> {
     let cl: Vec<ZClaim> = match &claims.boolean {
         Some(c) => vec![c.ab.clone(), c.c.clone()],
         None => Vec::new(),
@@ -439,13 +460,13 @@ fn verify_merged_opening<Ch: Challenger>(
 /// `x ↦ γ·x` — indistinguishable, to its per-claim weight builder, from a
 /// ring-switched claim's Φ-fold.
 pub fn verify_ligerito_union_mixed_class<Ch: Challenger>(
-    union: &crate::union::UnionInstance<'_>,
+    union: &UnionInstance<'_>,
     circuits: &[&dyn lincheck::LincheckCircuit],
     commitment: &Commitment,
-    proof: &crate::proof::R1csProofMixedClassMerged,
-    pcs_params: &crate::pcs::PcsParams,
+    proof: &R1csProofMixedClassMerged,
+    pcs_params: &PcsParams,
     challenger: &mut Ch,
-) -> Result<crate::proof::UnionClassClaims, VerifyError> {
+) -> Result<UnionClassClaims, VerifyError> {
     if proof.boolean.is_some() != (union.num_boolean() > 0)
         || proof.element.is_some() != union.has_element()
     {
@@ -532,13 +553,13 @@ pub fn verify_ligerito_union_mixed_class<Ch: Challenger>(
 /// lincheck is simply wrong still returns `Ok` here, so a caller that is not
 /// accumulating must use [`verify_ligerito_union_mixed_class`].
 pub fn verify_ligerito_union_mixed_class_deferred<Ch: Challenger>(
-    union: &crate::union::UnionInstance<'_>,
+    union: &UnionInstance<'_>,
     circuits: &[&dyn lincheck::LincheckCircuit],
     commitment: &Commitment,
-    proof: &crate::proof::R1csProofMixedClassMerged,
-    pcs_params: &crate::pcs::PcsParams,
+    proof: &R1csProofMixedClassMerged,
+    pcs_params: &PcsParams,
     challenger: &mut Ch,
-) -> Result<(crate::proof::UnionClassClaims, DeferredMatrixWork), VerifyError> {
+) -> Result<(UnionClassClaims, DeferredMatrixWork), VerifyError> {
     if proof.boolean.is_some() != (union.num_boolean() > 0)
         || proof.element.is_some() != union.has_element()
     {
@@ -618,14 +639,14 @@ pub fn verify_ligerito_union_mixed_class_deferred<Ch: Challenger>(
 /// Runs on the 1-thread verifier pool, like every other verify core.
 #[allow(clippy::too_many_arguments)]
 fn verify_union_piops<Ch: Challenger>(
-    union: &crate::union::UnionInstance<'_>,
+    union: &UnionInstance<'_>,
     binding: UnionVerifyBinding<'_>,
     circuits: &[&dyn lincheck::LincheckCircuit],
     commitment: &Commitment,
-    boolean: Option<&crate::proof::BooleanPiopProof>,
-    element: Option<&crate::element_r1cs::union::Proof>,
-    wiring: Option<&crate::circuit::WiringProof>,
-    pcs_params: &crate::pcs::PcsParams,
+    boolean: Option<&BooleanPiopProof>,
+    element: Option<&Proof>,
+    wiring: Option<&WiringProof>,
+    pcs_params: &PcsParams,
     challenger: &mut Ch,
 ) -> Result<UnionPiopOut, VerifyError> {
     // The commitment is to the DENSE stack q (M4/M5): PcsParams.m is the
@@ -648,9 +669,7 @@ fn verify_union_piops<Ch: Challenger>(
         || commitment.params.log_inv_rate != pcs_params.log_inv_rate
         || commitment.params.num_ntts() != pcs_params.num_ntts()
     {
-        return Err(VerifyError::PcsOpen(
-            crate::pcs::VerifyErrorOpen::Ligerito,
-        ));
+        return Err(VerifyError::PcsOpen(VerifyErrorOpen::Ligerito));
     }
     // Verification is single-threaded; run the PIOP replay on the dedicated
     // 1-thread pool (verify_claims_jagged_ligerito installs it itself).
@@ -663,7 +682,7 @@ fn verify_union_piops<Ch: Challenger>(
         }
 
         let mut matrix: Option<lincheck::MatrixAssertion> = None;
-        let mut el_matrix: Option<crate::element_r1cs::union::ElementAssertion> = None;
+        let mut el_matrix: Option<ElementAssertion> = None;
         let bool_claim = match boolean {
             Some(piop) => {
                 // The boolean PIOP runs over the BOOLEAN REGION only — the
@@ -713,8 +732,7 @@ fn verify_union_piops<Ch: Challenger>(
         // `*_deferred` entry really does defer BOTH classes.
         let el_claim = match element {
             Some(p) => {
-                let (c, a) = crate::element_r1cs::union::verify_deferred(union, p, challenger)
-                    .map_err(VerifyError::Element)?;
+                let (c, a) = verify_deferred(union, p, challenger).map_err(VerifyError::Element)?;
                 el_matrix = Some(a);
                 Some(c)
             }
@@ -722,7 +740,7 @@ fn verify_union_piops<Ch: Challenger>(
         };
         let mut packed_direct = el_claim
             .as_ref()
-            .map(|c: &crate::element_r1cs::union::Claims| {
+            .map(|c: &Claims| {
                 vec![
                     (c.c_point.clone(), c.c_value),
                     (c.lc_point.clone(), c.lc_value),
@@ -737,8 +755,8 @@ fn verify_union_piops<Ch: Challenger>(
             let proof = wiring.ok_or(VerifyError::CircuitMismatch)?;
             #[cfg(feature = "mul-count")]
             let wiring_start = crate::field::gf2_128::op_count::snapshot();
-            let gather = crate::circuit::verify_wiring(circuit, public, proof, challenger)
-                .map_err(VerifyError::Wiring)?;
+            let gather =
+                verify_wiring(circuit, public, proof, challenger).map_err(VerifyError::Wiring)?;
             #[cfg(feature = "mul-count")]
             if std::env::var("MUL_TRACE").is_ok() {
                 let e = crate::field::gf2_128::op_count::snapshot();
@@ -755,7 +773,7 @@ fn verify_union_piops<Ch: Challenger>(
         }
 
         Ok((
-            crate::proof::UnionClassClaims {
+            UnionClassClaims {
                 boolean: bool_claim,
                 element: el_claim,
             },
@@ -771,10 +789,10 @@ fn verify_union_piops<Ch: Challenger>(
 /// ran — the [`lincheck::MatrixAssertion`] carrying its undischarged matrix
 /// work.
 type UnionPiopOut = (
-    crate::proof::UnionClassClaims,
+    UnionClassClaims,
     Vec<(Vec<F128>, F128)>,
     Option<lincheck::MatrixAssertion>,
-    Option<crate::element_r1cs::union::ElementAssertion>,
+    Option<ElementAssertion>,
 );
 
 /// Both classes' undischarged matrix work, as a `*_deferred` entry returns
@@ -782,7 +800,7 @@ type UnionPiopOut = (
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DeferredMatrixWork {
     pub boolean: Option<lincheck::MatrixAssertion>,
-    pub element: Option<crate::element_r1cs::union::ElementAssertion>,
+    pub element: Option<ElementAssertion>,
 }
 
 /// Verify a batched PCS opening over an arbitrary list of `ẑ`-claims — the
@@ -793,7 +811,7 @@ pub fn verify_claims_ligerito<Ch: Challenger>(
     commitment: &Commitment,
     claims: &[ZClaim],
     pcs_open: &pcs::BatchOpeningProofLigerito,
-    pcs_params: &crate::pcs::PcsParams,
+    pcs_params: &PcsParams,
     challenger: &mut Ch,
 ) -> Result<(), pcs::VerifyError> {
     // Verification is single-threaded; run the body on the dedicated 1-thread pool.
@@ -806,7 +824,7 @@ fn verify_claims_ligerito_inner<Ch: Challenger>(
     commitment: &Commitment,
     claims: &[ZClaim],
     pcs_open: &pcs::BatchOpeningProofLigerito,
-    pcs_params: &crate::pcs::PcsParams,
+    pcs_params: &PcsParams,
     challenger: &mut Ch,
 ) -> Result<(), pcs::VerifyError> {
     let z_skips: Vec<F128> = claims.iter().map(|c| c.point.z_skip).collect();
@@ -868,7 +886,7 @@ fn verify_core_inner<Ch: Challenger>(
     lincheck_circuit: &dyn lincheck::LincheckCircuit,
     challenger: &mut Ch,
 ) -> Result<(ZClaim, ZClaim), VerifyError> {
-    let trace = std::env::var("VERIFY_TRACE").is_ok();
+    let trace = var("VERIFY_TRACE").is_ok();
     let fmt = |s: f64| -> String {
         let ms = s * 1000.0;
         if ms < 1.0 {
@@ -879,8 +897,8 @@ fn verify_core_inner<Ch: Challenger>(
     };
 
     // ---- Bind FS transcript to the statement (mirrors prover::prove).
-    let t = std::time::Instant::now();
-    crate::proof::bind_statement(challenger, r1cs, commitment);
+    let t = Instant::now();
+    bind_statement(challenger, r1cs, commitment);
     if trace {
         eprintln!(
             "      [vco] bind_statement: {}",
@@ -889,7 +907,7 @@ fn verify_core_inner<Ch: Challenger>(
     }
 
     // ---- Zerocheck.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let zc_claim =
         zerocheck::verify(r1cs.m, zerocheck_proof, challenger).map_err(VerifyError::Zerocheck)?;
     if trace {
@@ -904,7 +922,7 @@ fn verify_core_inner<Ch: Challenger>(
     let x_ab = r1cs.x_ab_from_mlv(zc_claim.z, &zc_claim.mlv_challenges);
 
     // ---- Lincheck. v_a, v_b come from the zerocheck's final â, b̂ evals.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let lc_claim = lincheck::verify(
         r1cs.m,
         r1cs.k_log,

--- a/crates/flock-core/src/zerocheck.rs
+++ b/crates/flock-core/src/zerocheck.rs
@@ -18,7 +18,16 @@
 use crate::challenger::Challenger;
 use crate::field::{F8, F128};
 use crate::ntt::{AdditiveNttGf8, InvNttTableByteSingleGf8};
+use crate::scratch::give_f128;
+use crate::scratch::take_f128;
+use crate::zerocheck::univariate_skip_optimized::round1_shift_reduce_extract_c_packed_padded_with_s_hat_v;
 use serde::{Deserialize, Serialize};
+use std::env::var;
+use std::env::var_os;
+use std::mem::replace;
+use std::mem::swap;
+use std::sync::OnceLock;
+use std::time::Instant;
 
 pub mod multilinear;
 pub mod univariate_skip;
@@ -56,9 +65,9 @@ pub const SPARSE_TAIL_GATE: usize = 1;
 /// tuning knob for A/B experiments; the constant above is the default.
 /// Value-identical either way (the sparse kernels drop only zero terms).
 fn sparse_tail_gate() -> usize {
-    static GATE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    static GATE: OnceLock<usize> = OnceLock::new();
     *GATE.get_or_init(|| {
-        std::env::var("FLOCK_SPARSE_GATE")
+        var("FLOCK_SPARSE_GATE")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(SPARSE_TAIL_GATE)
@@ -368,8 +377,9 @@ fn prove_packed_padded_inner<C: Challenger>(
     capture_s_hat_v_c: bool,
     challenger: &mut C,
 ) -> (ZerocheckProof, ZerocheckClaim, Option<Vec<F128>>) {
+    const N_INNER: usize = 7;
     let k_skip = K_SKIP;
-    const N_INNER: usize = 7; // 3 small + 4 medium fixed-constant eq dims
+    // 3 small + 4 medium fixed-constant eq dims
     assert!(
         m >= k_skip + N_INNER,
         "prove requires m >= k_skip + N_INNER (= {})",
@@ -411,23 +421,15 @@ fn prove_packed_padded_inner<C: Challenger>(
     // C_s factor analysis in `univariate_skip_optimized`). The wire format
     // must be in "naive" convention so the verifier doesn't need to know
     // about this internal optimization; we restore the C_s factor here.
-    let zc_timing = std::env::var_os("FLOCK_ZC_TIMING").is_some();
-    let t_round1 = std::time::Instant::now();
+    let zc_timing = var_os("FLOCK_ZC_TIMING").is_some();
+    let t_round1 = Instant::now();
     let ntt_s = AdditiveNttGf8::new(k_skip, F8::ZERO);
     let ntt_l = AdditiveNttGf8::new(k_skip, F8(1u8 << k_skip));
     let inv_table = InvNttTableByteSingleGf8::new(&ntt_s, &ntt_l);
     let (round1_ab_opt, round1_c_opt, s_hat_v_c) = if capture_s_hat_v_c {
-        let (ab, c, s) =
-            crate::zerocheck::univariate_skip_optimized::round1_shift_reduce_extract_c_packed_padded_with_s_hat_v(
-                a_packed,
-                b_packed,
-                c_packed,
-                m,
-                k_skip,
-                &r,
-                &inv_table,
-                padding,
-            );
+        let (ab, c, s) = round1_shift_reduce_extract_c_packed_padded_with_s_hat_v(
+            a_packed, b_packed, c_packed, m, k_skip, &r, &inv_table, padding,
+        );
         (ab, c, Some(s))
     } else {
         let (ab, c) = round1_shift_reduce_extract_c_packed_padded(
@@ -464,7 +466,7 @@ fn prove_packed_padded_inner<C: Challenger>(
     // Convention A wrapping: pass `mlv_arg[0] = ONE` so the function's output
     // `mlv_arg[0] · G(1)` becomes the bare `G(1)` we send on the wire. The
     // verifier samples ρ_1 after observing this message.
-    let t_round2 = std::time::Instant::now();
+    let t_round2 = Instant::now();
     let fold_table = UniSkipFoldTable::new(k_skip, z);
     let mut mlv_arg = vec![F128::ONE; n_mlv];
     mlv_arg[1..].copy_from_slice(&r[k_skip + 1..]);
@@ -523,7 +525,7 @@ fn prove_packed_padded_inner<C: Challenger>(
             t_round2.elapsed().as_secs_f64() * 1e3
         );
     }
-    let t_tail = std::time::Instant::now();
+    let t_tail = Instant::now();
     let mut multilinear_msgs = Vec::with_capacity(n_mlv);
     multilinear_msgs.push((msg_1, msg_inf));
     challenger.observe_f128(msg_1);
@@ -546,10 +548,7 @@ fn prove_packed_padded_inner<C: Challenger>(
     // output); only needed when the first round is actually fused.
     let n_in = a_mlv.len();
     let (mut a_nxt, mut b_nxt) = if n_in >= 1024 {
-        (
-            crate::scratch::take_f128(n_in / 2),
-            crate::scratch::take_f128(n_in / 2),
-        )
+        (take_f128(n_in / 2), take_f128(n_in / 2))
     } else {
         (Vec::new(), Vec::new())
     };
@@ -585,8 +584,8 @@ fn prove_packed_padded_inner<C: Challenger>(
             // padded buffer and zero the rest.
             let a_full = multilinear::expand_to_dense(&a_mlv, &st, domain);
             let b_full = multilinear::expand_to_dense(&b_mlv, &st, domain);
-            crate::scratch::give_f128(std::mem::replace(&mut a_mlv, a_full));
-            crate::scratch::give_f128(std::mem::replace(&mut b_mlv, b_full));
+            give_f128(replace(&mut a_mlv, a_full));
+            give_f128(replace(&mut b_mlv, b_full));
             sparse_dirty = false;
         }
 
@@ -596,10 +595,10 @@ fn prove_packed_padded_inner<C: Challenger>(
             // only round outward by one slot per interval end.
             let cap = st.len() + 2 * st.intervals().len() + 2;
             if a_nxt.len() < cap {
-                crate::scratch::give_f128(a_nxt);
-                crate::scratch::give_f128(b_nxt);
-                a_nxt = crate::scratch::take_f128(cap);
-                b_nxt = crate::scratch::take_f128(cap);
+                give_f128(a_nxt);
+                give_f128(b_nxt);
+                a_nxt = take_f128(cap);
+                b_nxt = take_f128(cap);
             }
             let (m1, mi, store_out) = fold_and_round_pair_sparse_into(
                 &a_mlv,
@@ -611,8 +610,8 @@ fn prove_packed_padded_inner<C: Challenger>(
                 st,
                 domain,
             );
-            std::mem::swap(&mut a_mlv, &mut a_nxt);
-            std::mem::swap(&mut b_mlv, &mut b_nxt);
+            swap(&mut a_mlv, &mut a_nxt);
+            swap(&mut b_mlv, &mut b_nxt);
             a_mlv.truncate(store_out.len());
             b_mlv.truncate(store_out.len());
             store = Some(store_out);
@@ -632,8 +631,8 @@ fn prove_packed_padded_inner<C: Challenger>(
             // folded size. The old (larger) buffer becomes scratch; we only
             // ever write its leading `half` slots next round, so its stale
             // length is harmless.
-            std::mem::swap(&mut a_mlv, &mut a_nxt);
-            std::mem::swap(&mut b_mlv, &mut b_nxt);
+            swap(&mut a_mlv, &mut a_nxt);
+            swap(&mut b_mlv, &mut b_nxt);
             a_mlv.truncate(half);
             b_mlv.truncate(half);
             (m1, mi)
@@ -679,10 +678,10 @@ fn prove_packed_padded_inner<C: Challenger>(
 
     // Recycle the four tail buffers (the two len-1 survivors still own their
     // full round-2 capacity) for the next phase/prove.
-    crate::scratch::give_f128(a_mlv);
-    crate::scratch::give_f128(b_mlv);
-    crate::scratch::give_f128(a_nxt);
-    crate::scratch::give_f128(b_nxt);
+    give_f128(a_mlv);
+    give_f128(b_mlv);
+    give_f128(a_nxt);
+    give_f128(b_nxt);
 
     if zc_timing {
         eprintln!(
@@ -725,9 +724,9 @@ pub fn verify<C: Challenger>(
     proof: &ZerocheckProof,
     challenger: &mut C,
 ) -> Result<ZerocheckClaim, VerifyError> {
+    const N_INNER: usize = 7;
     let m = log_n;
     let k_skip = K_SKIP;
-    const N_INNER: usize = 7;
 
     if m < k_skip + N_INNER {
         return Err(VerifyError::LogNTooSmall { log_n: m, k_skip });

--- a/crates/flock-core/src/zerocheck/multilinear.rs
+++ b/crates/flock-core/src/zerocheck/multilinear.rs
@@ -33,6 +33,8 @@
 //! Verifier reconstructs `G(0)` from the running claim via
 //! `current_claim = (1+r_now)·G(0) + r_now·G(1)`.
 
+use crate::bits::lowest_one;
+use crate::field::f128_slice::fold_pairs;
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx512f",
@@ -40,8 +42,13 @@
 ))]
 use crate::field::gf2_128::x86_64::{WideGhashX4, f128x4_loadu, f128x4_set, ghash_mul_x4};
 use crate::field::{F128, F256Unreduced, PHI_8_TABLE};
+use crate::scratch::take_f128;
+use crate::zerocheck::PaddingRun;
 use crate::zerocheck::PaddingSpec;
 use crate::zerocheck::univariate_skip::{SplitEqGhash, build_eq, pack_bits};
+use std::array::from_fn;
+use std::mem::take;
+use std::ops::Range;
 
 mod kernels;
 
@@ -67,7 +74,7 @@ use kernels::x86_64::{fold_and_message_x86_avx512, fold_round2_pair_x86_unchecke
 /// when `useful_bits` is odd in chunk units) is INSIDE the useful range and
 /// processed normally — its padding side has value 0 so the message
 /// contribution is naturally correct.
-fn round2_pair_skip(run: &crate::zerocheck::PaddingRun, k_skip: usize) -> (usize, usize) {
+fn round2_pair_skip(run: &PaddingRun, k_skip: usize) -> (usize, usize) {
     if run.k_log <= k_skip + 1 {
         return (0, usize::MAX);
     }
@@ -111,7 +118,7 @@ fn subspace_denominator_pair(dim: usize) -> (F128, F128) {
     use std::sync::OnceLock;
     static CACHE: OnceLock<[(F128, F128); 9]> = OnceLock::new();
     let table = CACHE.get_or_init(|| {
-        std::array::from_fn(|d| {
+        from_fn(|d| {
             let den = (1..(1usize << d)).fold(F128::ONE, |acc, i| acc * PHI_8_TABLE[i]);
             (den, den.inv())
         })
@@ -447,7 +454,7 @@ impl UniSkipFoldTable {
                 if (v & (v - 1)) == 0 {
                     continue; // skip powers of 2 (already written)
                 }
-                let lo_bit = crate::bits::lowest_one(v);
+                let lo_bit = lowest_one(v);
                 let parent = v ^ lo_bit;
                 data[j * 256 + v] = data[j * 256 + parent] + data[j * 256 + lo_bit];
             }
@@ -572,7 +579,7 @@ pub fn uni_skip_fold_and_round_pair_optimized_packed_padded(
 pub(crate) fn balanced_interval_tasks(
     live: &[(usize, usize)],
     target: usize,
-) -> (Vec<(usize, usize)>, Vec<std::ops::Range<usize>>) {
+) -> (Vec<(usize, usize)>, Vec<Range<usize>>) {
     debug_assert!(target > 0);
     let mut pieces: Vec<(usize, usize)> = Vec::with_capacity(live.len());
     for &(s, e) in live {
@@ -583,7 +590,7 @@ pub(crate) fn balanced_interval_tasks(
             c = next;
         }
     }
-    let mut tasks: Vec<std::ops::Range<usize>> = Vec::new();
+    let mut tasks: Vec<Range<usize>> = Vec::new();
     let (mut start, mut acc) = (0usize, 0usize);
     for (i, &(s, e)) in pieces.iter().enumerate() {
         acc += e - s;
@@ -878,8 +885,8 @@ where
         Some(iv) => 2 * iv.iter().map(|&(s, e)| e - s).sum::<usize>(),
         None => n_out,
     };
-    let mut a_folded: Vec<F128> = crate::scratch::take_f128(out_len);
-    let mut b_folded: Vec<F128> = crate::scratch::take_f128(out_len);
+    let mut a_folded: Vec<F128> = take_f128(out_len);
+    let mut b_folded: Vec<F128> = take_f128(out_len);
 
     let eq = SplitEqGhash::new(&mlv_challenges[1..]);
     let lo_size = 1usize << eq.n_lo;
@@ -922,9 +929,9 @@ where
                 (&mut a_folded[..], &mut b_folded[..]);
             for t in &tasks {
                 let span: usize = pieces[t.clone()].iter().map(|&(s, e)| 2 * (e - s)).sum();
-                let (a_task, rest) = std::mem::take(&mut a_rem).split_at_mut(span);
+                let (a_task, rest) = take(&mut a_rem).split_at_mut(span);
                 a_rem = rest;
-                let (b_task, rest) = std::mem::take(&mut b_rem).split_at_mut(span);
+                let (b_task, rest) = take(&mut b_rem).split_at_mut(span);
                 b_rem = rest;
                 work.push((&pieces[t.clone()], a_task, b_task));
             }
@@ -1282,8 +1289,8 @@ pub fn fold_and_compute_round_pair_into(
                 // Fold a_in→a_out and b_in→b_out at r_fold. The field layer
                 // selects the architecture kernel; this loop only consumes
                 // the resulting values to build the message.
-                crate::field::f128_slice::fold_pairs(a_in, 0, a_out, r_fold);
-                crate::field::f128_slice::fold_pairs(b_in, 0, b_out, r_fold);
+                fold_pairs(a_in, 0, a_out, r_fold);
+                fold_pairs(b_in, 0, b_out, r_fold);
 
                 let mut p1_acc = F256Unreduced::ZERO;
                 let mut pinf_acc = F256Unreduced::ZERO;
@@ -1570,6 +1577,21 @@ pub fn fold_and_round_pair_sparse_into(
     store_in: &LiveLayout,
     domain: usize,
 ) -> (F128, F128, LiveLayout) {
+    // The pair cover split into tasks of roughly equal LIVE work, each with
+    // its own disjoint output slices — parallel like the dense kernel,
+    // instead of one scalar walk (measured ~3x per element at low
+    // utilization: no cores, no hoisted eq_hi, one reduced multiply per
+    // term). Tasks are cut from the interval list, so their count follows the
+    // live support and not the domain: a fragmented slot schedule (367
+    // intervals at 6.25% utilization, against 2 at full) would otherwise
+    // spawn one near-empty task per interval per round — 6.6K tasks over the
+    // tail against 1.5K for the same live volume when unfragmented.
+    // Within a task the per-hi-run products accumulate UNREDUCED and reduce
+    // once, and eq_hi multiplies the run total — pure reassociation of exact
+    // field algebra (reduction commutes with XOR), so the message stays
+    // byte-identical to the scalar loop and to the dense kernel.
+    const CHUNK: usize = 1 << 12;
+    use rayon::prelude::*;
     assert!(domain.is_power_of_two() && domain >= 8);
     assert_eq!(a.len(), store_in.len());
     assert_eq!(b.len(), store_in.len());
@@ -1594,20 +1616,6 @@ pub fn fold_and_round_pair_sparse_into(
     let store_out = LiveLayout::new(pair_cover.iter().map(|&(s, e)| (2 * s, 2 * e)).collect());
     assert!(a_out.len() >= store_out.len() && b_out.len() >= store_out.len());
 
-    // The pair cover split into tasks of roughly equal LIVE work, each with
-    // its own disjoint output slices — parallel like the dense kernel,
-    // instead of one scalar walk (measured ~3x per element at low
-    // utilization: no cores, no hoisted eq_hi, one reduced multiply per
-    // term). Tasks are cut from the interval list, so their count follows the
-    // live support and not the domain: a fragmented slot schedule (367
-    // intervals at 6.25% utilization, against 2 at full) would otherwise
-    // spawn one near-empty task per interval per round — 6.6K tasks over the
-    // tail against 1.5K for the same live volume when unfragmented.
-    // Within a task the per-hi-run products accumulate UNREDUCED and reduce
-    // once, and eq_hi multiplies the run total — pure reassociation of exact
-    // field algebra (reduction commutes with XOR), so the message stays
-    // byte-identical to the scalar loop and to the dense kernel.
-    const CHUNK: usize = 1 << 12;
     let (pieces, tasks) = balanced_interval_tasks(&pair_cover, CHUNK);
     let mut work: Vec<(&[(usize, usize)], &mut [F128], &mut [F128])> =
         Vec::with_capacity(tasks.len());
@@ -1616,15 +1624,14 @@ pub fn fold_and_round_pair_sparse_into(
         let mut b_rem: &mut [F128] = &mut b_out[..store_out.len()];
         for t in &tasks {
             let span: usize = pieces[t.clone()].iter().map(|&(s, e)| 2 * (e - s)).sum();
-            let (a_task, rest) = std::mem::take(&mut a_rem).split_at_mut(span);
+            let (a_task, rest) = take(&mut a_rem).split_at_mut(span);
             a_rem = rest;
-            let (b_task, rest) = std::mem::take(&mut b_rem).split_at_mut(span);
+            let (b_task, rest) = take(&mut b_rem).split_at_mut(span);
             b_rem = rest;
             work.push((&pieces[t.clone()], a_task, b_task));
         }
     }
 
-    use rayon::prelude::*;
     let (sum1, sum_inf) = work
         .into_par_iter()
         .map(|(task_pieces, a_task, b_task)| {
@@ -1695,7 +1702,7 @@ pub fn fold_and_round_pair_sparse_into(
 /// (`SPARSE_TAIL_GATE > 1`, or the domain drops below the fused threshold).
 pub fn expand_to_dense(compact: &[F128], store: &LiveLayout, domain: usize) -> Vec<F128> {
     debug_assert_eq!(compact.len(), store.len());
-    let mut out = crate::scratch::take_f128(domain);
+    let mut out = take_f128(domain);
     out.fill(F128::ZERO);
     for (i, &(s, e)) in store.intervals().iter().enumerate() {
         let off = store.offset_of(i);

--- a/crates/flock-core/src/zerocheck/univariate_skip_deg4_optimized.rs
+++ b/crates/flock-core/src/zerocheck/univariate_skip_deg4_optimized.rs
@@ -46,6 +46,7 @@
 //! All of these are direct ports of the degree-2 versions and are pure
 //! perf-engineering — the math is settled by the tests in this file.
 
+use core::arch::aarch64::uint8x16_t;
 use std::sync::OnceLock;
 
 use crate::field::gf2_8::gf8_reduce;
@@ -277,10 +278,10 @@ unsafe fn xor_apply_byte_into_4_regs_deg4<
 >(
     table_base: *const u8,
     byte: u8,
-    d0: &mut core::arch::aarch64::uint8x16_t,
-    d1: &mut core::arch::aarch64::uint8x16_t,
-    d2: &mut core::arch::aarch64::uint8x16_t,
-    d3: &mut core::arch::aarch64::uint8x16_t,
+    d0: &mut uint8x16_t,
+    d1: &mut uint8x16_t,
+    d2: &mut uint8x16_t,
+    d3: &mut uint8x16_t,
 ) {
     use core::arch::aarch64::*;
     unsafe {
@@ -315,12 +316,7 @@ unsafe fn xor_apply_byte_into_4_regs_deg4<
 unsafe fn build_factor_row_4chunks_deg4<const TILE_BASE: usize>(
     table_base: *const u8,
     factor_row: *const u8,
-) -> (
-    core::arch::aarch64::uint8x16_t,
-    core::arch::aarch64::uint8x16_t,
-    core::arch::aarch64::uint8x16_t,
-    core::arch::aarch64::uint8x16_t,
-) {
+) -> (uint8x16_t, uint8x16_t, uint8x16_t, uint8x16_t) {
     use core::arch::aarch64::*;
     unsafe {
         let row0 = table_base.add(*factor_row as usize * V8_SIZE);

--- a/crates/flock-core/src/zerocheck/univariate_skip_optimized.rs
+++ b/crates/flock-core/src/zerocheck/univariate_skip_optimized.rs
@@ -949,6 +949,7 @@ fn round1_shift_reduce_extract_c_packed_serial(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(test)]
     use crate::ntt::AdditiveNttGf8;
     use crate::zerocheck::univariate_skip::round1_naive;
 
@@ -1528,7 +1529,7 @@ mod tests {
             for i in 0..3 {
                 r[K_SKIP + i] = phi8(F8(SMALL_CHAL_F8[i]));
             }
-            let medium = crate::zerocheck::univariate_skip_optimized::medium_challenges_ghash();
+            let medium = medium_challenges_ghash();
             for i in 0..4 {
                 r[K_SKIP + 3 + i] = medium[i];
             }
@@ -1540,8 +1541,8 @@ mod tests {
             }
 
             let inv_table = {
-                let ntt_s = crate::ntt::AdditiveNttGf8::new(K_SKIP, F8::ZERO);
-                let ntt_l = crate::ntt::AdditiveNttGf8::new(K_SKIP, F8(1u8 << K_SKIP));
+                let ntt_s = AdditiveNttGf8::new(K_SKIP, F8::ZERO);
+                let ntt_l = AdditiveNttGf8::new(K_SKIP, F8(1u8 << K_SKIP));
                 InvNttTableByteSingleGf8::new(&ntt_s, &ntt_l)
             };
 

--- a/crates/flock-core/src/zerocheck/univariate_skip_optimized/kernels/aarch64.rs
+++ b/crates/flock-core/src/zerocheck/univariate_skip_optimized/kernels/aarch64.rs
@@ -1,4 +1,6 @@
 use super::super::{F8, F128, InvNttTableByteSingleGf8, N_CHUNKS};
+use core::arch::aarch64::uint8x16_t;
+use core::arch::aarch64::uint16x8_t;
 
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
@@ -112,19 +114,18 @@ pub(crate) unsafe fn bit_transpose_64bytes_neon(input: &[u8; 64], output: &mut [
     use core::arch::aarch64::*;
 
     unsafe {
-        let in_ptr = input.as_ptr();
-        let v0 = vld1q_u8(in_ptr);
-        let v1 = vld1q_u8(in_ptr.add(16));
-        let v2 = vld1q_u8(in_ptr.add(32));
-        let v3 = vld1q_u8(in_ptr.add(48));
-        let table = uint8x16x4_t(v0, v1, v2, v3);
-
         // vqtbl4q indexes that bring bytes belonging to byte-chunk b ∈ 0..8
         // into contiguous 8-byte runs, packed two-chunks-per-Q-reg.
         const IDX0: [u8; 16] = [0, 8, 16, 24, 32, 40, 48, 56, 1, 9, 17, 25, 33, 41, 49, 57];
         const IDX1: [u8; 16] = [2, 10, 18, 26, 34, 42, 50, 58, 3, 11, 19, 27, 35, 43, 51, 59];
         const IDX2: [u8; 16] = [4, 12, 20, 28, 36, 44, 52, 60, 5, 13, 21, 29, 37, 45, 53, 61];
         const IDX3: [u8; 16] = [6, 14, 22, 30, 38, 46, 54, 62, 7, 15, 23, 31, 39, 47, 55, 63];
+        let in_ptr = input.as_ptr();
+        let v0 = vld1q_u8(in_ptr);
+        let v1 = vld1q_u8(in_ptr.add(16));
+        let v2 = vld1q_u8(in_ptr.add(32));
+        let v3 = vld1q_u8(in_ptr.add(48));
+        let table = uint8x16x4_t(v0, v1, v2, v3);
 
         let mut y0 = vreinterpretq_u64_u8(vqtbl4q_u8(table, vld1q_u8(IDX0.as_ptr())));
         let mut y1 = vreinterpretq_u64_u8(vqtbl4q_u8(table, vld1q_u8(IDX1.as_ptr())));
@@ -275,14 +276,14 @@ unsafe fn xor_apply_byte_into_8_regs<const BH: usize, const ODD: bool>(
     table_base: *const u8,
     a_byte: u8,
     b_byte: u8,
-    da0: &mut core::arch::aarch64::uint8x16_t,
-    da1: &mut core::arch::aarch64::uint8x16_t,
-    da2: &mut core::arch::aarch64::uint8x16_t,
-    da3: &mut core::arch::aarch64::uint8x16_t,
-    db0: &mut core::arch::aarch64::uint8x16_t,
-    db1: &mut core::arch::aarch64::uint8x16_t,
-    db2: &mut core::arch::aarch64::uint8x16_t,
-    db3: &mut core::arch::aarch64::uint8x16_t,
+    da0: &mut uint8x16_t,
+    da1: &mut uint8x16_t,
+    da2: &mut uint8x16_t,
+    da3: &mut uint8x16_t,
+    db0: &mut uint8x16_t,
+    db1: &mut uint8x16_t,
+    db2: &mut uint8x16_t,
+    db3: &mut uint8x16_t,
 ) {
     use core::arch::aarch64::*;
     unsafe {
@@ -329,14 +330,14 @@ unsafe fn fused_apply_one_k<const K: i32>(
     table_base: *const u8,
     a_row: *const u8,
     b_row: *const u8,
-    acc0_lo: &mut core::arch::aarch64::uint16x8_t,
-    acc0_hi: &mut core::arch::aarch64::uint16x8_t,
-    acc1_lo: &mut core::arch::aarch64::uint16x8_t,
-    acc1_hi: &mut core::arch::aarch64::uint16x8_t,
-    acc2_lo: &mut core::arch::aarch64::uint16x8_t,
-    acc2_hi: &mut core::arch::aarch64::uint16x8_t,
-    acc3_lo: &mut core::arch::aarch64::uint16x8_t,
-    acc3_hi: &mut core::arch::aarch64::uint16x8_t,
+    acc0_lo: &mut uint16x8_t,
+    acc0_hi: &mut uint16x8_t,
+    acc1_lo: &mut uint16x8_t,
+    acc1_hi: &mut uint16x8_t,
+    acc2_lo: &mut uint16x8_t,
+    acc2_hi: &mut uint16x8_t,
+    acc3_lo: &mut uint16x8_t,
+    acc3_hi: &mut uint16x8_t,
 ) {
     use crate::field::gf2_8::neon::gf8_mul_vec16;
     use core::arch::aarch64::*;

--- a/crates/flock-core/tests/assist_blocked.rs
+++ b/crates/flock-core/tests/assist_blocked.rs
@@ -16,6 +16,8 @@ use flock_core::pcs::jagged::{
     self, FrobeniusClaim, JaggedParams, prove_assist, prove_frobenius_assist, verify_assist,
     verify_frobenius_assist,
 };
+use std::hint::black_box;
+use std::time::Instant;
 
 /// xorshift — the probe only needs points that aren't structurally special.
 struct Rng(u64);
@@ -52,7 +54,7 @@ fn registry_heights(regions: &[(usize, u64)], k: usize) -> Vec<u64> {
 fn min_ms(iters: usize, mut f: impl FnMut()) -> f64 {
     let mut best = f64::INFINITY;
     for _ in 0..iters {
-        let t = std::time::Instant::now();
+        let t = Instant::now();
         f();
         best = best.min(t.elapsed().as_secs_f64() * 1e3);
     }
@@ -153,12 +155,17 @@ fn assist_shapes_probe() {
         let fproof = prove_frobenius_assist(&params, &claims, &[], &rho, &mut fp);
         let fprove = min_ms(iters, || {
             let mut ch = FsChallenger::new(b"assist-blocked-probe");
-            std::hint::black_box(prove_frobenius_assist(&params, &claims, &[], &rho, &mut ch));
+            black_box(prove_frobenius_assist(&params, &claims, &[], &rho, &mut ch));
         });
         let fverify = min_ms(iters, || {
             let mut ch = FsChallenger::new(b"assist-blocked-probe");
-            std::hint::black_box(verify_frobenius_assist(
-                &params, &claims, &[], &rho, &fproof, &mut ch,
+            black_box(verify_frobenius_assist(
+                &params,
+                &claims,
+                &[],
+                &rho,
+                &fproof,
+                &mut ch,
             ));
         });
         let mut vch = FsChallenger::new(b"assist-blocked-probe");
@@ -175,11 +182,11 @@ fn assist_shapes_probe() {
         let aproof = prove_assist(&params, &zr, &zc, &zi, &mut ap);
         let aprove = min_ms(iters, || {
             let mut ch = FsChallenger::new(b"assist-blocked-probe");
-            std::hint::black_box(prove_assist(&params, &zr, &zc, &zi, &mut ch));
+            black_box(prove_assist(&params, &zr, &zc, &zi, &mut ch));
         });
         let averify = min_ms(iters, || {
             let mut ch = FsChallenger::new(b"assist-blocked-probe");
-            std::hint::black_box(verify_assist(&params, &zr, &zc, &zi, &aproof, &mut ch));
+            black_box(verify_assist(&params, &zr, &zc, &zi, &aproof, &mut ch));
         });
         let mut vch = FsChallenger::new(b"assist-blocked-probe");
         assert_eq!(

--- a/crates/flock-core/tests/sigma_route_b.rs
+++ b/crates/flock-core/tests/sigma_route_b.rs
@@ -76,7 +76,10 @@ fn sigma_claims_fold_and_discharge() {
         "the emitted sigma claim discharges against the reshaped table"
     );
     let c2 = sigma_claim(mu, nu, &sigma, b"sigma-route-b-2");
-    assert_ne!(c1.value, c2.value, "independent transcripts, distinct points");
+    assert_ne!(
+        c1.value, c2.value,
+        "independent transcripts, distinct points"
+    );
 
     // The merge-node operation: fold 2 -> 1, verify the fold, discharge the
     // folded claim — the root's single evaluation.

--- a/crates/flock-core/tests/union_lincheck.rs
+++ b/crates/flock-core/tests/union_lincheck.rs
@@ -25,6 +25,7 @@ use flock_core::union::UnionInstance;
 use flock_core::zerocheck::multilinear::lagrange_weights_naive;
 use flock_core::zerocheck::univariate_skip::pack_bits;
 use flock_core::zerocheck::{self, K_SKIP};
+use std::collections::BTreeSet;
 
 const DOMAIN: &[u8] = b"flock-union-lincheck-test-v0";
 
@@ -75,7 +76,7 @@ fn random_useful_matrix(
 ) -> SparseBinaryMatrix {
     let mut rows: Vec<Vec<usize>> = vec![Vec::new(); k];
     for row in rows.iter_mut().take(useful) {
-        let mut cols = std::collections::BTreeSet::new();
+        let mut cols = BTreeSet::new();
         for _ in 0..per_row {
             cols.insert((rng.next_u64() as usize) % useful);
         }

--- a/crates/flock-prover/benches/apply_block_diag_probe.rs
+++ b/crates/flock-prover/benches/apply_block_diag_probe.rs
@@ -13,7 +13,12 @@
 //! density — exactly why the fused generators exist — but the kernel ratio
 //! is still meaningful).
 
+use flock_prover::r1cs_hashes::blake3::build_matrices as Blake3build_matrices;
+use flock_prover::r1cs_hashes::sha2::build_matrices as Sha2build_matrices;
+use std::array::from_fn;
 use std::hint::black_box;
+use std::slice::from_raw_parts;
+use std::slice::from_raw_parts_mut;
 use std::time::Instant;
 
 use flock_prover::field::F128;
@@ -67,8 +72,7 @@ fn apply_one_block_aligned_old(
     out_block: &mut [F128],
     k: usize,
 ) {
-    let z_u128: &[u128] =
-        unsafe { std::slice::from_raw_parts(z_block.as_ptr() as *const u128, z_block.len()) };
+    let z_u128: &[u128] = unsafe { from_raw_parts(z_block.as_ptr() as *const u128, z_block.len()) };
     let f128_per_block = k / 128;
     let mut row_iter = m_0.rows.iter();
     for out_idx in 0..f128_per_block {
@@ -136,6 +140,7 @@ fn apply_block_diag_packed_strip64(
     m: usize,
     k_log: usize,
 ) -> Vec<F128> {
+    const S: usize = 64;
     use rayon::prelude::*;
     let k = 1usize << k_log;
     let n_packed = 1usize << (m - 7);
@@ -144,20 +149,15 @@ fn apply_block_diag_packed_strip64(
     let (row_ptr, cols) = flatten_csr_local(m_0);
     let mut out = vec![F128::ZERO; n_packed];
 
-    const S: usize = 64;
     out.par_chunks_mut(S * f128_per_block)
         .zip(z_packed.par_chunks(S * f128_per_block))
         .for_each(|(out_strip, z_strip)| {
             let n_blocks = z_strip.len() / f128_per_block;
             assert_eq!(n_blocks, S, "probe requires n_outer % 64 == 0");
-            let z_u64: &[u64] = unsafe {
-                std::slice::from_raw_parts(z_strip.as_ptr() as *const u64, z_strip.len() * 2)
-            };
+            let z_u64: &[u64] =
+                unsafe { from_raw_parts(z_strip.as_ptr() as *const u64, z_strip.len() * 2) };
             let out_u64: &mut [u64] = unsafe {
-                std::slice::from_raw_parts_mut(
-                    out_strip.as_mut_ptr() as *mut u64,
-                    out_strip.len() * 2,
-                )
+                from_raw_parts_mut(out_strip.as_mut_ptr() as *mut u64, out_strip.len() * 2)
             };
 
             // Transpose in: colbits[j] = bit j of all 64 blocks.
@@ -251,13 +251,13 @@ fn main() {
     );
     println!("threads: {}\n", rayon::current_num_threads());
 
-    let (sha2_a, sha2_b) = flock_prover::r1cs_hashes::sha2::build_matrices();
+    let (sha2_a, sha2_b) = Sha2build_matrices();
     for n_log in [10usize, 12, 14] {
         probe("sha2 A0", &sha2_a, 15, n_log, 3);
     }
     probe("sha2 B0", &sha2_b, 15, 12, 3);
 
-    let (bl_a, _) = flock_prover::r1cs_hashes::blake3::build_matrices();
+    let (bl_a, _) = Blake3build_matrices();
     probe("blake3 A0", &bl_a, 14, 6, 3);
 
     // e2e context: the generic (non-fused) sha2 prove materializes a = A·z
@@ -272,8 +272,8 @@ fn main() {
         let comps: Vec<([u32; 8], [u32; 16])> = (0..n)
             .map(|_| {
                 (
-                    std::array::from_fn(|_| rng.next_u64() as u32),
-                    std::array::from_fn(|_| rng.next_u64() as u32),
+                    from_fn(|_| rng.next_u64() as u32),
+                    from_fn(|_| rng.next_u64() as u32),
                 )
             })
             .collect();

--- a/crates/flock-prover/benches/blake3_fast_vs_slim.rs
+++ b/crates/flock-prover/benches/blake3_fast_vs_slim.rs
@@ -9,6 +9,10 @@
 //!
 //! Run: `cargo bench --bench blake3_fast_vs_slim`  (ST: RAYON_NUM_THREADS=1)
 
+use flock_prover::pcs::ligerito::LigeritoProfile;
+use flock_prover::proof_io::R1csProofBundleLigerito;
+use std::array::from_fn;
+use std::env::var;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -30,8 +34,8 @@ impl Rng {
 }
 
 fn random_compression(rng: &mut Rng) -> Compression {
-    let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+    let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+    let m: [u32; 16] = from_fn(|_| rng.next_u32());
     (cv, m, rng.next_u32() as u64, 64u32, 11u32)
 }
 
@@ -46,12 +50,7 @@ fn fmt_kb(b: usize) -> String {
     }
 }
 
-fn bench_mode(
-    n_blocks: usize,
-    profile: flock_prover::pcs::ligerito::LigeritoProfile,
-    n_runs: usize,
-    label: &str,
-) {
+fn bench_mode(n_blocks: usize, profile: LigeritoProfile, n_runs: usize, label: &str) {
     let setup = Blake3Setup::with_profile(n_blocks, profile);
     let mut rng = Rng::new(0xB1A_3_511_3E ^ (label.len() as u64));
     let blocks: Vec<Compression> = (0..n_blocks)
@@ -85,7 +84,7 @@ fn bench_mode(
         verify_t = verify_t.min(t0.elapsed().as_secs_f64());
     }
 
-    let bundle = flock_prover::proof_io::R1csProofBundleLigerito { commitment, proof };
+    let bundle = R1csProofBundleLigerito { commitment, proof };
     let size = bundle.to_bytes().len();
     black_box(&bundle);
 
@@ -98,6 +97,7 @@ fn bench_mode(
 }
 
 fn main() {
+    use flock_prover::pcs::ligerito::LigeritoProfile;
     let _ = flock_prover::init_perf_thread_pool();
     let threads = rayon::current_num_threads();
     let label = if threads == 1 {
@@ -106,13 +106,13 @@ fn main() {
         format!("MT, {threads} threads")
     };
 
-    let n_blocks: usize = std::env::var("BLAKE3_K")
+    let n_blocks: usize = var("BLAKE3_K")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(65536);
     let n_log = min_n_blocks_log(n_blocks);
     let m = K_LOG + n_log;
-    let n_runs: usize = std::env::var("FLOCK_BENCH_RUNS")
+    let n_runs: usize = var("FLOCK_BENCH_RUNS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(2);
@@ -121,7 +121,6 @@ fn main() {
     println!("(target: aarch64 + aes)");
     println!("BLAKE3 Ligerito fast vs slim — K = {n_blocks} (m = {m}, {label})\n");
 
-    use flock_prover::pcs::ligerito::LigeritoProfile;
     bench_mode(n_blocks, LigeritoProfile::Fast, n_runs, "fast");
     bench_mode(n_blocks, LigeritoProfile::Slim, n_runs, "slim");
     bench_mode(n_blocks, LigeritoProfile::Secure, n_runs, "secure");

--- a/crates/flock-prover/benches/blake3_native_chain.rs
+++ b/crates/flock-prover/benches/blake3_native_chain.rs
@@ -17,6 +17,7 @@
 //!
 //! Run: `cargo bench --bench blake3_native_chain`
 
+use std::hint::black_box;
 use std::time::Instant;
 
 use rayon::prelude::*;
@@ -88,13 +89,13 @@ fn bench_single_chain(t: u64, runs: usize) {
     rng.fill_bytes(&mut initial);
 
     // Warm up branch predictor + caches.
-    let _ = std::hint::black_box(hash_chain(initial, 1024));
+    let _ = black_box(hash_chain(initial, 1024));
 
     let mut best = f64::INFINITY;
     let mut last_out = [0u8; 32];
     for run in 0..runs {
         let t0 = Instant::now();
-        let out = hash_chain(std::hint::black_box(initial), t);
+        let out = hash_chain(black_box(initial), t);
         let elapsed = t0.elapsed().as_secs_f64();
         let hps = t as f64 / elapsed;
         let ns_per_hash = elapsed * 1e9 / t as f64;

--- a/crates/flock-prover/benches/blake3_proof.rs
+++ b/crates/flock-prover/benches/blake3_proof.rs
@@ -2,7 +2,11 @@
 //! timing breakdown. Times the fast prover path (`Blake3Setup::prove_fast`);
 //! the slow `prove` path is exercised by unit tests in `src/blake3.rs`.
 
+use flock_prover::proof_io::R1csProofBundleLigerito;
 use std::alloc::{GlobalAlloc, Layout, System};
+use std::array::from_fn;
+use std::env::var;
+use std::env::var_os;
 use std::hint::black_box;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
@@ -66,8 +70,8 @@ impl Rng {
 }
 
 fn random_compression(rng: &mut Rng) -> Compression {
-    let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+    let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+    let m: [u32; 16] = from_fn(|_| rng.next_u32());
     // counter varies per instance; block_len = 64 (full block), flags = a
     // typical CHUNK_START|CHUNK_END|ROOT for a single-block chunk.
     (cv, m, rng.next_u32() as u64, 64u32, 11u32)
@@ -96,7 +100,7 @@ fn bench_one(n_blocks: usize, n_runs: usize) {
     );
 
     // BLAKE3_BATCH_MAJOR=1 switches the witness layout (WitnessLayout::BatchMajor).
-    let mut setup = if std::env::var_os("BLAKE3_BATCH_MAJOR").is_some() {
+    let mut setup = if var_os("BLAKE3_BATCH_MAJOR").is_some() {
         Blake3Setup::new_batch_major(n_blocks)
     } else {
         Blake3Setup::new(n_blocks)
@@ -105,14 +109,14 @@ fn bench_one(n_blocks: usize, n_runs: usize) {
     // sha256). Setting it on `pcs_params` is enough: the Ligerito prover and
     // verifier configs are derived from those params, so the L0 commitment and
     // every recursive level follow.
-    if let Ok(h) = std::env::var("FLOCK_MERKLE_HASH") {
+    if let Ok(h) = var("FLOCK_MERKLE_HASH") {
         setup.pcs_params.merkle_hash =
             HashKind::parse(&h).expect("FLOCK_MERKLE_HASH must be sha256 or blake3");
     }
     let setup = setup;
     // FLOCK_FS_HASH=sha256|blake3 selects the Fiat-Shamir transcript hash
     // (default sha256), independently of the Merkle hash above.
-    let fs_hash = match std::env::var("FLOCK_FS_HASH") {
+    let fs_hash = match var("FLOCK_FS_HASH") {
         Ok(h) => HashKind::parse(&h).expect("FLOCK_FS_HASH must be sha256 or blake3"),
         Err(_) => HashKind::default(),
     };
@@ -182,7 +186,7 @@ fn bench_one(n_blocks: usize, n_runs: usize) {
             .expect("verify failed");
         println!("  verify: {}", fmt_ms(t.elapsed().as_secs_f64()));
 
-        let bundle = flock_prover::proof_io::R1csProofBundleLigerito { commitment, proof };
+        let bundle = R1csProofBundleLigerito { commitment, proof };
         let proof_size = bundle.to_bytes().len();
         println!(
             "  proof size: {} bytes ({:.2} KiB)",
@@ -225,7 +229,7 @@ fn main() {
     // to sweep at the same sizes as the competitors; each listed size is benched
     // best-of-3. Default: small-scale context + the SHA-256/Keccak baseline sizes.
     // n_blocks → m: K_LOG=14, so m = 14 + ceil_log2(max(n_blocks, 8)).
-    let specs: Vec<(usize, usize)> = match std::env::var("BLAKE3_LOG2S") {
+    let specs: Vec<(usize, usize)> = match var("BLAKE3_LOG2S") {
         Ok(s) => s
             .split([',', ' '])
             .filter(|t| !t.is_empty())

--- a/crates/flock-prover/benches/ecore_offload_probe.rs
+++ b/crates/flock-prover/benches/ecore_offload_probe.rs
@@ -18,6 +18,8 @@
 #![allow(clippy::uninit_vec)]
 
 use std::hint::black_box;
+use std::ptr::write_bytes;
+use std::thread::scope;
 use std::time::Instant;
 
 use flock_prover::field::F128;
@@ -41,7 +43,7 @@ fn alloc_and_pad(src: &[F128]) -> Vec<F128> {
     buf[..half.min(src.len())].copy_from_slice(&src[..half.min(src.len())]);
     // write_bytes count is in F128 ELEMENTS (each set to the 0 byte pattern).
     unsafe {
-        std::ptr::write_bytes(buf.as_mut_ptr().add(half), 0u8, N - half);
+        write_bytes(buf.as_mut_ptr().add(half), 0u8, N - half);
     }
     buf
 }
@@ -94,7 +96,7 @@ fn prefault_then_work<R>(src: &[F128], work: impl FnOnce() -> R) -> (Vec<F128>, 
         let r = work();
         (buf, r)
     } else {
-        std::thread::scope(|s| {
+        scope(|s| {
             let h = s.spawn(|| {
                 SPAWNED.fetch_add(1, Ordering::Relaxed);
                 set_background_qos();
@@ -160,7 +162,7 @@ fn main() {
     for _ in 0..n_runs {
         let src_ref = &src;
         let t = Instant::now();
-        let buf = std::thread::scope(|s| {
+        let buf = scope(|s| {
             let h = s.spawn(|| alloc_and_pad(src_ref));
             black_box(pcore_workload(rounds));
             h.join().unwrap()
@@ -175,7 +177,7 @@ fn main() {
     for _ in 0..n_runs {
         let src_ref = &src;
         let t = Instant::now();
-        let buf = std::thread::scope(|s| {
+        let buf = scope(|s| {
             let h = s.spawn(|| {
                 set_background_qos();
                 alloc_and_pad(src_ref)

--- a/crates/flock-prover/benches/eq_build_probe.rs
+++ b/crates/flock-prover/benches/eq_build_probe.rs
@@ -102,6 +102,7 @@ fn fmt_ms(s: f64) -> String {
 }
 
 fn main() {
+    const RUNS: usize = 30;
     let _ = flock_prover::init_perf_thread_pool();
     println!("eq-build probe: PMULL vs mul_by_x for medium friendlies\n");
 
@@ -110,8 +111,8 @@ fn main() {
     //   round 3: r[8..23] (n=15)
     //   ...
     for n in [10usize, 12, 14, 16, 18, 20].iter().copied() {
-        let r = make_r_round2(n);
         const RUNS: usize = 50;
+        let r = make_r_round2(n);
 
         // Standard build.
         let mut tot_std = 0.0;
@@ -155,7 +156,7 @@ fn main() {
     // Also: measure SplitEqGhash::new since that's what the rounds actually call.
     println!("\nSplitEqGhash::new (round-2 shape at m=30: n=23, n_lo=16, n_hi=7):");
     let r = make_r_round2(23);
-    const RUNS: usize = 30;
+
     let mut tot = 0.0;
     for _ in 0..RUNS {
         let t = Instant::now();

--- a/crates/flock-prover/benches/field.rs
+++ b/crates/flock-prover/benches/field.rs
@@ -337,8 +337,8 @@ fn bench_f128_mul() {
 }
 
 fn bench_f128_mul_by_x() {
-    header("F128 mul_by_x (shift + conditional fold)");
     use flock_prover::field::mul_by_x;
+    header("F128 mul_by_x (shift + conditional fold)");
 
     // Latency
     {
@@ -386,6 +386,10 @@ fn bench_f128_mul_by_x() {
 }
 
 fn bench_f128_deferred() {
+    // Vary BOTH `lo` and `hi` of each `a` every iter. If only `lo` changes,
+    // the compiler hoists PMULL(a.hi, b.*) out of the loop, halving the work.
+    const STEP_LO: u64 = 1;
+    const STEP_HI: u64 = 0x9E3779B97F4A7C15;
     header("F128 deferred-reduction sumcheck pattern");
     // The realistic sumcheck pattern: accumulate K unreduced products into a
     // single F256Unreduced, then call .reduce() once. We measure cost per
@@ -418,10 +422,7 @@ fn bench_f128_deferred() {
     let mut acc1 = F256Unreduced::ZERO;
     let mut acc2 = F256Unreduced::ZERO;
     let mut acc3 = F256Unreduced::ZERO;
-    // Vary BOTH `lo` and `hi` of each `a` every iter. If only `lo` changes,
-    // the compiler hoists PMULL(a.hi, b.*) out of the loop, halving the work.
-    const STEP_LO: u64 = 1;
-    const STEP_HI: u64 = 0x9E3779B97F4A7C15;
+
     for _ in 0..iters {
         acc0 ^= a0.mul_unreduced(b);
         acc1 ^= a1.mul_unreduced(b);

--- a/crates/flock-prover/benches/fs_challenger.rs
+++ b/crates/flock-prover/benches/fs_challenger.rs
@@ -55,11 +55,15 @@ fn report(label: &str, secs: f64, ops: u64) {
 }
 
 fn main() {
+    const N_OBSERVE: usize = 1 << 16;
+    const N_SAMPLE: usize = 1 << 14;
+    const N_POW: usize = 1 << 20;
+    const N_MIXED: usize = 1 << 14;
     println!("Fiat-Shamir transcript cost by hash (best of {REPS}).");
 
     // ---- 1. Absorption.
     println!("\n===== observe_f128 (transcript absorption) =====");
-    const N_OBSERVE: usize = 1 << 16;
+
     for kind in KINDS {
         let secs = best(|| {
             let mut ch = FsChallenger::with_hash(b"fs-bench", kind);
@@ -80,7 +84,7 @@ fn main() {
 
     // ---- 2. Squeezing, scalar.
     println!("\n===== sample_f128 (16-byte squeeze each) =====");
-    const N_SAMPLE: usize = 1 << 14;
+
     for kind in KINDS {
         let secs = best(|| {
             let mut ch = FsChallenger::with_hash(b"fs-bench", kind);
@@ -127,7 +131,7 @@ fn main() {
     // per-hash: SHA-256 uses 40 bytes (one compression), BLAKE3 uses a padded
     // 64-byte whole block so the search can be SIMD-batched.
     println!("\n===== PoW inner loop, scalar (one nonce at a time) =====");
-    const N_POW: usize = 1 << 20;
+
     let state = [0xA5u8; 32];
     for kind in KINDS {
         let secs = best(|| {
@@ -180,7 +184,7 @@ fn main() {
     // ---- 4. A transcript shaped like a real proof: interleaved observes and
     // samples, which is what the sumcheck rounds actually do.
     println!("\n===== mixed script (2 observes + 1 sample, ×N) =====");
-    const N_MIXED: usize = 1 << 14;
+
     for kind in KINDS {
         let secs = best(|| {
             let mut ch = FsChallenger::with_hash(b"fs-bench", kind);

--- a/crates/flock-prover/benches/gamma_bake_probe.rs
+++ b/crates/flock-prover/benches/gamma_bake_probe.rs
@@ -35,13 +35,29 @@ fn fmt_ms(s: f64) -> String {
 }
 
 fn main() {
+    // m=30 setup: x_outer has length m - 6 = 24. Suffix x_outer[1..] has length
+    // 23. Split into n_hi = 12 / n_lo = 11 for the dense_splits factor.
+    const M: usize = 30;
+    // Build eq_r_dprime (length 128) for 2 claims via the standard
+    // tensor-product expansion of 7-coord r''.
+    fn build_eq(r: &[F128]) -> Vec<F128> {
+        let mut acc = vec![F128 { lo: 1, hi: 0 }];
+        for &ri in r {
+            let mut next = Vec::with_capacity(acc.len() * 2);
+            let one = F128 { lo: 1, hi: 0 };
+            for &a in &acc {
+                next.push(a * (one + ri));
+                next.push(a * ri);
+            }
+            acc = next;
+        }
+        acc
+    }
+    const RUNS: usize = 5;
     let _ = flock_prover::init_perf_thread_pool();
     let threads = rayon::current_num_threads();
     println!("gamma-bake probe ({threads} thread(s))\n");
 
-    // m=30 setup: x_outer has length m - 6 = 24. Suffix x_outer[1..] has length
-    // 23. Split into n_hi = 12 / n_lo = 11 for the dense_splits factor.
-    const M: usize = 30;
     let l = 1usize << (M - 7); // 8.4M
     let n_lo = (M - 7) / 2; // 11
     let n_hi = (M - 7) - n_lo; // 12
@@ -62,21 +78,6 @@ fn main() {
     let eq_lo_1: Vec<F128> = (0..b_lo).map(|_| rng.f128()).collect();
     let eq_hi_1: Vec<F128> = (0..b_hi).map(|_| rng.f128()).collect();
 
-    // Build eq_r_dprime (length 128) for 2 claims via the standard
-    // tensor-product expansion of 7-coord r''.
-    fn build_eq(r: &[F128]) -> Vec<F128> {
-        let mut acc = vec![F128 { lo: 1, hi: 0 }];
-        for &ri in r {
-            let mut next = Vec::with_capacity(acc.len() * 2);
-            let one = F128 { lo: 1, hi: 0 };
-            for &a in &acc {
-                next.push(a * (one + ri));
-                next.push(a * ri);
-            }
-            acc = next;
-        }
-        acc
-    }
     let r_dprime_0: Vec<F128> = (0..7).map(|_| rng.f128()).collect();
     let r_dprime_1: Vec<F128> = (0..7).map(|_| rng.f128()).collect();
     let eq_r_dprime_0 = build_eq(&r_dprime_0);
@@ -99,9 +100,10 @@ fn main() {
     let mut a_fold1_total = 0.0;
     let mut a_combine_total = 0.0;
     let mut a_total = 0.0;
-    const RUNS: usize = 5;
+
     let mut b_a = Vec::new();
     for run in 0..RUNS {
+        use rayon::prelude::*;
         let t_all = Instant::now();
         let t0 = Instant::now();
         let b0 = fold_b128_elems_split(&eq_lo_0, &eq_hi_0, &eq_r_dprime_0);
@@ -114,7 +116,7 @@ fn main() {
         a_fold1_total += dt1;
 
         let tc = Instant::now();
-        use rayon::prelude::*;
+
         let b_combined: Vec<F128> = (0..l)
             .into_par_iter()
             .map(|j| g0 * b0[j] + g1 * b1[j])
@@ -157,6 +159,7 @@ fn main() {
     let mut b_total = 0.0;
     let mut b_b = Vec::new();
     for run in 0..RUNS {
+        use rayon::prelude::*;
         let t_all = Instant::now();
 
         let ts0 = Instant::now();
@@ -180,7 +183,7 @@ fn main() {
         b_fold1_total += dt1;
 
         let tc = Instant::now();
-        use rayon::prelude::*;
+
         let b_combined: Vec<F128> = (0..l).into_par_iter().map(|j| b0[j] + b1[j]).collect();
         let dtc = tc.elapsed().as_secs_f64();
         b_combine_total += dtc;

--- a/crates/flock-prover/benches/generic_vs_fast_proof.rs
+++ b/crates/flock-prover/benches/generic_vs_fast_proof.rs
@@ -13,6 +13,7 @@
 //! Keccak has no generic path at all — its BlockR1cs carries empty matrix
 //! stubs by design, so the matrices the generic path needs don't exist.
 
+use std::array::from_fn;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -60,12 +61,7 @@ fn bench_sha2(n: usize) {
     let m = setup.m();
     let mut rng = Rng(0x5A2 ^ n as u64);
     let comps: Vec<Compression> = (0..n)
-        .map(|_| {
-            (
-                std::array::from_fn(|_| rng.u32()),
-                std::array::from_fn(|_| rng.u32()),
-            )
-        })
+        .map(|_| (from_fn(|_| rng.u32()), from_fn(|_| rng.u32())))
         .collect();
 
     println!("\n=== sha2, {n} compressions (m = {m}) ===");
@@ -113,8 +109,8 @@ fn bench_blake3(n: usize) {
     let blocks: Vec<Compression> = (0..n)
         .map(|_| {
             (
-                std::array::from_fn(|_| rng.u32()),
-                std::array::from_fn(|_| rng.u32()),
+                from_fn(|_| rng.u32()),
+                from_fn(|_| rng.u32()),
                 rng.next_u64(),
                 rng.u32(),
                 64u32,

--- a/crates/flock-prover/benches/genwitness_phase.rs
+++ b/crates/flock-prover/benches/genwitness_phase.rs
@@ -2,6 +2,7 @@
 //! (the "gen_witness_ab + lincheck" phase). Best-of-N to isolate it from the
 //! rest of the prove pipeline's thermal load. Honors RAYON_NUM_THREADS.
 
+use std::array::from_fn;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -24,8 +25,8 @@ impl Rng {
 }
 
 fn random_compression(rng: &mut Rng) -> Compression {
-    let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+    let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+    let m: [u32; 16] = from_fn(|_| rng.next_u32());
     (cv, m, rng.next_u32() as u64, 64u32, 11u32)
 }
 

--- a/crates/flock-prover/benches/grinding_sha256.rs
+++ b/crates/flock-prover/benches/grinding_sha256.rs
@@ -8,6 +8,7 @@
 //! For each `c`, runs many independent grindings (each with a fresh 32-byte
 //! prefix) so the geometric noise in number of tries averages out.
 
+use std::hint::black_box;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Instant;
 
@@ -165,7 +166,7 @@ fn main() {
 
     // Pre-warm the SHA-256 unit (first call sometimes shows JIT-style startup).
     let warm = hash_with_nonce(&[0u8; 32], 0);
-    std::hint::black_box(&warm);
+    black_box(&warm);
 
     println!("SHA-256 grinding cost — hardware-accelerated (sha2 crate, asm feature)");
     #[cfg(target_arch = "aarch64")]

--- a/crates/flock-prover/benches/hash_throughput.rs
+++ b/crates/flock-prover/benches/hash_throughput.rs
@@ -5,6 +5,8 @@
 //! `RAYON_NUM_THREADS`; `benchmarks/bench_hash_throughput.sh` runs the complete
 //! single- and multi-threaded matrix and renders it as Markdown.
 
+use std::array::from_fn;
+use std::env::var;
 use std::hint::black_box;
 use std::time::{Duration, Instant};
 
@@ -51,16 +53,13 @@ impl Rng {
 }
 
 fn random_sha2_input(rng: &mut Rng) -> ([u32; 8], [u32; 16]) {
-    (
-        std::array::from_fn(|_| rng.next_u32()),
-        std::array::from_fn(|_| rng.next_u32()),
-    )
+    (from_fn(|_| rng.next_u32()), from_fn(|_| rng.next_u32()))
 }
 
 fn random_blake3_input(rng: &mut Rng) -> Compression {
     (
-        std::array::from_fn(|_| rng.next_u32()),
-        std::array::from_fn(|_| rng.next_u32()),
+        from_fn(|_| rng.next_u32()),
+        from_fn(|_| rng.next_u32()),
         rng.next_u64(),
         64,
         11,
@@ -194,7 +193,7 @@ fn bench_keccak(batch: usize, layout: BenchLayout, runs: usize) {
 }
 
 fn parse_log2_batches() -> Vec<u32> {
-    let value = std::env::var("HASH_BENCH_LOG2S").unwrap_or_else(|_| "10 12 14 16 18".to_owned());
+    let value = var("HASH_BENCH_LOG2S").unwrap_or_else(|_| "10 12 14 16 18".to_owned());
     let batches: Vec<u32> = value
         .split([',', ' '])
         .filter(|part| !part.is_empty())
@@ -218,7 +217,7 @@ fn parse_log2_batches() -> Vec<u32> {
 }
 
 fn parse_runs() -> usize {
-    let runs = std::env::var("HASH_BENCH_RUNS")
+    let runs = var("HASH_BENCH_RUNS")
         .unwrap_or_else(|_| "3".to_owned())
         .parse::<usize>()
         .expect("HASH_BENCH_RUNS must be a positive integer");

--- a/crates/flock-prover/benches/keccak3_profiles.rs
+++ b/crates/flock-prover/benches/keccak3_profiles.rs
@@ -8,6 +8,8 @@
 //!
 //! Run: `cargo bench --bench keccak3_profiles`   (ST: RAYON_NUM_THREADS=1)
 
+use flock_prover::proof_io::R1csProofBundleLigerito;
+use std::env::var;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -81,7 +83,7 @@ fn bench_profile(n_keccaks: usize, profile: LigeritoProfile, n_runs: usize, labe
         verify_t = verify_t.min(t0.elapsed().as_secs_f64());
     }
 
-    let bundle = flock_prover::proof_io::R1csProofBundleLigerito { commitment, proof };
+    let bundle = R1csProofBundleLigerito { commitment, proof };
     let size = bundle.to_bytes().len();
     black_box(&bundle);
 
@@ -104,11 +106,11 @@ fn main() {
     } else {
         format!("MT, {threads} threads")
     };
-    let n_keccaks: usize = std::env::var("KECCAK3_K")
+    let n_keccaks: usize = var("KECCAK3_K")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(24576);
-    let n_runs: usize = std::env::var("FLOCK_BENCH_RUNS")
+    let n_runs: usize = var("FLOCK_BENCH_RUNS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(10);

--- a/crates/flock-prover/benches/keccak3_proof.rs
+++ b/crates/flock-prover/benches/keccak3_proof.rs
@@ -13,7 +13,9 @@
 //! For single-threaded numbers, run with `RAYON_NUM_THREADS=1` — the perf
 //! pool honors it.
 
+use flock_prover::proof_io::R1csProofBundleLigerito;
 use std::alloc::{GlobalAlloc, Layout, System};
+use std::env::var;
 use std::hint::black_box;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
@@ -236,7 +238,7 @@ fn bench_3wide_report(n_keccaks: usize, n_runs: usize) {
             .expect("verify failed");
         println!("  verify: {}", fmt_ms(t.elapsed().as_secs_f64()));
 
-        let bundle = flock_prover::proof_io::R1csProofBundleLigerito { commitment, proof };
+        let bundle = R1csProofBundleLigerito { commitment, proof };
         let proof_size = bundle.to_bytes().len();
         println!(
             "  proof size: {} bytes ({:.2} KiB)",
@@ -280,7 +282,7 @@ fn main() {
     // parseable prove_fast/peak/verify/proof-size fields consumed by
     // bench_keccak.sh. Best for counts of the form 3·2^j. Unset → the default
     // single-vs-3-wide comparison sweep below.
-    if let Ok(s) = std::env::var("KECCAK3_KS") {
+    if let Ok(s) = var("KECCAK3_KS") {
         println!("3-wide Keccak-f[1600] prove_fast (flock3) ({threads} thread(s)).");
         let counts: Vec<usize> = s
             .split([',', ' '])

--- a/crates/flock-prover/benches/keccak3_secure_proof.rs
+++ b/crates/flock-prover/benches/keccak3_secure_proof.rs
@@ -23,7 +23,9 @@
 //! For single-threaded numbers, run with `RAYON_NUM_THREADS=1` — the perf
 //! pool honors it.
 
+use flock_prover::proof_io::R1csProofBundleLigerito;
 use std::alloc::{GlobalAlloc, Layout, System};
+use std::env::var;
 use std::hint::black_box;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
@@ -252,7 +254,7 @@ fn bench_3wide_report(n_keccaks: usize, n_runs: usize) {
             .expect("verify failed");
         println!("  verify: {}", fmt_ms(t.elapsed().as_secs_f64()));
 
-        let bundle = flock_prover::proof_io::R1csProofBundleLigerito { commitment, proof };
+        let bundle = R1csProofBundleLigerito { commitment, proof };
         let proof_size = bundle.to_bytes().len();
         println!(
             "  proof size: {} bytes ({:.2} KiB)",
@@ -274,7 +276,7 @@ fn main() {
     // parseable prove_fast/peak/verify/proof-size fields consumed by
     // bench_keccak.sh. Best for counts of the form 3·2^j. Unset → the default
     // single-vs-3-wide comparison sweep below.
-    if let Ok(s) = std::env::var("KECCAK3_KS") {
+    if let Ok(s) = var("KECCAK3_KS") {
         println!(
             "3-wide Keccak-f[1600] prove_fast (flock3, SECURE 120-bit) ({threads} thread(s))."
         );

--- a/crates/flock-prover/benches/keccak3_slim_proof.rs
+++ b/crates/flock-prover/benches/keccak3_slim_proof.rs
@@ -21,7 +21,9 @@
 //! For single-threaded numbers, run with `RAYON_NUM_THREADS=1` — the perf
 //! pool honors it.
 
+use flock_prover::proof_io::R1csProofBundleLigerito;
 use std::alloc::{GlobalAlloc, Layout, System};
+use std::env::var;
 use std::hint::black_box;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
@@ -249,7 +251,7 @@ fn bench_3wide_report(n_keccaks: usize, n_runs: usize) {
             .expect("verify failed");
         println!("  verify: {}", fmt_ms(t.elapsed().as_secs_f64()));
 
-        let bundle = flock_prover::proof_io::R1csProofBundleLigerito { commitment, proof };
+        let bundle = R1csProofBundleLigerito { commitment, proof };
         let proof_size = bundle.to_bytes().len();
         println!(
             "  proof size: {} bytes ({:.2} KiB)",
@@ -271,7 +273,7 @@ fn main() {
     // parseable prove_fast/peak/verify/proof-size fields consumed by
     // bench_keccak.sh. Best for counts of the form 3·2^j. Unset → the default
     // single-vs-3-wide comparison sweep below.
-    if let Ok(s) = std::env::var("KECCAK3_KS") {
+    if let Ok(s) = var("KECCAK3_KS") {
         println!("3-wide Keccak-f[1600] prove_fast (flock3, SLIM rate 1/4) ({threads} thread(s)).");
         let counts: Vec<usize> = s
             .split([',', ' '])

--- a/crates/flock-prover/benches/keccak3_witlc_probe.rs
+++ b/crates/flock-prover/benches/keccak3_witlc_probe.rs
@@ -9,6 +9,7 @@
 //! Prints best-of-N per phase, their sum, and FNV checksums over all phase
 //! outputs (seeded inputs ⇒ bit-stable across valid optimizations).
 
+use std::env::args;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -71,14 +72,8 @@ impl Fnv {
 
 fn main() {
     let _ = flock_prover::init_perf_thread_pool();
-    let n_runs: usize = std::env::args()
-        .nth(1)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(8);
-    let n_keccaks: usize = std::env::args()
-        .nth(2)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(24576);
+    let n_runs: usize = args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(8);
+    let n_keccaks: usize = args().nth(2).and_then(|s| s.parse().ok()).unwrap_or(24576);
 
     let setup = KeccakSetup::new(n_keccaks);
     let r1cs = &setup.r1cs;

--- a/crates/flock-prover/benches/keccak_native_chain.rs
+++ b/crates/flock-prover/benches/keccak_native_chain.rs
@@ -17,6 +17,7 @@
 //!
 //! Run: `cargo bench --bench keccak_native_chain`
 
+use std::hint::black_box;
 use std::time::Instant;
 
 use rayon::prelude::*;
@@ -91,13 +92,13 @@ fn bench_single_chain(t: u64, runs: usize) {
     rng.fill_bytes(&mut initial);
 
     // Warm up branch predictor + caches.
-    let _ = std::hint::black_box(hash_chain(initial, 1024));
+    let _ = black_box(hash_chain(initial, 1024));
 
     let mut best = f64::INFINITY;
     let mut last_out = [0u8; 32];
     for run in 0..runs {
         let t0 = Instant::now();
-        let out = hash_chain(std::hint::black_box(initial), t);
+        let out = hash_chain(black_box(initial), t);
         let elapsed = t0.elapsed().as_secs_f64();
         let hps = t as f64 / elapsed;
         let ns_per_hash = elapsed * 1e9 / t as f64;

--- a/crates/flock-prover/benches/lincheck.rs
+++ b/crates/flock-prover/benches/lincheck.rs
@@ -10,6 +10,8 @@
 //! delta isolates the kernel speedup. Expect ~1.0× below the guard (both iblock)
 //! and oblock's win above it (≈1.4–1.7× by m=28–29 at this k_log).
 
+use std::collections::HashSet;
+use std::env::var;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -60,7 +62,7 @@ impl Rng {
 /// Sparse matrix with ~`nnz` random nonzeros across `k × k` slots.
 fn random_sparse_matrix(k: usize, nnz: usize, rng: &mut Rng) -> SparseBinaryMatrix {
     let mut rows: Vec<Vec<usize>> = vec![Vec::new(); k];
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = HashSet::new();
     let mut count = 0;
     while count < nnz {
         let r = (rng.next_u64() as usize) % k;
@@ -82,7 +84,7 @@ fn random_sparse_matrix(k: usize, nnz: usize, rng: &mut Rng) -> SparseBinaryMatr
 
 fn main() {
     let _ = flock_prover::init_perf_thread_pool();
-    let fold_ab = std::env::var("FOLD_AB").is_ok();
+    let fold_ab = var("FOLD_AB").is_ok();
     #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
     println!("(target: aarch64 + aes)");
     println!("k_log = {K_LOG}, k = {}", 1usize << K_LOG);

--- a/crates/flock-prover/benches/merkle.rs
+++ b/crates/flock-prover/benches/merkle.rs
@@ -20,6 +20,7 @@
 //!
 //! Run: `cargo bench --bench merkle`
 
+use std::hint::black_box;
 use std::time::Instant;
 
 use flock_prover::merkle::{HashKind, hash_leaf, merkle_tree};
@@ -163,7 +164,7 @@ fn bench_merkle_tree(num_leaves: usize, leaf_size: usize, kind: HashKind) -> f64
         let t0 = Instant::now();
         let tree = merkle_tree(&data, num_leaves, kind);
         best = best.min(t0.elapsed().as_secs_f64());
-        std::hint::black_box(&tree);
+        black_box(&tree);
     }
     // Tree work = leaves + internal nodes; internal = num_leaves - 1 hashes.
     let total_hashes = (2 * num_leaves - 1) as u64;

--- a/crates/flock-prover/benches/merkle_l0_opening.rs
+++ b/crates/flock-prover/benches/merkle_l0_opening.rs
@@ -22,6 +22,10 @@
 //! MLO_PATHS=106,218 MLO_DEPTH=11 cargo bench -p flock-prover --bench merkle_l0_opening
 //! ```
 
+use flock_core::field::F128;
+use flock_core::lincheck::LincheckCircuit;
+use std::array::from_fn;
+use std::env::var;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -40,7 +44,7 @@ use flock_prover::r1cs_hashes::merkle_r1cs::{
 const DOMAIN: &[u8] = b"flock-merkle-l0-opening-bench-v0";
 
 fn env_usize(name: &str, default: usize) -> usize {
-    std::env::var(name)
+    var(name)
         .ok()
         .and_then(|v| v.parse().ok())
         .filter(|&n| n > 0)
@@ -61,7 +65,7 @@ fn reps() -> usize {
 
 /// Path counts to sweep; any positive count (capacity rounds up).
 fn path_counts() -> Vec<usize> {
-    match std::env::var("MLO_PATHS") {
+    match var("MLO_PATHS") {
         Ok(v) => v
             .split(',')
             .filter_map(|s| s.trim().parse::<usize>().ok())
@@ -80,7 +84,7 @@ impl Rng {
         (z ^ (z >> 31)) as u32
     }
     fn digest(&mut self) -> [u32; SLOT_WORDS] {
-        std::array::from_fn(|_| self.next_u32())
+        from_fn(|_| self.next_u32())
     }
     fn opening(&mut self, d: usize, leaf: usize) -> ChunkPathInput {
         ChunkPathInput {
@@ -90,8 +94,8 @@ impl Rng {
         }
     }
     fn compression(&mut self) -> blake3::Compression {
-        let cv: [u32; 8] = std::array::from_fn(|_| self.next_u32());
-        let m: [u32; 16] = std::array::from_fn(|_| self.next_u32());
+        let cv: [u32; 8] = from_fn(|_| self.next_u32());
+        let m: [u32; 16] = from_fn(|_| self.next_u32());
         let counter = ((self.next_u32() as u64) << 32) | self.next_u32() as u64;
         (cv, m, counter, 64u32, 11u32)
     }
@@ -142,15 +146,8 @@ fn measure(
     k_log: usize,
     useful_bits: usize,
     base_nnz: usize,
-    circuit: &dyn flock_core::lincheck::LincheckCircuit,
-    make_witness: &(
-         dyn Fn() -> (
-        Vec<flock_core::field::F128>,
-        Vec<flock_core::field::F128>,
-        Vec<flock_core::field::F128>,
-        Vec<u8>,
-    ) + Sync
-     ),
+    circuit: &dyn LincheckCircuit,
+    make_witness: &(dyn Fn() -> (Vec<F128>, Vec<F128>, Vec<F128>, Vec<u8>) + Sync),
     solo: &rayon::ThreadPool,
 ) -> Row {
     let union = UnionInstance::new(registry, vec![rows]);
@@ -288,8 +285,8 @@ fn main() {
     println!("  prover pool     : {threads} threads (physical P-cores)");
     println!(
         "  verify pool     : {} thread(s){}",
-        std::env::var("FLOCK_VERIFY_THREADS").unwrap_or_else(|_| "1".into()),
-        if std::env::var("FLOCK_VERIFY_THREADS").is_ok() {
+        var("FLOCK_VERIFY_THREADS").unwrap_or_else(|_| "1".into()),
+        if var("FLOCK_VERIFY_THREADS").is_ok() {
             " (FLOCK_VERIFY_THREADS override)"
         } else {
             " (production default)"

--- a/crates/flock-prover/benches/merkle_probe.rs
+++ b/crates/flock-prover/benches/merkle_probe.rs
@@ -9,6 +9,7 @@
 //! Default: 50 runs at m=29 (~3 sec ST) under sha256. Pass `blake3` as the
 //! third argument to profile the other Merkle hash.
 
+use std::env::args;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -30,15 +31,9 @@ impl Rng {
 
 fn main() {
     let _ = flock_prover::init_perf_thread_pool();
-    let n_runs: usize = std::env::args()
-        .nth(1)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(50);
-    let m: usize = std::env::args()
-        .nth(2)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(29);
-    let kind = match std::env::args().nth(3) {
+    let n_runs: usize = args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(50);
+    let m: usize = args().nth(2).and_then(|s| s.parse().ok()).unwrap_or(29);
+    let kind = match args().nth(3) {
         Some(s) => HashKind::parse(&s).expect("third arg must be sha256 or blake3"),
         None => HashKind::Sha256,
     };

--- a/crates/flock-prover/benches/merkle_vs_plain_blake3.rs
+++ b/crates/flock-prover/benches/merkle_vs_plain_blake3.rs
@@ -36,6 +36,10 @@
 //! FLOCK_VERIFY_THREADS=4 cargo bench -p flock-prover --bench merkle_vs_plain_blake3
 //! ```
 
+use flock_core::field::F128;
+use flock_core::lincheck::LincheckCircuit;
+use std::array::from_fn;
+use std::env::var;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -56,7 +60,7 @@ const DOMAIN: &[u8] = b"flock-merkle-vs-blake3-bench-v0";
 /// `2^(k_log-7)` that the Frobenius assist scales with — so it is the knob that
 /// moves the assist, unlike the path count.
 fn depth() -> usize {
-    std::env::var("MVB_DEPTH")
+    var("MVB_DEPTH")
         .ok()
         .and_then(|v| v.parse().ok())
         .filter(|&d| d >= 1)
@@ -67,7 +71,7 @@ fn depth() -> usize {
 /// that 3 reps left the BLAKE3 column visibly non-monotonic in size.
 /// Override with `MVB_REPS` (`MVB_REPS=1` for a quick `VERIFY_TRACE` run).
 fn reps() -> usize {
-    std::env::var("MVB_REPS")
+    var("MVB_REPS")
         .ok()
         .and_then(|v| v.parse().ok())
         .filter(|&n| n > 0)
@@ -77,7 +81,7 @@ fn reps() -> usize {
 /// Path counts to sweep; override with e.g. `MVB_PATHS=8,16`. Each must be a
 /// power of two — it is the registry's `2^nu` row capacity.
 fn path_counts() -> Vec<usize> {
-    match std::env::var("MVB_PATHS") {
+    match var("MVB_PATHS") {
         Ok(v) => v
             .split(',')
             .filter_map(|s| s.trim().parse::<usize>().ok())
@@ -102,7 +106,7 @@ impl Rng {
         (z ^ (z >> 31)) as u32
     }
     fn digest(&mut self) -> [u32; merkle_r1cs::SLOT_WORDS] {
-        std::array::from_fn(|_| self.next_u32())
+        from_fn(|_| self.next_u32())
     }
     fn path(&mut self, depth: usize) -> PathInput {
         PathInput {
@@ -112,8 +116,8 @@ impl Rng {
         }
     }
     fn compression(&mut self) -> blake3::Compression {
-        let cv: [u32; 8] = std::array::from_fn(|_| self.next_u32());
-        let m: [u32; 16] = std::array::from_fn(|_| self.next_u32());
+        let cv: [u32; 8] = from_fn(|_| self.next_u32());
+        let m: [u32; 16] = from_fn(|_| self.next_u32());
         let counter = ((self.next_u32() as u64) << 32) | self.next_u32() as u64;
         (cv, m, counter, 64u32, 11u32)
     }
@@ -175,15 +179,8 @@ fn measure(
     k_log: usize,
     useful_bits: usize,
     base_nnz: usize,
-    circuit: &dyn flock_core::lincheck::LincheckCircuit,
-    make_witness: &(
-         dyn Fn() -> (
-        Vec<flock_core::field::F128>,
-        Vec<flock_core::field::F128>,
-        Vec<flock_core::field::F128>,
-        Vec<u8>,
-    ) + Sync
-     ),
+    circuit: &dyn LincheckCircuit,
+    make_witness: &(dyn Fn() -> (Vec<F128>, Vec<F128>, Vec<F128>, Vec<u8>) + Sync),
     solo: &rayon::ThreadPool,
 ) -> Row {
     let union = UnionInstance::new(registry, vec![rows]);
@@ -329,8 +326,8 @@ fn main() {
     println!("  prover pool     : {threads} threads (physical P-cores)");
     println!(
         "  verify pool     : {} thread(s){}",
-        std::env::var("FLOCK_VERIFY_THREADS").unwrap_or_else(|_| "1".into()),
-        if std::env::var("FLOCK_VERIFY_THREADS").is_ok() {
+        var("FLOCK_VERIFY_THREADS").unwrap_or_else(|_| "1".into()),
+        if var("FLOCK_VERIFY_THREADS").is_ok() {
             " (FLOCK_VERIFY_THREADS override)"
         } else {
             " (production default)"

--- a/crates/flock-prover/benches/ntt_butterfly_probe.rs
+++ b/crates/flock-prover/benches/ntt_butterfly_probe.rs
@@ -8,6 +8,7 @@
 //!
 //! Default: 50 runs at m=29 (~3 sec ST). Matches BLAKE3 num_ntts=64 (K_LOG=14, log_batch_size=6).
 
+use std::env::args;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -36,15 +37,9 @@ impl Rng {
 
 fn main() {
     let _ = flock_prover::init_perf_thread_pool();
-    let n_runs: usize = std::env::args()
-        .nth(1)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(50);
+    let n_runs: usize = args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(50);
     // BLAKE3 m=29: log_msg_len = 22, log_batch_size = 6, k_code = 17, num_ntts = 64.
-    let m: usize = std::env::args()
-        .nth(2)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(29);
+    let m: usize = args().nth(2).and_then(|s| s.parse().ok()).unwrap_or(29);
     let log_msg_len = m - 7;
     let log_batch_size = 6usize;
     let log_inv_rate = 1usize;

--- a/crates/flock-prover/benches/ntt_layout_probe.rs
+++ b/crates/flock-prover/benches/ntt_layout_probe.rs
@@ -46,6 +46,7 @@
 //!
 //! Run: `cargo bench --bench ntt_layout_probe [n_runs]`
 
+use std::env::args;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -365,10 +366,7 @@ fn main() {
     #[cfg(not(all(target_arch = "aarch64", target_feature = "aes")))]
     println!("(target: non-aarch64 / software fallback path)");
 
-    let n_runs: usize = std::env::args()
-        .nth(1)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(20);
+    let n_runs: usize = args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(20);
 
     // m=30-representative: log_dim=19, num_ntts=16 (log_batch_size=4), k=12
     // real lanes (25% zero padding). Rate 1/2 is the pcs_commit default; rate

--- a/crates/flock-prover/benches/padded_vs_dense.rs
+++ b/crates/flock-prover/benches/padded_vs_dense.rs
@@ -8,6 +8,8 @@
 //! padded_vs_dense`. Default sizes target m=30 (16384 Keccak permutations,
 //! 32768 SHA-256 compressions).
 
+use std::array::from_fn;
+use std::env::var;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -136,12 +138,7 @@ fn bench_sha2(n_compressions: usize, n_runs: usize) {
     let mut setup = Sha256HybridSetup::new(n_compressions);
     let mut rng = Rng::new(0xC0FFEE_5A55_u64.wrapping_add(n_compressions as u64));
     let inputs: Vec<([u32; 8], [u32; 16])> = (0..n_compressions)
-        .map(|_| {
-            (
-                std::array::from_fn(|_| rng.next_u32()),
-                std::array::from_fn(|_| rng.next_u32()),
-            )
-        })
+        .map(|_| (from_fn(|_| rng.next_u32()), from_fn(|_| rng.next_u32())))
         .collect();
 
     // Padded path.
@@ -194,7 +191,7 @@ fn bench_sha2(n_compressions: usize, n_runs: usize) {
 
 fn main() {
     let _ = flock_prover::init_perf_thread_pool();
-    let threads = std::env::var("RAYON_NUM_THREADS").unwrap_or_else(|_| "(default)".into());
+    let threads = var("RAYON_NUM_THREADS").unwrap_or_else(|_| "(default)".into());
     println!("URM padding-skip A/B for prove_fast (RAYON_NUM_THREADS={threads})");
 
     // m=30: 16384 Keccak perms, 32768 SHA-256 compressions.

--- a/crates/flock-prover/benches/pcs_commit.rs
+++ b/crates/flock-prover/benches/pcs_commit.rs
@@ -8,6 +8,8 @@
 //!
 //! Run: `cargo bench --bench pcs_commit`
 
+use core::mem::size_of;
+use core::slice::from_raw_parts;
 use std::time::Instant;
 
 use flock_prover::field::F128;
@@ -313,9 +315,9 @@ fn bench_commit_packed_breakdown(m: usize) {
 
     // ---- 3. Cast codeword bytes (zero-copy — same as pcs::commit).
     let codeword_bytes: &[u8] = unsafe {
-        core::slice::from_raw_parts(
+        from_raw_parts(
             codeword.as_ptr() as *const u8,
-            codeword.len() * core::mem::size_of::<F128>(),
+            codeword.len() * size_of::<F128>(),
         )
     };
 

--- a/crates/flock-prover/benches/profile_prover.rs
+++ b/crates/flock-prover/benches/profile_prover.rs
@@ -9,6 +9,8 @@
 //! `N_RUNS` defaults to 10. At m=29 single-thread each prove_fast is ~440 ms,
 //! so 10 runs = 4.4 sec, dominating the ~0.5 sec setup.
 
+use std::array::from_fn;
+use std::env::args;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -30,21 +32,15 @@ impl Rng {
 }
 
 fn random_compression(rng: &mut Rng) -> Compression {
-    let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+    let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+    let m: [u32; 16] = from_fn(|_| rng.next_u32());
     (cv, m, rng.next_u32() as u64, 64u32, 11u32)
 }
 
 fn main() {
     let _ = flock_prover::init_perf_thread_pool();
-    let n_runs: usize = std::env::args()
-        .nth(1)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(10);
-    let n_blocks: usize = std::env::args()
-        .nth(2)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(32768);
+    let n_runs: usize = args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(10);
+    let n_blocks: usize = args().nth(2).and_then(|s| s.parse().ok()).unwrap_or(32768);
 
     let n_log = min_n_blocks_log(n_blocks);
     let m = K_LOG + n_log;

--- a/crates/flock-prover/benches/round1.rs
+++ b/crates/flock-prover/benches/round1.rs
@@ -7,6 +7,7 @@
 //! and in any real prover). The naive variant only runs at m ≤ 20 — beyond
 //! that it's many seconds and uninformative.
 
+use flock_prover::zerocheck::PaddingSpec;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -219,7 +220,7 @@ fn main() {
             K_SKIP,
             &r,
             &table,
-            &flock_prover::zerocheck::PaddingSpec::dense(m),
+            &PaddingSpec::dense(m),
         );
         let mut best_fusion_ms = f64::INFINITY;
         for run in 0..n_runs {
@@ -237,7 +238,7 @@ fn main() {
                 K_SKIP,
                 &r,
                 &table,
-                &flock_prover::zerocheck::PaddingSpec::dense(m),
+                &PaddingSpec::dense(m),
             );
             let elapsed = t0.elapsed().as_secs_f64() * 1000.0;
             println!("  {:<40} {:>10.2} ms", label, elapsed);

--- a/crates/flock-prover/benches/sha2_merkle_proof.rs
+++ b/crates/flock-prover/benches/sha2_merkle_proof.rs
@@ -13,6 +13,7 @@
 //! Reports both the chain overhead and the Merkle overhead over `prove_fast`,
 //! and the Merkle-vs-chain delta. K_LOG=15 → m=29 at 16,384 blocks.
 
+use std::array::from_fn;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -53,7 +54,7 @@ fn fmt_ms(s: f64) -> String {
 /// All blocks use the public SHA-256 IV as H_in.
 fn honest_merkle_path(n: usize, seed: u64) -> (Vec<Compression>, [u32; 8], [u32; 8], Vec<bool>) {
     let mut rng = Rng::new(seed);
-    let leaf: [u32; 8] = std::array::from_fn(|_| rng.nx() as u32);
+    let leaf: [u32; 8] = from_fn(|_| rng.nx() as u32);
     let mut b_bits = vec![false; n];
     for bit in b_bits.iter_mut().skip(1) {
         *bit = rng.nx() & 1 == 1;
@@ -61,7 +62,7 @@ fn honest_merkle_path(n: usize, seed: u64) -> (Vec<Compression>, [u32; 8], [u32;
     let mut blocks = Vec::with_capacity(n);
     let mut current = leaf;
     for i in 0..n {
-        let sibling: [u32; 8] = std::array::from_fn(|_| rng.nx() as u32);
+        let sibling: [u32; 8] = from_fn(|_| rng.nx() as u32);
         let mut m = [0u32; 16];
         if !b_bits[i] {
             m[..8].copy_from_slice(&current);

--- a/crates/flock-prover/benches/sha2_proof.rs
+++ b/crates/flock-prover/benches/sha2_proof.rs
@@ -3,7 +3,11 @@
 //! Uses `Sha256HybridSetup::prove_fast` — the fused (z, a, b, c, z_lincheck)
 //! generator, mirroring `sha_packed::prove_fast`.
 
+use flock_prover::proof_io::R1csProofBundleLigerito;
 use std::alloc::{GlobalAlloc, Layout, System};
+use std::array::from_fn;
+use std::env::var;
+use std::env::var_os;
 use std::hint::black_box;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
@@ -67,8 +71,8 @@ impl Rng {
 }
 
 fn random_input(rng: &mut Rng) -> ([u32; 8], [u32; 16]) {
-    let h: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+    let h: [u32; 8] = from_fn(|_| rng.next_u32());
+    let m: [u32; 16] = from_fn(|_| rng.next_u32());
     (h, m)
 }
 
@@ -100,7 +104,7 @@ fn bench_one(n_compressions: usize, n_runs: usize) {
     );
 
     // SHA2_BATCH_MAJOR=1 switches the witness layout (WitnessLayout::BatchMajor).
-    let setup = if std::env::var_os("SHA2_BATCH_MAJOR").is_some() {
+    let setup = if var_os("SHA2_BATCH_MAJOR").is_some() {
         Sha256HybridSetup::new_batch_major(n_compressions)
     } else {
         Sha256HybridSetup::new(n_compressions)
@@ -160,7 +164,7 @@ fn bench_one(n_compressions: usize, n_runs: usize) {
             .expect("verify failed");
         println!("  verify: {}", fmt_ms(t.elapsed().as_secs_f64()));
 
-        let bundle = flock_prover::proof_io::R1csProofBundleLigerito { commitment, proof };
+        let bundle = R1csProofBundleLigerito { commitment, proof };
         let proof_size = bundle.to_bytes().len();
         println!(
             "  proof size: {} bytes ({:.2} KiB)",
@@ -205,7 +209,7 @@ fn main() {
     // with SHA2_LOG2S (space/comma-separated log2 compression counts, e.g. "12 14") —
     // used by benchmarks/bench_sha256.sh to sweep at the same sizes as the
     // competitors; each listed size is benched best-of-3.
-    let specs: Vec<(usize, usize)> = match std::env::var("SHA2_LOG2S") {
+    let specs: Vec<(usize, usize)> = match var("SHA2_LOG2S") {
         Ok(s) => s
             .split([',', ' '])
             .filter(|t| !t.is_empty())

--- a/crates/flock-prover/benches/stability_probe.rs
+++ b/crates/flock-prover/benches/stability_probe.rs
@@ -7,6 +7,8 @@
 //!
 //! Prints one `RUN <bench> <ms>` line per timed prove (machine-readable).
 
+use std::array::from_fn;
+use std::env::var;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -31,12 +33,12 @@ impl Rng {
 
 fn main() {
     let _ = flock_prover::init_perf_thread_pool();
-    let runs: usize = std::env::var("STAB_RUNS")
+    let runs: usize = var("STAB_RUNS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(30);
     // STAB_WARMUP=0 exposes cold-start (first-prove) behavior.
-    let warmup: usize = std::env::var("STAB_WARMUP")
+    let warmup: usize = var("STAB_WARMUP")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(3);
@@ -49,12 +51,7 @@ fn main() {
         let mut rng = Rng::new(0x57AB);
         let mk = |rng: &mut Rng| -> Vec<([u32; 8], [u32; 16])> {
             (0..n)
-                .map(|_| {
-                    (
-                        std::array::from_fn(|_| rng.u32()),
-                        std::array::from_fn(|_| rng.u32()),
-                    )
-                })
+                .map(|_| (from_fn(|_| rng.u32()), from_fn(|_| rng.u32())))
                 .collect()
         };
         for _ in 0..warmup {
@@ -81,7 +78,7 @@ fn main() {
         let mut rng = Rng::new(0x57AC);
         let mk = |rng: &mut Rng| -> Vec<State> {
             (0..k)
-                .map(|_| std::array::from_fn(|_| rng.next_u64() & 1 == 1))
+                .map(|_| from_fn(|_| rng.next_u64() & 1 == 1))
                 .collect()
         };
         for _ in 0..warmup {

--- a/crates/flock-prover/benches/streaming_fusion_probe.rs
+++ b/crates/flock-prover/benches/streaming_fusion_probe.rs
@@ -119,11 +119,13 @@ fn build_eq(r: &[F128]) -> Vec<F128> {
 }
 
 fn main() {
+    const M: usize = 30;
+    const RUNS: usize = 5;
+    const MICRO: usize = 256;
     let _ = flock_prover::init_perf_thread_pool();
     let threads = rayon::current_num_threads();
     println!("streaming-fusion probe ({threads} thread(s))\n");
 
-    const M: usize = 30;
     let l = 1usize << (M - 7);
     let n_lo = (M - 7) / 2;
     let n_hi = (M - 7) - n_lo;
@@ -171,7 +173,7 @@ fn main() {
     // (par_chunks_mut(2) writes b_combined and accumulates prime).
     // ============================================================
     println!("\n[PATH A] current (materialize per-claim + fused combine + prime)");
-    const RUNS: usize = 5;
+
     let mut a_fold0_total = 0.0;
     let mut a_fold1_total = 0.0;
     let mut a_combine_total = 0.0;
@@ -180,6 +182,7 @@ fn main() {
     let mut path_a_u0 = F128::ZERO;
     let mut path_a_u2 = F128::ZERO;
     for run in 0..RUNS {
+        use rayon::prelude::*;
         let t_all = Instant::now();
         let t0 = Instant::now();
         let b0 = fold_b128_elems_split(&eq_lo_0, &eq_hi_0, &scaled_0);
@@ -190,7 +193,7 @@ fn main() {
 
         // Combine + prime in one par_chunks_mut(2) pass (mirrors current pcs::open_batch_mixed).
         let tc = Instant::now();
-        use rayon::prelude::*;
+
         let mut b_combined: Vec<F128> = vec![F128 { lo: 0, hi: 0 }; l];
         let (u_0, u_2) = b_combined
             .par_chunks_mut(2)
@@ -246,6 +249,7 @@ fn main() {
     let mut path_b_u0 = F128::ZERO;
     let mut path_b_u2 = F128::ZERO;
     for run in 0..RUNS {
+        use rayon::prelude::*;
         let t_all = Instant::now();
         // Build γ-baked byte tables.
         let tb = Instant::now();
@@ -257,7 +261,7 @@ fn main() {
         // task processes one i_hi worth of slots (= one row of the
         // logical (i_hi, i_lo) grid).
         let tp = Instant::now();
-        use rayon::prelude::*;
+
         let mut b_combined: Vec<F128> = vec![F128 { lo: 0, hi: 0 }; l];
         let (u_0, u_2) = b_combined
             .par_chunks_mut(b_lo)
@@ -326,7 +330,7 @@ fn main() {
     // and eq_lo lines pushed it over).
     // ============================================================
     println!("\n[PATH C] micro-tiled fusion (256-element scratchpad, 1 active table per sub-pass)");
-    const MICRO: usize = 256;
+
     let mut c_total = 0.0;
     let mut c_table_build_total = 0.0;
     let mut c_fused_pass_total = 0.0;
@@ -334,6 +338,7 @@ fn main() {
     let mut path_c_u0 = F128::ZERO;
     let mut path_c_u2 = F128::ZERO;
     for run in 0..RUNS {
+        use rayon::prelude::*;
         let t_all = Instant::now();
         let tb = Instant::now();
         let table_0 = build_phi_byte_table(&scaled_0);
@@ -341,7 +346,7 @@ fn main() {
         c_table_build_total += tb.elapsed().as_secs_f64();
 
         let tp = Instant::now();
-        use rayon::prelude::*;
+
         let mut b_combined: Vec<F128> = vec![F128 { lo: 0, hi: 0 }; l];
         let (u_0, u_2) = b_combined
             .par_chunks_mut(b_lo)

--- a/crates/flock-prover/benches/urm_probe.rs
+++ b/crates/flock-prover/benches/urm_probe.rs
@@ -14,6 +14,7 @@
 //!
 //! Default: 30 runs at m=29 (~3.2 sec ST).
 
+use std::env::args;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -47,14 +48,8 @@ impl Rng {
 
 fn main() {
     let _ = flock_prover::init_perf_thread_pool();
-    let n_runs: usize = std::env::args()
-        .nth(1)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(30);
-    let m: usize = std::env::args()
-        .nth(2)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(29);
+    let n_runs: usize = args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(30);
+    let m: usize = args().nth(2).and_then(|s| s.parse().ok()).unwrap_or(29);
 
     let n_bytes = (1usize << m) / 8;
     let mut rng = Rng::new(0xDEAD_C0DE ^ (m as u64));
@@ -84,9 +79,7 @@ fn main() {
     let ntt_s = AdditiveNttGf8::new(K_SKIP, F8::ZERO);
     let ntt_l = AdditiveNttGf8::new(K_SKIP, F8(1u8 << K_SKIP));
     let inv_table = InvNttTableByteSingleGf8::new(&ntt_s, &ntt_l);
-    let padding_mode = std::env::args()
-        .nth(3)
-        .unwrap_or_else(|| "dense".to_string());
+    let padding_mode = args().nth(3).unwrap_or_else(|| "dense".to_string());
     let padding = match padding_mode.as_str() {
         "dense" => PaddingSpec::dense(m),
         // BLAKE3 prove_fast shape: K_LOG=14, USEFUL_BITS=15,409.

--- a/crates/flock-prover/benches/witness_lincheck_probe.rs
+++ b/crates/flock-prover/benches/witness_lincheck_probe.rs
@@ -12,6 +12,8 @@
 //! outputs. Inputs are seeded, so the checksums must be bit-stable across
 //! any valid optimization.
 
+use std::array::from_fn;
+use std::env::args;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -47,8 +49,8 @@ impl Rng {
 }
 
 fn random_compression(rng: &mut Rng) -> Compression {
-    let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+    let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+    let m: [u32; 16] = from_fn(|_| rng.next_u32());
     (cv, m, rng.next_u32() as u64, 64u32, 11u32)
 }
 
@@ -72,14 +74,8 @@ impl Fnv {
 
 fn main() {
     let _ = flock_prover::init_perf_thread_pool();
-    let n_runs: usize = std::env::args()
-        .nth(1)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(8);
-    let n_blocks: usize = std::env::args()
-        .nth(2)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(65536);
+    let n_runs: usize = args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(8);
+    let n_blocks: usize = args().nth(2).and_then(|s| s.parse().ok()).unwrap_or(65536);
 
     let n_log = min_n_blocks_log(n_blocks);
     let setup = Blake3Setup::new(n_blocks);

--- a/crates/flock-prover/benches/zerocheck_phases.rs
+++ b/crates/flock-prover/benches/zerocheck_phases.rs
@@ -17,6 +17,7 @@
 //! Plus an end-to-end `prove_packed` run for cross-check.
 
 use std::hint::black_box;
+use std::mem::swap;
 use std::time::Instant;
 
 use flock_prover::challenger::{Challenger, FsChallenger};
@@ -194,8 +195,8 @@ fn prove_with_phase_timing(
                         rho_prev,
                         &r_next,
                     );
-                    std::mem::swap(&mut a_mlv, &mut a_nxt);
-                    std::mem::swap(&mut b_mlv, &mut b_nxt);
+                    swap(&mut a_mlv, &mut a_nxt);
+                    swap(&mut b_mlv, &mut b_nxt);
                     a_mlv.truncate(half);
                     b_mlv.truncate(half);
                     fused_ms += t.elapsed().as_secs_f64() * 1000.0;

--- a/crates/flock-prover/examples/gen_ligerito_configs.rs
+++ b/crates/flock-prover/examples/gen_ligerito_configs.rs
@@ -15,7 +15,9 @@
 //!
 //! Run: `cargo run --release --example gen_ligerito_configs`
 
+use std::fs::write;
 use std::path::Path;
+use std::process::exit;
 
 use flock_prover::pcs::ligerito::{LigeritoProfile, LigeritoSecurityConfig};
 
@@ -38,7 +40,7 @@ fn main() {
                     // Round-trip to be sure the written form re-validates.
                     LigeritoSecurityConfig::from_toml_str(&toml)
                         .unwrap_or_else(|e| panic!("m={m}: written toml fails reload: {e}"));
-                    std::fs::write(&path, &toml).expect("write toml");
+                    write(&path, &toml).expect("write toml");
                     let queries: usize = cfg.levels.iter().map(|l| l.queries).sum();
                     let ood: usize = cfg.levels.iter().map(|l| l.ood_samples).sum();
                     let max_fold_grind = cfg
@@ -62,6 +64,6 @@ fn main() {
         }
     }
     if failures > 0 {
-        std::process::exit(1);
+        exit(1);
     }
 }

--- a/crates/flock-prover/examples/keccak_chain_bench.rs
+++ b/crates/flock-prover/examples/keccak_chain_bench.rs
@@ -4,6 +4,8 @@
 //!
 //! Run: `cargo run --release --example keccak_chain_bench`
 
+use flock_prover::chain::prove_chain_shift;
+use flock_prover::r1cs::WitnessLayout;
 use std::hint::black_box;
 use std::time::Instant;
 
@@ -114,12 +116,7 @@ fn bench(n_keccaks: usize, n_runs: usize) {
     let mut io = (Vec::new(), Vec::new());
     for _ in 0..n_runs {
         let t = Instant::now();
-        io = fold_in_out(
-            &CHAIN_LAYOUT,
-            flock_prover::r1cs::WitnessLayout::RowMajor,
-            &z_packed,
-            &fold,
-        );
+        io = fold_in_out(&CHAIN_LAYOUT, WitnessLayout::RowMajor, &z_packed, &fold);
         best_fold = best_fold.min(t.elapsed().as_secs_f64());
     }
     let (in_vals, out_vals) = io;
@@ -130,7 +127,7 @@ fn bench(n_keccaks: usize, n_runs: usize) {
         let mut ch = FsChallenger::new(b"chain-bench-shift");
         let _ = ch.sample_f128(); // keep transcript nondegenerate
         let t = Instant::now();
-        let (p, _) = flock_prover::chain::prove_chain_shift(&in_vals, &out_vals, &mut ch);
+        let (p, _) = prove_chain_shift(&in_vals, &out_vals, &mut ch);
         best_shift = best_shift.min(t.elapsed().as_secs_f64());
         black_box(&p);
     }

--- a/crates/flock-prover/examples/linear_sha_verifier.rs
+++ b/crates/flock-prover/examples/linear_sha_verifier.rs
@@ -23,7 +23,10 @@
 //! Verified for correctness against the standard verifier path. Times both
 //! at the sha2 R1CS dimensions.
 
+use flock_prover::r1cs::SparseBinaryMatrix;
+use std::array::from_fn;
 use std::hint::black_box;
+use std::process::exit;
 use std::time::Instant;
 
 use flock_prover::field::F128;
@@ -196,7 +199,7 @@ fn linear_ab_consistency(z_vec: &[F128], eq_inner: &[F128]) -> (F128, F128) {
     }
 
     // 3. State words derived from H_in slots.
-    let h_in: [FWord; 8] = std::array::from_fn(|w| FWord::read_from(z_vec, h_bit(w, 0)));
+    let h_in: [FWord; 8] = from_fn(|w| FWord::read_from(z_vec, h_bit(w, 0)));
 
     // 4. Message schedule.
     let mut w_words: Vec<FWord> = (0..N_SCHED + 16).map(|_| FWord::zero()).collect();
@@ -377,8 +380,8 @@ fn linear_ab_consistency(z_vec: &[F128], eq_inner: &[F128]) -> (F128, F128) {
 // ───────────────────────────────────────────────────────────────────────────
 
 fn standard_ab_consistency(
-    a_0: &flock_prover::r1cs::SparseBinaryMatrix,
-    b_0: &flock_prover::r1cs::SparseBinaryMatrix,
+    a_0: &SparseBinaryMatrix,
+    b_0: &SparseBinaryMatrix,
     z_vec: &[F128],
     eq_inner: &[F128],
 ) -> (F128, F128) {
@@ -421,6 +424,7 @@ impl Rng {
 }
 
 fn main() {
+    const N_ITERS: usize = 200;
     use flock_prover::r1cs_hashes::sha2::build_block_witness;
 
     let mut rng = Rng::new(0x00C0_FFEE_5A55);
@@ -434,7 +438,7 @@ fn main() {
         0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
         0x5be0cd19,
     ];
-    let m_in: [u32; 16] = std::array::from_fn(|_| rng.next_u64() as u32);
+    let m_in: [u32; 16] = from_fn(|_| rng.next_u64() as u32);
     let z_bool = build_block_witness(&h_in, &m_in);
     let z_vec: Vec<F128> = z_bool
         .iter()
@@ -462,13 +466,12 @@ fn main() {
         println!("  ✓ both match");
     } else {
         println!("  ✗ MISMATCH");
-        std::process::exit(1);
+        exit(1);
     }
 
     // ---- Timing (single-threaded, no rayon).
     println!();
     println!("=== Timing (single-threaded, full A+B consistency check) ===");
-    const N_ITERS: usize = 200;
 
     // Warm up both paths.
     let _ = black_box(standard_ab_consistency(&a_0, &b_0, &z_vec, &eq_inner));

--- a/crates/flock-prover/src/bin/flock_chain.rs
+++ b/crates/flock-prover/src/bin/flock_chain.rs
@@ -17,6 +17,10 @@
 //! Build the prover: `cargo build --release --bin flock_chain`.
 //! Run via `cargo run --release --bin flock_chain -- <subcommand> [args]`.
 
+use flock_prover::pcs::PcsParams;
+use flock_prover::pcs::ligerito::LigeritoProfile;
+use flock_prover::r1cs::BlockR1cs;
+use std::array::from_fn;
 use std::env;
 use std::process::ExitCode;
 use std::time::Instant;
@@ -49,7 +53,7 @@ use flock_prover::r1cs_hashes::sha2::{
 /// Johnson+OOD, 100-bit (default). `Slim` = rate 1/4, Johnson+OOD + query
 /// grinding, 100-bit (smaller proof, slower prover). `Secure` = rate 1/2,
 /// unique-decoding regime, 120-bit (largest proof, most conservative).
-type Mode = flock_prover::pcs::ligerito::LigeritoProfile;
+type Mode = LigeritoProfile;
 
 #[derive(Default)]
 struct Args {
@@ -239,7 +243,7 @@ impl Rng {
         z ^ (z >> 31)
     }
     fn next_block(&mut self) -> [u32; 16] {
-        std::array::from_fn(|_| self.nx() as u32)
+        from_fn(|_| self.nx() as u32)
     }
 }
 
@@ -328,13 +332,13 @@ fn cmd_prove_mix(mix: MixSpec, args: Args) -> Result<(), String> {
     let mut rng = Rng::new(seed);
     let blake3_inputs: Vec<blake3_chain::Compression> = (0..mix.blake3)
         .map(|_| {
-            let cv: [u32; 8] = std::array::from_fn(|_| rng.nx() as u32);
+            let cv: [u32; 8] = from_fn(|_| rng.nx() as u32);
             let m = rng.next_block();
             (cv, m, 0u64, 64u32, 0u32)
         })
         .collect();
     let sha2_inputs: Vec<sha2_chain::Compression> = (0..mix.sha2)
-        .map(|_| (std::array::from_fn(|_| rng.nx() as u32), rng.next_block()))
+        .map(|_| (from_fn(|_| rng.nx() as u32), rng.next_block()))
         .collect();
 
     let t = Instant::now();
@@ -382,7 +386,7 @@ fn prove_blake3(
 ) -> Result<ChainProofBundleLigerito, String> {
     let initial_cv: [u32; 8] = if let Some(h) = initial_hex {
         let v = parse_u32_be_words(h, 8)?;
-        std::array::from_fn(|i| v[i])
+        from_fn(|i| v[i])
     } else {
         BLAKE3_IV
     };
@@ -423,7 +427,7 @@ fn prove_sha2(
 ) -> Result<ChainProofBundleLigerito, String> {
     let initial_cv: [u32; 8] = if let Some(h) = initial_hex {
         let v = parse_u32_be_words(h, 8)?;
-        std::array::from_fn(|i| v[i])
+        from_fn(|i| v[i])
     } else {
         SHA256_IV
     };
@@ -660,12 +664,12 @@ fn cmd_verify_mix(input: &str, bytes: &[u8]) -> Result<(), String> {
 }
 
 fn verify_ligerito_with_layout(
-    r1cs: &flock_prover::r1cs::BlockR1cs,
+    r1cs: &BlockR1cs,
     layout: &chain_common::ChainLayout,
     commitment: &Commitment,
     bundle: &ChainProofBundleLigerito,
     n_log: usize,
-    pcs_params: &flock_prover::pcs::PcsParams,
+    pcs_params: &PcsParams,
     challenger: &mut FsChallenger,
 ) -> Result<(), chain_common::ChainVerifyError> {
     let lc_circuit = r1cs.csc_lincheck_circuit();

--- a/crates/flock-prover/src/chain.rs
+++ b/crates/flock-prover/src/chain.rs
@@ -57,11 +57,13 @@
 //! `eq(τ',0ⁿ)`. Soundness rests on the PCS binding `g(τ',s₀*)` to the committed
 //! `ẑ`; the sumcheck (random `τ`, `α`) proves the glue + both endpoints at once.
 
+use flock_core::bits::lowest_one;
 use flock_core::challenger::Challenger;
 use flock_core::field::F128;
 use flock_core::lincheck::build_eq_table;
 use flock_core::zerocheck::multilinear::eq_eval;
 use serde::{Deserialize, Serialize};
+use std::slice::from_raw_parts;
 
 /// Multilinear extension of the successor relation `b = a + 1` (integer
 /// increment on `n` bits, LSB-first), evaluated at `(a, b) ∈ Fⁿ × Fⁿ`.
@@ -396,7 +398,7 @@ pub fn fold_contiguous_regions(
     for bo in 0..n_bytes {
         let t = &mut tab[bo];
         for v in 1usize..256 {
-            let lsb = flock_core::bits::lowest_one(v);
+            let lsb = lowest_one(v);
             let bit = lsb.trailing_zeros() as usize;
             t[v] = t[v ^ lsb] + region_weights[8 * bo + bit];
         }
@@ -404,8 +406,7 @@ pub fn fold_contiguous_regions(
 
     // SAFETY: F128 is repr(C, align(16)) = two LE u64s, so byte B of this view
     // holds logical bits [8B, 8B+8); bit (8B+r) = (byte >> r) & 1.
-    let bytes: &[u8] =
-        unsafe { std::slice::from_raw_parts(packed.as_ptr() as *const u8, packed.len() * 16) };
+    let bytes: &[u8] = unsafe { from_raw_parts(packed.as_ptr() as *const u8, packed.len() * 16) };
 
     // Single par_iter over instances producing one length-`n_regions` row per
     // instance — fuses what was previously N sequential `(par_iter).collect()`

--- a/crates/flock-prover/src/merkle_path.rs
+++ b/crates/flock-prover/src/merkle_path.rs
@@ -31,6 +31,7 @@
 //! extra evaluation just constrains the interpolation to the lower-degree
 //! polynomial.
 
+use crate::chain::shift_mle as chain_shift_mle;
 use flock_core::challenger::Challenger;
 use flock_core::field::F128;
 use flock_core::lincheck::build_eq_table;
@@ -184,7 +185,7 @@ fn slot_indicator(target_slot: u8, ss: F128, sd: F128) -> F128 {
 
 #[inline]
 fn shift_mle(a: &[F128], b: &[F128]) -> F128 {
-    crate::chain::shift_mle(a, b)
+    chain_shift_mle(a, b)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/flock-prover/src/mixed.rs
+++ b/crates/flock-prover/src/mixed.rs
@@ -42,6 +42,7 @@ use flock_core::r1cs::BlockR1cs;
 use flock_core::schedule::{Registry, TableType};
 use flock_core::union::UnionInstance;
 use flock_core::verifier::{self, VerifyError};
+use serde::de::Error;
 use serde::{Deserialize, Serialize};
 
 use crate::prover::{self, UnionSlotProverInput};
@@ -161,7 +162,7 @@ impl<'de> Deserialize<'de> for MixedRegistryId {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         let code = u8::deserialize(d)?;
         Self::from_code(code)
-            .ok_or_else(|| serde::de::Error::custom(format!("unknown mixed registry id {code}")))
+            .ok_or_else(|| Error::custom(format!("unknown mixed registry id {code}")))
     }
 }
 

--- a/crates/flock-prover/src/proof_io.rs
+++ b/crates/flock-prover/src/proof_io.rs
@@ -32,6 +32,27 @@
 //! // Then call e.g. `setup.verify(&bundle.commitment, &bundle.proof, ...)`.
 //! ```
 
+use crate::mixed::MixedRegistryId;
+#[cfg(test)]
+use crate::r1cs_hashes::blake3::Compression as Blake3Compression;
+use crate::r1cs_hashes::chain_common::ChainProofLigerito;
+#[cfg(test)]
+use crate::r1cs_hashes::sha2::Compression as Sha2Compression;
+use flock_core::proof::R1csProofLigerito;
+use flock_core::proof::R1csProofMergedLigerito;
+#[cfg(test)]
+use std::array::from_fn;
+#[cfg(test)]
+use std::env::temp_dir;
+use std::error::Error;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
+use std::fs::read;
+#[cfg(test)]
+use std::fs::remove_file;
+use std::fs::rename;
+use std::fs::write;
 use std::io;
 use std::path::Path;
 
@@ -170,8 +191,8 @@ pub enum DeserializeError {
     Bincode(bincode::Error),
 }
 
-impl std::fmt::Display for DeserializeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for DeserializeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Self::BadMagic => write!(f, "bad magic: not a FLOCK proof file"),
             Self::UnsupportedVersion(v) => {
@@ -187,7 +208,7 @@ impl std::fmt::Display for DeserializeError {
     }
 }
 
-impl std::error::Error for DeserializeError {}
+impl Error for DeserializeError {}
 
 impl From<bincode::Error> for DeserializeError {
     fn from(e: bincode::Error) -> Self {
@@ -202,7 +223,7 @@ impl From<bincode::Error> for DeserializeError {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct R1csProofBundleLigerito {
     pub commitment: Commitment,
-    pub proof: flock_core::proof::R1csProofLigerito,
+    pub proof: R1csProofLigerito,
 }
 
 /// Bundles a hash-chain proof with its commitment + public endpoint bits
@@ -214,7 +235,7 @@ pub struct R1csProofBundleLigerito {
 pub struct ChainProofBundleLigerito {
     pub hash_kind: HashKind,
     pub commitment: Commitment,
-    pub proof: crate::r1cs_hashes::chain_common::ChainProofLigerito,
+    pub proof: ChainProofLigerito,
     pub cv_0_phys: Vec<bool>,
     pub cv_last_phys: Vec<bool>,
 }
@@ -258,12 +279,12 @@ impl ChainProofBundleLigerito {
 /// — no per-invocation I/O binding.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MixedProofBundleLigerito {
-    pub registry_id: crate::mixed::MixedRegistryId,
+    pub registry_id: MixedRegistryId,
     /// Declared invocation counts, in slot order (for the current tiers:
     /// SHA-256, then BLAKE3).
     pub counts: Vec<u64>,
     pub commitment: Commitment,
-    pub proof: flock_core::proof::R1csProofMergedLigerito,
+    pub proof: R1csProofMergedLigerito,
 }
 
 impl MixedProofBundleLigerito {
@@ -350,13 +371,13 @@ pub fn write_bytes_to_file<P: AsRef<Path>>(path: P, bytes: &[u8]) -> io::Result<
         )),
         None => Path::new(".flock-proof.tmp").to_path_buf(),
     };
-    std::fs::write(&tmp, bytes)?;
-    std::fs::rename(&tmp, path)
+    write(&tmp, bytes)?;
+    rename(&tmp, path)
 }
 
 /// Read raw bytes from a file. Thin wrapper over `std::fs::read`.
 pub fn read_bytes_from_file<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
-    std::fs::read(path)
+    read(path)
 }
 
 /// Write a Ligerito chain bundle to `path`.
@@ -383,8 +404,8 @@ pub enum BundleReadError {
     Deserialize(DeserializeError),
 }
 
-impl std::fmt::Display for BundleReadError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for BundleReadError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Self::Io(e) => write!(f, "I/O error: {e}"),
             Self::Deserialize(e) => write!(f, "deserialize error: {e}"),
@@ -392,7 +413,7 @@ impl std::fmt::Display for BundleReadError {
     }
 }
 
-impl std::error::Error for BundleReadError {}
+impl Error for BundleReadError {}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -422,11 +443,11 @@ mod tests {
     /// Build a small honest BLAKE3 chain (n=8) for the bundle tests.
     fn honest_chain(n: usize, seed: u64) -> (Vec<Compression>, [u32; 8], [u32; 8]) {
         let mut rng = Rng::new(seed);
-        let mut cv: [u32; 8] = std::array::from_fn(|_| rng.nx() as u32);
+        let mut cv: [u32; 8] = from_fn(|_| rng.nx() as u32);
         let cv0 = cv;
         let mut blocks = Vec::with_capacity(n);
         for _ in 0..n {
-            let m: [u32; 16] = std::array::from_fn(|_| rng.nx() as u32);
+            let m: [u32; 16] = from_fn(|_| rng.nx() as u32);
             let counter = 0u64;
             let block_len = 64u32;
             let flags = 0u32;
@@ -481,10 +502,10 @@ mod tests {
         }
 
         // File roundtrip.
-        let path = std::env::temp_dir().join("flock-proofio-roundtrip.bin");
+        let path = temp_dir().join("flock-proofio-roundtrip.bin");
         write_bytes_to_file(&path, &bytes).expect("write");
         let read_back = read_bytes_from_file(&path).expect("read");
-        let _ = std::fs::remove_file(&path);
+        let _ = remove_file(&path);
         let bundle4 = R1csProofBundleLigerito::from_bytes(&read_back).expect("file round-trip");
         let mut chv = FsChallenger::new(b"flock-proofio-lig");
         setup
@@ -599,10 +620,10 @@ mod tests {
         );
 
         // File roundtrip.
-        let path = std::env::temp_dir().join("flock-proofio-mixed-roundtrip.bin");
+        let path = temp_dir().join("flock-proofio-mixed-roundtrip.bin");
         write_mixed_bundle_ligerito_to_file(&path, &bundle).expect("write");
         let bundle3 = read_mixed_bundle_ligerito_from_file(&path).expect("file round-trip");
-        let _ = std::fs::remove_file(&path);
+        let _ = remove_file(&path);
         assert_eq!(bundle3.counts, bundle.counts);
 
         eprintln!(
@@ -615,32 +636,21 @@ mod tests {
 
     /// Deterministic input generators shared with the mixed bundle test.
     mod flock_prover_test_inputs {
-        use super::Rng;
+        use super::{Blake3Compression, Rng, Sha2Compression, from_fn};
 
-        pub fn random_blake3_inputs(
-            rng: &mut Rng,
-            n: usize,
-        ) -> Vec<crate::r1cs_hashes::blake3::Compression> {
+        pub fn random_blake3_inputs(rng: &mut Rng, n: usize) -> Vec<Blake3Compression> {
             (0..n)
                 .map(|_| {
-                    let cv: [u32; 8] = std::array::from_fn(|_| rng.nx() as u32);
-                    let m: [u32; 16] = std::array::from_fn(|_| rng.nx() as u32);
+                    let cv: [u32; 8] = from_fn(|_| rng.nx() as u32);
+                    let m: [u32; 16] = from_fn(|_| rng.nx() as u32);
                     (cv, m, rng.nx(), 64u32, 11u32)
                 })
                 .collect()
         }
 
-        pub fn random_sha2_inputs(
-            rng: &mut Rng,
-            n: usize,
-        ) -> Vec<crate::r1cs_hashes::sha2::Compression> {
+        pub fn random_sha2_inputs(rng: &mut Rng, n: usize) -> Vec<Sha2Compression> {
             (0..n)
-                .map(|_| {
-                    (
-                        std::array::from_fn(|_| rng.nx() as u32),
-                        std::array::from_fn(|_| rng.nx() as u32),
-                    )
-                })
+                .map(|_| (from_fn(|_| rng.nx() as u32), from_fn(|_| rng.nx() as u32)))
                 .collect()
         }
     }

--- a/crates/flock-prover/src/prover.rs
+++ b/crates/flock-prover/src/prover.rs
@@ -25,15 +25,42 @@
 //!     R1csClaim { ab: z-claim from lincheck,  c: z-claim from extract_c }
 //! ```
 
+use core::mem::size_of;
 use flock_core::challenger::Challenger;
+use flock_core::circuit::Circuit;
+use flock_core::circuit::WiringProof;
+use flock_core::circuit::prove_wiring;
+use flock_core::element_r1cs::ElementTableType;
+use flock_core::element_r1cs::union::Claims;
+use flock_core::element_r1cs::union::Proof;
+use flock_core::element_r1cs::union::copy_live_region;
+use flock_core::element_r1cs::union::dead_rows_unread;
+use flock_core::element_r1cs::union::fill_slot;
+use flock_core::element_r1cs::union::prove;
 use flock_core::field::F128;
 use flock_core::lincheck::{self, QuirkyPoint, pack_z_lincheck_from_packed};
 use flock_core::pcs::{self, Commitment, PcsParams};
-use flock_core::proof::{
-    R1csClaim, R1csProofLigerito, ZClaim, bind_statement,
-};
+use flock_core::proof::BooleanPiopProof;
+use flock_core::proof::R1csProofCircuitMerged;
+use flock_core::proof::R1csProofMergedLigerito;
+use flock_core::proof::R1csProofMixedClassMerged;
+use flock_core::proof::UnionClassClaims;
+use flock_core::proof::{R1csClaim, R1csProofLigerito, ZClaim, bind_statement};
 use flock_core::r1cs::BlockR1cs;
+use flock_core::r1cs::WitnessLayout;
+use flock_core::schedule::TableClass;
+use flock_core::scratch::give_f128;
+use flock_core::scratch::give_u8;
+use flock_core::union::SlotWitness;
+use flock_core::union::SlotWitnessDest;
+use flock_core::union::UnionInstance;
+use flock_core::union::WitnessBufMode;
 use flock_core::zerocheck;
+use std::env::var;
+use std::mem::size_of_val;
+use std::slice::from_raw_parts;
+use std::sync::Arc;
+use std::time::Instant;
 
 /// Construct a multilinear `x_outer_full` of length `m − k_skip` from a
 /// QuirkyPoint: concatenate `x_inner_rest` and `x_outer`. This is the format
@@ -102,7 +129,7 @@ pub fn prove_ligerito<Ch: Challenger>(
 ) -> (R1csProofLigerito, Commitment, R1csClaim) {
     assert_eq!(
         r1cs.layout,
-        flock_core::r1cs::WitnessLayout::RowMajor,
+        WitnessLayout::RowMajor,
         "the generic matrix-driven provers assume the row-major layout \
          (block-diagonal apply + lincheck stripe packing); batch-major \
          setups must use the per-hash prove_fast paths"
@@ -126,7 +153,7 @@ pub fn prove_ligerito<Ch: Challenger>(
         r1cs.apply_c_packed(&z_packed)
     };
     let cast = |v: &[F128]| -> &[u8] {
-        unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, std::mem::size_of_val(v)) }
+        unsafe { from_raw_parts(v.as_ptr() as *const u8, size_of_val(v)) }
     };
     let a_packed: &[u8] = cast(&a_packed_f128);
     let b_packed: &[u8] = cast(&b_packed_f128);
@@ -275,19 +302,19 @@ enum UnionSlotWitnessSource<'a> {
     /// Already generated into the slot's own buffers — the union assembly
     /// COPIES them to the slot's aligned block.
     Prebuilt {
-        witness: flock_core::union::SlotWitness,
+        witness: SlotWitness,
         z_lincheck: Vec<u8>,
     },
     /// Generated in place: the closure is handed the slot's block of the
     /// union buffers and writes it directly, returning the lincheck stripe.
     /// No copy — see [`flock_core::union::SlotWitnessDest`].
-    InPlace(Box<dyn FnOnce(flock_core::union::SlotWitnessDest<'_>) -> Vec<u8> + Send + 'a>),
+    InPlace(Box<dyn FnOnce(SlotWitnessDest<'_>) -> Vec<u8> + Send + 'a>),
     /// An ELEMENT slot: the closure writes the slot's committed element words
     /// into the `z` view and `element_r1cs::union::fill_slot` derives `a`/`b`
     /// from them by sparse gather. There is no lincheck stripe — the element
     /// lincheck folds the committed region itself.
     Element {
-        ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+        ty: Arc<ElementTableType>,
         generate: Box<dyn FnOnce(&mut [F128]) + Send + 'a>,
     },
 }
@@ -330,7 +357,7 @@ impl<'a> UnionSlotProverInput<'a> {
     ) -> Self {
         Self {
             source: UnionSlotWitnessSource::Prebuilt {
-                witness: flock_core::union::SlotWitness {
+                witness: SlotWitness {
                     z_packed,
                     a_packed,
                     b_packed,
@@ -357,7 +384,7 @@ impl<'a> UnionSlotProverInput<'a> {
     /// — a slot's BatchMajor layout IS its aligned union sub-block — so the
     /// proof is byte-identical, only the copy is gone.
     pub fn in_place(
-        generate: impl FnOnce(flock_core::union::SlotWitnessDest<'_>) -> Vec<u8> + Send + 'a,
+        generate: impl FnOnce(SlotWitnessDest<'_>) -> Vec<u8> + Send + 'a,
         lincheck_circuit: &'a dyn lincheck::LincheckCircuit,
     ) -> Self {
         Self {
@@ -382,7 +409,7 @@ impl<'a> UnionSlotProverInput<'a> {
 /// vector has one entry per slot, EMPTY for element slots — the element
 /// lincheck folds the committed region directly and has no stripe.
 fn build_union_witness(
-    union: &flock_core::union::UnionInstance<'_>,
+    union: &UnionInstance<'_>,
     sources: Vec<UnionSlotWitnessSource<'_>>,
     padding_unread: bool,
 ) -> (
@@ -390,7 +417,7 @@ fn build_union_witness(
     Vec<F128>,
     Vec<F128>,
     Vec<Vec<u8>>,
-    flock_core::union::WitnessBufMode,
+    WitnessBufMode,
 ) {
     assert_eq!(
         sources.len(),
@@ -416,25 +443,18 @@ fn build_union_witness(
             }
         }
         let (z, a, b) = union.assemble_witness(witnesses);
-        return (
-            z,
-            a,
-            b,
-            stripes,
-            flock_core::union::WitnessBufMode::PooledZeroed,
-        );
+        return (z, a, b, stripes, WitnessBufMode::PooledZeroed);
     }
 
     let (mut z, mut a, mut b, mode) = union.take_witness_buffers(padding_unread);
-    let elide = mode != flock_core::union::WitnessBufMode::PooledZeroed;
+    let elide = mode != WitnessBufMode::PooledZeroed;
     let nu = union.n_log();
     // Live-only element `pa`/`pb` derivation: when the region zerocheck will
     // take its sparse arm, dead rows of `a`/`b` are unread everywhere (their
     // values are substituted analytically), so the gather skips them — the
     // same pay-per-live discipline the boolean side's run-lists apply. Gated
     // by the zerocheck's OWN predicate so the two cannot drift.
-    let elem_live = union.has_element()
-        && flock_core::element_r1cs::union::dead_rows_unread(union);
+    let elem_live = union.has_element() && dead_rows_unread(union);
     let stripes = union
         .slot_dests(&mut z, &mut a, &mut b, elide)
         .into_iter()
@@ -453,9 +473,7 @@ fn build_union_witness(
             }
             UnionSlotWitnessSource::Element { ty, generate } => {
                 let live = elem_live.then(|| union.counts()[i]);
-                flock_core::element_r1cs::union::fill_slot(
-                    &ty, nu, live, dst.z, dst.a, dst.b, generate,
-                );
+                fill_slot(&ty, nu, live, dst.z, dst.a, dst.b, generate);
                 Vec::new()
             }
         })
@@ -479,7 +497,7 @@ enum UnionProveBinding<'a> {
 /// union's declared counts) and its public words, in public-segment order.
 #[derive(Clone, Copy)]
 pub struct CircuitProverInput<'a> {
-    pub circuit: &'a flock_core::circuit::Circuit,
+    pub circuit: &'a Circuit,
     pub public: &'a [F128],
 }
 
@@ -497,18 +515,14 @@ pub struct CircuitProverInput<'a> {
 /// Verify with [`flock_core::verifier::verify_ligerito_union_circuit`].
 #[allow(clippy::too_many_arguments)]
 pub fn prove_fast_ligerito_union_circuit<Ch: Challenger>(
-    union: &flock_core::union::UnionInstance<'_>,
-    circuit: &flock_core::circuit::Circuit,
+    union: &UnionInstance<'_>,
+    circuit: &Circuit,
     public: &[F128],
     pcs_params: &PcsParams,
     slots: Vec<UnionSlotProverInput<'_>>,
     element_slots: Vec<UnionElementSlotInput<'_>>,
     challenger: &mut Ch,
-) -> (
-    flock_core::proof::R1csProofCircuitMerged,
-    Commitment,
-    flock_core::proof::UnionClassClaims,
-) {
+) -> (R1csProofCircuitMerged, Commitment, UnionClassClaims) {
     assert!(
         circuit.check_instance(union),
         "the circuit and the union instance must be the same statement \
@@ -537,14 +551,14 @@ pub fn prove_fast_ligerito_union_circuit<Ch: Challenger>(
         None => (None, None),
     };
     (
-        flock_core::proof::R1csProofCircuitMerged {
+        R1csProofCircuitMerged {
             boolean: bool_proof,
             element: el_proof,
             wiring: wiring.expect("the circuit binding runs the wiring argument"),
             pcs_open,
         },
         commitment,
-        flock_core::proof::UnionClassClaims {
+        UnionClassClaims {
             boolean: bool_claim,
             element: el_claim,
         },
@@ -569,15 +583,11 @@ pub fn prove_fast_ligerito_union_circuit<Ch: Challenger>(
 /// `generate_witness_batch_major` drivers fill padding rows with real dummy
 /// invocations (pin = 1) and are only valid here at `n_t = 2^nu`.
 pub fn prove_fast_ligerito_union<Ch: Challenger>(
-    union: &flock_core::union::UnionInstance<'_>,
+    union: &UnionInstance<'_>,
     pcs_params: &PcsParams,
     slots: Vec<UnionSlotProverInput<'_>>,
     challenger: &mut Ch,
-) -> (
-    flock_core::proof::R1csProofMergedLigerito,
-    Commitment,
-    R1csClaim,
-) {
+) -> (R1csProofMergedLigerito, Commitment, R1csClaim) {
     // This entry returns `R1csClaim` — structurally boolean-only. Element
     // registries go through the mixed-class entry, whose merged open carries
     // their claims packed-direct.
@@ -596,7 +606,7 @@ pub fn prove_fast_ligerito_union<Ch: Challenger>(
     );
     let (piop, claim) = out.boolean.expect("asserted boolean-only above");
     (
-        flock_core::proof::R1csProofMergedLigerito {
+        R1csProofMergedLigerito {
             zerocheck: piop.zerocheck,
             lincheck: piop.lincheck,
             pcs_open: out.pcs_open,
@@ -610,14 +620,11 @@ pub fn prove_fast_ligerito_union<Ch: Challenger>(
 /// paired with its claims (`None` when the registry has no type of that class),
 /// plus the single opening covering all of them.
 struct UnionProveOutput {
-    boolean: Option<(flock_core::proof::BooleanPiopProof, R1csClaim)>,
-    element: Option<(
-        flock_core::element_r1cs::union::Proof,
-        flock_core::element_r1cs::union::Claims,
-    )>,
+    boolean: Option<(BooleanPiopProof, R1csClaim)>,
+    element: Option<(Proof, Claims)>,
     /// The wiring argument's transcript — `Some` exactly under
     /// [`UnionProveBinding::Circuit`].
-    wiring: Option<flock_core::circuit::WiringProof>,
+    wiring: Option<WiringProof>,
     pcs_open: pcs::MergedOpenProof,
 }
 
@@ -628,7 +635,7 @@ struct UnionProveOutput {
 /// order documented on [`prove_fast_ligerito_union_mixed_class`],
 /// then batches all four claims into one merged opening.
 fn prove_union_with_binding<Ch: Challenger>(
-    union: &flock_core::union::UnionInstance<'_>,
+    union: &UnionInstance<'_>,
     binding: UnionProveBinding,
     pcs_params: &PcsParams,
     slots: Vec<UnionSlotProverInput<'_>>,
@@ -671,8 +678,8 @@ fn prove_union_with_binding<Ch: Challenger>(
     }
     for (ty, input) in union.registry().element_types().iter().zip(element_slots) {
         let element = match &ty.class {
-            flock_core::schedule::TableClass::LargeField(el) => el.clone(),
-            flock_core::schedule::TableClass::Boolean => {
+            TableClass::LargeField(el) => el.clone(),
+            TableClass::Boolean => {
                 unreachable!("element_types() are LargeField")
             }
         };
@@ -681,9 +688,9 @@ fn prove_union_with_binding<Ch: Challenger>(
             generate: input.generate,
         });
     }
-    let trace = std::env::var("PCS_TRACE").is_ok();
-    let t_all = std::time::Instant::now();
-    let t = std::time::Instant::now();
+    let trace = var("PCS_TRACE").is_ok();
+    let t_all = Instant::now();
+    let t = Instant::now();
     // BOOLEAN-only registries never read dropped words: the zerocheck is
     // run-list-gated, the union lincheck is count-proportional, compaction
     // reads declared rows only, and (when s_hat_v is precomputed) the
@@ -703,7 +710,7 @@ fn prove_union_with_binding<Ch: Challenger>(
         && union.m_total() - union.n_log() >= pcs::LOG_PACKING;
     let (z_packed, a_packed_f128, b_packed_f128, stripes, buf_mode) =
         build_union_witness(union, sources, padding_unread);
-    let give_back = buf_mode != flock_core::union::WitnessBufMode::FreshZeroed;
+    let give_back = buf_mode != WitnessBufMode::FreshZeroed;
     if trace {
         eprintln!(
             "  [prove_union] witgen (padded 2^{}, {:?}): {:7.2} ms",
@@ -728,10 +735,10 @@ fn prove_union_with_binding<Ch: Challenger>(
     // cost only. Under PooledDirty, dropped words are dirty by design —
     // and never read — so the compaction skips the honest-zeros
     // debug_assert.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let q: Vec<F128> = if union.compaction_is_identity() {
         z_packed.clone()
-    } else if buf_mode == flock_core::union::WitnessBufMode::PooledDirty {
+    } else if buf_mode == WitnessBufMode::PooledDirty {
         union.compact_witness_unchecked(&z_packed)
     } else {
         union.compact_witness(&z_packed)
@@ -751,7 +758,7 @@ fn prove_union_with_binding<Ch: Challenger>(
     // chunk-columns are still a contiguous zero tail (BLAKE3 commits 121 of
     // 128, so t = 61 of 64 lanes at M = 30). Both arms therefore dispatch on
     // `num_lanes` alone.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let (commitment, prover_data) = if pcs_params.num_lanes.is_some() {
         pcs::commit_lane_major(&q, pcs_params)
     } else {
@@ -763,7 +770,7 @@ fn prove_union_with_binding<Ch: Challenger>(
             t.elapsed().as_secs_f64() * 1e3
         );
     }
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     match binding {
         UnionProveBinding::Mixed => union.bind_statement(challenger, &commitment),
         UnionProveBinding::Circuit(ci) => {
@@ -811,15 +818,11 @@ fn prove_union_with_binding<Ch: Challenger>(
     // On the dense arm (> 50% region utilization) the zerocheck reads the
     // whole region, so the copy stays faithful — including whatever the
     // full derivation wrote on dead rows (the per-column constants).
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let element_ab: Option<(Vec<F128>, Vec<F128>)> = union.has_element().then(|| {
         let r = union.element_word_range();
-        if flock_core::element_r1cs::union::dead_rows_unread(union) {
-            flock_core::element_r1cs::union::copy_live_region(
-                union,
-                &a_packed_f128[r.clone()],
-                &b_packed_f128[r],
-            )
+        if dead_rows_unread(union) {
+            copy_live_region(union, &a_packed_f128[r.clone()], &b_packed_f128[r])
         } else {
             (a_packed_f128[r.clone()].to_vec(), b_packed_f128[r].to_vec())
         }
@@ -834,17 +837,12 @@ fn prove_union_with_binding<Ch: Challenger>(
     }
 
     // ---- The boolean class's PIOP pair, over the prefix subcube.
-    let t_bool = std::time::Instant::now();
+    let t_bool = Instant::now();
     let boolean = (union.num_boolean() > 0).then(|| {
         let (zc_proof, zc_claim, s_hat_v_c) = {
             // Zero-cost &[u8] views of the F128 buffers; c aliases z (C = I).
             let view = |v: &[F128]| -> &[u8] {
-                unsafe {
-                    std::slice::from_raw_parts(
-                        v.as_ptr() as *const u8,
-                        bool_words * core::mem::size_of::<F128>(),
-                    )
-                }
+                unsafe { from_raw_parts(v.as_ptr() as *const u8, bool_words * size_of::<F128>()) }
             };
             let a_packed = view(&a_packed_f128);
             let b_packed = view(&b_packed_f128);
@@ -910,7 +908,7 @@ fn prove_union_with_binding<Ch: Challenger>(
             None
         };
         (
-            flock_core::proof::BooleanPiopProof {
+            BooleanPiopProof {
                 zerocheck: zc_proof,
                 lincheck: lc_proof,
             },
@@ -929,24 +927,24 @@ fn prove_union_with_binding<Ch: Challenger>(
     }
     // a/b are consumed; recycle the buffers as in `prove_fast_core`.
     if give_back {
-        flock_core::scratch::give_f128(a_packed_f128);
-        flock_core::scratch::give_f128(b_packed_f128);
+        give_f128(a_packed_f128);
+        give_f128(b_packed_f128);
     }
     // Recycle the stripes (as large as the witness itself) rather than
     // unmapping them — the drivers take them from the same pool.
     for (stripe, _) in linchecks {
         if give_back {
-            flock_core::scratch::give_u8(stripe);
+            give_u8(stripe);
         }
     }
 
     // ---- The element class's PIOP pair, over the element region. Runs AFTER
     // the boolean pair, so its τ' is drawn from a transcript that already
     // absorbed every boolean message (and vice versa is impossible).
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let element = element_ab.map(|(pa, pb)| {
         let r = union.element_word_range();
-        flock_core::element_r1cs::union::prove(union, &z_packed[r], pa, pb, challenger)
+        prove(union, &z_packed[r], pa, pb, challenger)
     });
     if trace && element.is_some() {
         eprintln!(
@@ -963,11 +961,11 @@ fn prove_union_with_binding<Ch: Challenger>(
     // It reads `z_packed` — the padded buffer the commitment was built from,
     // whose dummy rows are zero by the union's witness contract, which is what
     // makes the dummy cells' `w = 0` honest.
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let wiring = match &binding {
-        UnionProveBinding::Circuit(ci) => Some(flock_core::circuit::prove_wiring(
-            ci.circuit, &z_packed, ci.public, challenger,
-        )),
+        UnionProveBinding::Circuit(ci) => {
+            Some(prove_wiring(ci.circuit, &z_packed, ci.public, challenger))
+        }
         _ => None,
     };
     if trace && let Some((_, claims)) = &wiring {
@@ -984,10 +982,10 @@ fn prove_union_with_binding<Ch: Challenger>(
     // PACKED-DIRECT — carried unbuilt by the merged open (it derives its
     // identity-fold weights from `point`/`value` alone and never reads
     // `eq_ind`).
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let heights = union.jagged_heights();
     let t_h = t.elapsed().as_secs_f64() * 1e3;
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let (z_claims, pre): (Vec<ZClaim>, Vec<Option<&[F128]>>) = match &boolean {
         Some((_, claim, s_hat_v_ab, s_hat_v_c)) => (
             vec![claim.ab.clone(), claim.c.clone()],
@@ -996,13 +994,13 @@ fn prove_union_with_binding<Ch: Challenger>(
         None => (Vec::new(), Vec::new()),
     };
     let t_z = t.elapsed().as_secs_f64() * 1e3;
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut packed_direct: Vec<pcs::PackedDirectClaim> = match &element {
         Some((_, claims)) => element_packed_direct_claims(claims),
         None => Vec::new(),
     };
     let t_e = t.elapsed().as_secs_f64() * 1e3;
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let wiring = wiring.map(|(proof, gather_claims)| {
         packed_direct.extend(gather_claims);
         proof
@@ -1015,9 +1013,11 @@ fn prove_union_with_binding<Ch: Challenger>(
             t_h + t_z + t_e + t_w
         );
     }
-    let t = std::time::Instant::now();
-    let x_fulls: Vec<Vec<F128>> =
-        z_claims.iter().map(|cl| quirky_x_outer_full(&cl.point)).collect();
+    let t = Instant::now();
+    let x_fulls: Vec<Vec<F128>> = z_claims
+        .iter()
+        .map(|cl| quirky_x_outer_full(&cl.point))
+        .collect();
     let x_refs: Vec<&[F128]> = x_fulls.iter().map(|v| v.as_slice()).collect();
     let pcs_open = pcs::open_batch_merged(
         q,
@@ -1033,7 +1033,7 @@ fn prove_union_with_binding<Ch: Challenger>(
         &lig_config,
         challenger,
     );
-    flock_core::scratch::give_f128(z_packed);
+    give_f128(z_packed);
     if trace {
         eprintln!(
             "  [prove_union] open (rs×{}, pd×{}): {:7.2} ms",
@@ -1079,9 +1079,7 @@ fn binding_circuit_mu(binding: &UnionProveBinding<'_>) -> usize {
 /// forgotten conversion on a path that DID need a tensor would trip the
 /// combine's "EqPoint claims are only supported alone" assert rather than
 /// silently dropping the contribution.)
-fn element_packed_direct_claims(
-    claims: &flock_core::element_r1cs::union::Claims,
-) -> Vec<pcs::PackedDirectClaim> {
+fn element_packed_direct_claims(claims: &Claims) -> Vec<pcs::PackedDirectClaim> {
     [
         (&claims.c_point, claims.c_value),
         (&claims.lc_point, claims.lc_value),
@@ -1178,21 +1176,21 @@ pub fn prove_fast_core_with_codeword<Ch: Challenger>(
     let (zc_proof, zc_claim, s_hat_v_c) = {
         // Zero-cost &[u8] views of the F128 buffers; c aliases z (C = I).
         let a_packed: &[u8] = unsafe {
-            std::slice::from_raw_parts(
+            from_raw_parts(
                 a_packed_f128.as_ptr() as *const u8,
-                a_packed_f128.len() * core::mem::size_of::<F128>(),
+                a_packed_f128.len() * size_of::<F128>(),
             )
         };
         let b_packed: &[u8] = unsafe {
-            std::slice::from_raw_parts(
+            from_raw_parts(
                 b_packed_f128.as_ptr() as *const u8,
-                b_packed_f128.len() * core::mem::size_of::<F128>(),
+                b_packed_f128.len() * size_of::<F128>(),
             )
         };
         let c_packed: &[u8] = unsafe {
-            std::slice::from_raw_parts(
+            from_raw_parts(
                 z_packed.as_ptr() as *const u8,
-                z_packed.len() * core::mem::size_of::<F128>(),
+                z_packed.len() * size_of::<F128>(),
             )
         };
         zerocheck::prove_packed_padded_capture_s_hat_v_c(
@@ -1202,8 +1200,8 @@ pub fn prove_fast_core_with_codeword<Ch: Challenger>(
     // Nothing downstream reads a/b (zerocheck consumed them in rounds 1–2);
     // recycle the two buffers (2 × 2^(m-3) bytes — 128 MB at m = 29) instead
     // of carrying them through lincheck and the PCS open.
-    flock_core::scratch::give_f128(a_packed_f128);
-    flock_core::scratch::give_f128(b_packed_f128);
+    give_f128(a_packed_f128);
+    give_f128(b_packed_f128);
 
     let x_ab = r1cs.x_ab_from_mlv(zc_claim.z, &zc_claim.mlv_challenges);
 
@@ -1221,7 +1219,7 @@ pub fn prove_fast_core_with_codeword<Ch: Challenger>(
     );
     // The lincheck stripe copy of z is dead from here on; free it before the
     // PCS open (2^(m-3) bytes — 64 MB at m = 29).
-    flock_core::scratch::give_u8(z_packed_lincheck);
+    give_u8(z_packed_lincheck);
 
     let ab = ZClaim {
         point: r1cs.ab_claim_point(lc_claim.r_inner_skip, &lc_claim.r_inner_rest, &x_ab.x_outer),
@@ -1322,21 +1320,21 @@ pub fn prove_fast_ligerito_timed<Ch: Challenger>(
     let t0 = Instant::now();
     let (zc_proof, zc_claim, s_hat_v_c) = {
         let a_packed: &[u8] = unsafe {
-            std::slice::from_raw_parts(
+            from_raw_parts(
                 a_packed_f128.as_ptr() as *const u8,
-                a_packed_f128.len() * core::mem::size_of::<F128>(),
+                a_packed_f128.len() * size_of::<F128>(),
             )
         };
         let b_packed: &[u8] = unsafe {
-            std::slice::from_raw_parts(
+            from_raw_parts(
                 b_packed_f128.as_ptr() as *const u8,
-                b_packed_f128.len() * core::mem::size_of::<F128>(),
+                b_packed_f128.len() * size_of::<F128>(),
             )
         };
         let c_packed: &[u8] = unsafe {
-            std::slice::from_raw_parts(
+            from_raw_parts(
                 z_packed.as_ptr() as *const u8,
-                z_packed.len() * core::mem::size_of::<F128>(),
+                z_packed.len() * size_of::<F128>(),
             )
         };
         zerocheck::prove_packed_padded_capture_s_hat_v_c(
@@ -1344,8 +1342,8 @@ pub fn prove_fast_ligerito_timed<Ch: Challenger>(
         )
     };
     t.zerocheck_s = t0.elapsed().as_secs_f64();
-    flock_core::scratch::give_f128(a_packed_f128);
-    flock_core::scratch::give_f128(b_packed_f128);
+    give_f128(a_packed_f128);
+    give_f128(b_packed_f128);
 
     let x_ab = r1cs.x_ab_from_mlv(zc_claim.z, &zc_claim.mlv_challenges);
 
@@ -1361,7 +1359,7 @@ pub fn prove_fast_ligerito_timed<Ch: Challenger>(
         &x_ab,
         challenger,
     );
-    flock_core::scratch::give_u8(z_packed_lincheck);
+    give_u8(z_packed_lincheck);
     let ab = ZClaim {
         point: r1cs.ab_claim_point(lc_claim.r_inner_skip, &lc_claim.r_inner_rest, &x_ab.x_outer),
         value: lc_claim.w,
@@ -1419,16 +1417,12 @@ pub fn prove_fast_ligerito_timed<Ch: Challenger>(
 /// only the proof struct differs), an element-only one `boolean: None` and
 /// an opening with no ring-switched claims at all.
 pub fn prove_fast_ligerito_union_mixed_class<Ch: Challenger>(
-    union: &flock_core::union::UnionInstance<'_>,
+    union: &UnionInstance<'_>,
     pcs_params: &PcsParams,
     slots: Vec<UnionSlotProverInput<'_>>,
     element_slots: Vec<UnionElementSlotInput<'_>>,
     challenger: &mut Ch,
-) -> (
-    flock_core::proof::R1csProofMixedClassMerged,
-    Commitment,
-    flock_core::proof::UnionClassClaims,
-) {
+) -> (R1csProofMixedClassMerged, Commitment, UnionClassClaims) {
     let (out, commitment) = prove_union_with_binding(
         union,
         UnionProveBinding::Mixed,
@@ -1453,13 +1447,13 @@ pub fn prove_fast_ligerito_union_mixed_class<Ch: Challenger>(
         None => (None, None),
     };
     (
-        flock_core::proof::R1csProofMixedClassMerged {
+        R1csProofMixedClassMerged {
             boolean: bool_proof,
             element: el_proof,
             pcs_open,
         },
         commitment,
-        flock_core::proof::UnionClassClaims {
+        UnionClassClaims {
             boolean: bool_claim,
             element: el_claim,
         },

--- a/crates/flock-prover/src/r1cs_hashes/blake3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/blake3.rs
@@ -89,12 +89,34 @@
 //!   eventually pin them to claimed public inputs.
 
 use super::common::{BitRecord, add_carry_parts, or_bit_at, or_u32_at_bit, xor_dedup};
+use crate::prover::ProvePhaseTimings;
+use crate::prover::prove_fast_ligerito_from_witness;
+use crate::prover::prove_fast_ligerito_timed;
+use crate::prover::prove_ligerito;
 use flock_core::challenger::Challenger;
 use flock_core::field::F128;
+#[cfg(test)]
+use flock_core::lincheck::CscCircuit;
+use flock_core::lincheck::LincheckCircuit;
+use flock_core::pcs::ligerito::LigeritoProfile;
+use flock_core::pcs::prefault_codeword_during;
 use flock_core::pcs::{Commitment, PcsParams};
 use flock_core::proof::R1csClaim;
+use flock_core::proof::R1csProofLigerito;
+use flock_core::r1cs::WitnessLayout;
 use flock_core::r1cs::{BlockR1cs, SparseBinaryMatrix};
+use flock_core::schedule::IoWord;
+use flock_core::scratch::prewarm_prover;
+use flock_core::union::SlotWitnessDest;
 use flock_core::verifier;
+#[cfg(test)]
+use flock_core::verifier::VerifyError;
+use std::array::from_fn;
+#[cfg(test)]
+use std::collections::HashSet;
+use std::mem::take;
+use std::slice::from_raw_parts_mut;
+use std::time::Instant;
 
 // ---------------------------------------------------------------------------
 // Public constants
@@ -222,7 +244,7 @@ pub const IO_OUT_HI1: usize = 10;
 ///
 /// The 128-bit alignment this depends on landed in `f95dfbb`
 /// ([`CV_BASE`] = 0, [`OUT_LO_BASE`] = 256, [`M_BASE`] = 512).
-pub fn io_schema() -> Vec<flock_core::schedule::IoWord> {
+pub fn io_schema() -> Vec<IoWord> {
     use flock_core::schedule::IoWord;
     let w = |bit_base: usize| bit_base / 128;
     vec![
@@ -402,21 +424,21 @@ struct Word {
 impl Word {
     fn zero() -> Self {
         Self {
-            bits: std::array::from_fn(|_| Vec::new()),
+            bits: from_fn(|_| Vec::new()),
         }
     }
     /// Construct from a 32-bit witness or lin-id slot whose 32 bits live at
     /// `[base + 0, base + 1, …, base + 31]`.
     fn from_slot_base(base: usize) -> Self {
         Self {
-            bits: std::array::from_fn(|i| vec![base + i]),
+            bits: from_fn(|i| vec![base + i]),
         }
     }
     /// Construct from a 32-bit constant — bit `i` is `[Z_CONST]` if set,
     /// `[]` otherwise.
     fn from_const(val: u32) -> Self {
         Self {
-            bits: std::array::from_fn(|i| {
+            bits: from_fn(|i| {
                 if (val >> i) & 1 == 1 {
                     vec![Z_CONST_POS]
                 } else {
@@ -437,13 +459,13 @@ impl Word {
     /// `rotr(n)` — pure index permutation; doesn't touch slot lists.
     fn rotr(&self, n: usize) -> Word {
         Word {
-            bits: std::array::from_fn(|i| self.bits[(i + n) % WORD_BITS].clone()),
+            bits: from_fn(|i| self.bits[(i + n) % WORD_BITS].clone()),
         }
     }
     /// Sort + cancel duplicates per bit.
     fn dedup(mut self) -> Word {
         for i in 0..WORD_BITS {
-            self.bits[i] = xor_dedup(std::mem::take(&mut self.bits[i]));
+            self.bits[i] = xor_dedup(take(&mut self.bits[i]));
         }
         self
     }
@@ -501,7 +523,7 @@ fn write_add_carry_rows(
 // ---------------------------------------------------------------------------
 
 fn initial_lane_words() -> [Word; 16] {
-    let mut s: [Word; 16] = std::array::from_fn(|_| Word::zero());
+    let mut s: [Word; 16] = from_fn(|_| Word::zero());
     for w in 0..8 {
         s[w] = Word::from_slot_base(cv_bit(w, 0));
     }
@@ -739,7 +761,7 @@ fn scatter_lin_id_row(
 
 pub struct Blake3LincheckCircuit;
 
-impl flock_core::lincheck::LincheckCircuit for Blake3LincheckCircuit {
+impl LincheckCircuit for Blake3LincheckCircuit {
     fn n_cols(&self) -> usize {
         K
     }
@@ -1214,11 +1236,8 @@ pub(crate) fn build_block_witness_ab_packed_into(
 pub fn generate_witness_with_ab_packed(
     blocks: &[Compression],
     n_blocks_log: usize,
-) -> (
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-) {
+) -> (Vec<F128>, Vec<F128>, Vec<F128>) {
+    const F128_PER_BLOCK: usize = K / 128;
     use flock_core::field::F128;
     use rayon::prelude::*;
     let n_total = 1usize << n_blocks_log;
@@ -1228,7 +1247,6 @@ pub fn generate_witness_with_ab_packed(
         "{n_blocks} compressions > 2^{n_blocks_log} = {n_total} slots"
     );
 
-    const F128_PER_BLOCK: usize = K / 128;
     let total_f128 = n_total * F128_PER_BLOCK;
     let mut z = vec![F128::ZERO; total_f128];
     let mut a = vec![F128::ZERO; total_f128];
@@ -1251,15 +1269,12 @@ pub fn generate_witness_with_ab_packed(
             };
             // SAFETY: F128 is repr(C, align(16)) with LE u64 halves — same
             // byte layout as a u64 pair.
-            let z_u64: &mut [u64] = unsafe {
-                std::slice::from_raw_parts_mut(z_c.as_mut_ptr() as *mut u64, z_c.len() * 2)
-            };
-            let a_u64: &mut [u64] = unsafe {
-                std::slice::from_raw_parts_mut(a_c.as_mut_ptr() as *mut u64, a_c.len() * 2)
-            };
-            let b_u64: &mut [u64] = unsafe {
-                std::slice::from_raw_parts_mut(b_c.as_mut_ptr() as *mut u64, b_c.len() * 2)
-            };
+            let z_u64: &mut [u64] =
+                unsafe { from_raw_parts_mut(z_c.as_mut_ptr() as *mut u64, z_c.len() * 2) };
+            let a_u64: &mut [u64] =
+                unsafe { from_raw_parts_mut(a_c.as_mut_ptr() as *mut u64, a_c.len() * 2) };
+            let b_u64: &mut [u64] =
+                unsafe { from_raw_parts_mut(b_c.as_mut_ptr() as *mut u64, b_c.len() * 2) };
             build_block_witness_ab_packed_into(cv, m, *t, *bl, *fl, z_u64, a_u64, b_u64);
         });
 
@@ -1282,12 +1297,7 @@ pub fn generate_witness_with_ab_packed(
 pub fn generate_witness_with_ab_packed_and_lincheck(
     blocks: &[Compression],
     n_blocks_log: usize,
-) -> (
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-    Vec<u8>,
-) {
+) -> (Vec<F128>, Vec<F128>, Vec<F128>, Vec<u8>) {
     // Constant-wire pin (docs/const-wire-pin.md): fill padding blocks with a
     // valid compression (of the all-zero input) so the constant cell is 1 in
     // every block. (The chain forbids padding, so this only affects the
@@ -1326,7 +1336,7 @@ impl Blake3Setup {
     /// chain/Merkle wrappers still require row-major.
     pub fn new_batch_major(n_blocks: usize) -> Self {
         let mut s = Self::new(n_blocks);
-        s.r1cs.layout = flock_core::r1cs::WitnessLayout::BatchMajor;
+        s.r1cs.layout = WitnessLayout::BatchMajor;
         s
     }
 
@@ -1334,19 +1344,12 @@ impl Blake3Setup {
     fn generate_witness_ab(
         &self,
         blocks: &[Compression],
-    ) -> (
-        Vec<flock_core::field::F128>,
-        Vec<flock_core::field::F128>,
-        Vec<flock_core::field::F128>,
-        Vec<u8>,
-    ) {
+    ) -> (Vec<F128>, Vec<F128>, Vec<F128>, Vec<u8>) {
         match self.r1cs.layout {
-            flock_core::r1cs::WitnessLayout::RowMajor => {
+            WitnessLayout::RowMajor => {
                 generate_witness_with_ab_packed_and_lincheck(blocks, self.n_blocks_log())
             }
-            flock_core::r1cs::WitnessLayout::BatchMajor => {
-                generate_witness_batch_major(blocks, self.n_blocks_log())
-            }
+            WitnessLayout::BatchMajor => generate_witness_batch_major(blocks, self.n_blocks_log()),
         }
     }
 
@@ -1358,25 +1361,22 @@ impl Blake3Setup {
     pub fn with_log_inv_rate(n_blocks: usize, log_inv_rate: usize) -> Self {
         // Rate keys the legacy profiles: 1 -> Fast, 2 -> Slim.
         let profile = match log_inv_rate {
-            1 => flock_core::pcs::ligerito::LigeritoProfile::Fast,
-            2 => flock_core::pcs::ligerito::LigeritoProfile::Slim,
-            _ => flock_core::pcs::ligerito::LigeritoProfile::Fast, // other rates default to Fast
+            1 => LigeritoProfile::Fast,
+            2 => LigeritoProfile::Slim,
+            _ => LigeritoProfile::Fast, // other rates default to Fast
         };
         Self::with_profile_and_rate(n_blocks, profile, log_inv_rate)
     }
 
     /// Build a setup for a named Ligerito profile (fast/slim/secure);
     /// the PCS rate follows the profile.
-    pub fn with_profile(
-        n_blocks: usize,
-        profile: flock_core::pcs::ligerito::LigeritoProfile,
-    ) -> Self {
+    pub fn with_profile(n_blocks: usize, profile: LigeritoProfile) -> Self {
         Self::with_profile_and_rate(n_blocks, profile, profile.log_inv_rate())
     }
 
     fn with_profile_and_rate(
         n_blocks: usize,
-        profile: flock_core::pcs::ligerito::LigeritoProfile,
+        profile: LigeritoProfile,
         log_inv_rate: usize,
     ) -> Self {
         assert!(n_blocks >= 1, "n_blocks must be ≥ 1");
@@ -1386,7 +1386,7 @@ impl Blake3Setup {
         // ~21M nonzeros) stays out of the first prove/verify, and pre-fault
         // the prove-cycle scratch buffers (see scratch::prewarm_prover).
         r1cs.csc_lincheck_circuit();
-        flock_core::scratch::prewarm_prover(r1cs.m);
+        prewarm_prover(r1cs.m);
         let pcs_params = PcsParams {
             m: r1cs.m,
             log_inv_rate,
@@ -1437,9 +1437,9 @@ impl Blake3Setup {
         &self,
         blocks: &[Compression],
         challenger: &mut Ch,
-    ) -> (flock_core::proof::R1csProofLigerito, Commitment, R1csClaim) {
+    ) -> (R1csProofLigerito, Commitment, R1csClaim) {
         let z_packed = self.generate_witness_packed(blocks);
-        crate::prover::prove_ligerito(&self.r1cs, z_packed, &self.pcs_params, challenger)
+        prove_ligerito(&self.r1cs, z_packed, &self.pcs_params, challenger)
     }
 
     /// Ligerito-backend prove. Requires m ≥ ~21.
@@ -1447,14 +1447,12 @@ impl Blake3Setup {
         &self,
         blocks: &[Compression],
         challenger: &mut Ch,
-    ) -> (flock_core::proof::R1csProofLigerito, Commitment, R1csClaim) {
+    ) -> (R1csProofLigerito, Commitment, R1csClaim) {
         assert_eq!(blocks.len(), self.n_blocks);
         let (codeword, (z_packed, a_packed_f128, b_packed_f128, z_packed_lincheck)) =
-            flock_core::pcs::prefault_codeword_during(&self.pcs_params, || {
-                self.generate_witness_ab(blocks)
-            });
+            prefault_codeword_during(&self.pcs_params, || self.generate_witness_ab(blocks));
         let lc_circuit = self.r1cs.csc_lincheck_circuit();
-        crate::prover::prove_fast_ligerito_from_witness(
+        prove_fast_ligerito_from_witness(
             &self.r1cs,
             &self.pcs_params,
             z_packed,
@@ -1474,19 +1472,14 @@ impl Blake3Setup {
         &self,
         blocks: &[Compression],
         challenger: &mut Ch,
-    ) -> (
-        flock_core::proof::R1csProofLigerito,
-        Commitment,
-        R1csClaim,
-        crate::prover::ProvePhaseTimings,
-    ) {
+    ) -> (R1csProofLigerito, Commitment, R1csClaim, ProvePhaseTimings) {
         assert_eq!(blocks.len(), self.n_blocks);
-        let t0 = std::time::Instant::now();
+        let t0 = Instant::now();
         let (z_packed, a_packed_f128, b_packed_f128, z_packed_lincheck) =
             self.generate_witness_ab(blocks);
         let witness_s = t0.elapsed().as_secs_f64();
         let lc_circuit = self.r1cs.csc_lincheck_circuit();
-        let (proof, commitment, claim, mut timings) = crate::prover::prove_fast_ligerito_timed(
+        let (proof, commitment, claim, mut timings) = prove_fast_ligerito_timed(
             &self.r1cs,
             &self.pcs_params,
             z_packed,
@@ -1504,7 +1497,7 @@ impl Blake3Setup {
     pub fn verify<Ch: Challenger>(
         &self,
         commitment: &Commitment,
-        proof: &flock_core::proof::R1csProofLigerito,
+        proof: &R1csProofLigerito,
         challenger: &mut Ch,
     ) -> Result<R1csClaim, verifier::VerifyError> {
         let lc_circuit = self.r1cs.csc_lincheck_circuit();
@@ -1634,7 +1627,7 @@ use super::common::{BM_V, BmRow, add_carry_parts_v, or_bit_row, or_u32_row};
 
 #[inline(always)]
 fn bm_xor_rotr(x: &[u32; BM_V], y: &[u32; BM_V], r: u32) -> [u32; BM_V] {
-    std::array::from_fn(|j| (x[j] ^ y[j]).rotate_right(r))
+    from_fn(|j| (x[j] ^ y[j]).rotate_right(r))
 }
 
 struct BmRows<'a> {
@@ -1682,12 +1675,12 @@ pub(crate) fn build_group_batch_major(
         a: ra,
         b: rb,
     };
-    let cv: [[u32; BM_V]; 8] = std::array::from_fn(|w| std::array::from_fn(|j| inputs[j].0[w]));
-    let m: [[u32; BM_V]; 16] = std::array::from_fn(|i| std::array::from_fn(|j| inputs[j].1[i]));
-    let counter_lo: [u32; BM_V] = std::array::from_fn(|j| inputs[j].2 as u32);
-    let counter_hi: [u32; BM_V] = std::array::from_fn(|j| (inputs[j].2 >> 32) as u32);
-    let block_len: [u32; BM_V] = std::array::from_fn(|j| inputs[j].3);
-    let flags: [u32; BM_V] = std::array::from_fn(|j| inputs[j].4);
+    let cv: [[u32; BM_V]; 8] = from_fn(|w| from_fn(|j| inputs[j].0[w]));
+    let m: [[u32; BM_V]; 16] = from_fn(|i| from_fn(|j| inputs[j].1[i]));
+    let counter_lo: [u32; BM_V] = from_fn(|j| inputs[j].2 as u32);
+    let counter_hi: [u32; BM_V] = from_fn(|j| (inputs[j].2 >> 32) as u32);
+    let block_len: [u32; BM_V] = from_fn(|j| inputs[j].3);
+    let flags: [u32; BM_V] = from_fn(|j| inputs[j].4);
 
     or_bit_row(rows.z, Z_CONST_POS);
     or_bit_row(rows.a, Z_CONST_POS);
@@ -1758,8 +1751,8 @@ pub(crate) fn build_group_batch_major(
     }
 
     for w in 0..8 {
-        let lo: [u32; BM_V] = std::array::from_fn(|j| state[w][j] ^ state[w + 8][j]);
-        let hi: [u32; BM_V] = std::array::from_fn(|j| state[w + 8][j] ^ cv[w][j]);
+        let lo: [u32; BM_V] = from_fn(|j| state[w][j] ^ state[w + 8][j]);
+        let hi: [u32; BM_V] = from_fn(|j| state[w + 8][j] ^ cv[w][j]);
         bm_write_lin(&mut rows, out_lo_bit(w, 0), &lo);
         bm_write_lin(&mut rows, out_hi_bit(w, 0), &hi);
     }
@@ -1771,12 +1764,7 @@ pub(crate) fn build_group_batch_major(
 pub fn generate_witness_batch_major(
     blocks: &[Compression],
     n_blocks_log: usize,
-) -> (
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-    Vec<u8>,
-) {
+) -> (Vec<F128>, Vec<F128>, Vec<F128>, Vec<u8>) {
     let padding: Compression = ([0u32; 8], [0u32; 16], 0u64, 0u32, 0u32);
     super::common::drive_witness_batch_major(
         blocks,
@@ -1797,12 +1785,7 @@ pub fn generate_witness_batch_major(
 pub fn generate_witness_batch_major_partial(
     blocks: &[Compression],
     n_blocks_log: usize,
-) -> (
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-    Vec<u8>,
-) {
+) -> (Vec<F128>, Vec<F128>, Vec<F128>, Vec<u8>) {
     super::common::drive_witness_batch_major_partial(
         blocks,
         n_blocks_log,
@@ -1818,7 +1801,7 @@ pub fn generate_witness_batch_major_partial(
 pub fn generate_witness_batch_major_into(
     blocks: &[Compression],
     n_blocks_log: usize,
-    dst: flock_core::union::SlotWitnessDest<'_>,
+    dst: SlotWitnessDest<'_>,
 ) -> Vec<u8> {
     let padding: Compression = ([0u32; 8], [0u32; 16], 0u64, 0u32, 0u32);
     super::common::drive_witness_batch_major_into(
@@ -1837,7 +1820,7 @@ pub fn generate_witness_batch_major_into(
 pub fn generate_witness_batch_major_partial_into(
     blocks: &[Compression],
     n_blocks_log: usize,
-    dst: flock_core::union::SlotWitnessDest<'_>,
+    dst: SlotWitnessDest<'_>,
 ) -> Vec<u8> {
     super::common::drive_witness_batch_major_partial_into(
         blocks,
@@ -1882,7 +1865,7 @@ mod tests {
         // Every input bit of the block is exposed: cv, m and the packed params
         // word. `GS_BASE` onward is internal (round intermediates, carries) and
         // is pinned by the relation, so it is correctly absent.
-        let covered: std::collections::HashSet<usize> = schema
+        let covered: HashSet<usize> = schema
             .iter()
             .filter(|w| w.dir == IoDirection::In)
             .map(|w| w.word_col)
@@ -1930,8 +1913,8 @@ mod tests {
             let mut rng = Rng::new(0xBA7C_B3 + n_log as u64);
             let inputs: Vec<Compression> = (0..n_inputs)
                 .map(|_| {
-                    let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-                    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                    let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+                    let m: [u32; 16] = from_fn(|_| rng.next_u32());
                     let counter = ((rng.next_u32() as u64) << 32) | (rng.next_u32() as u64);
                     (cv, m, counter, 64u32, 11u32)
                 })
@@ -1944,8 +1927,8 @@ mod tests {
             assert_eq!(stripe_b, stripe_r, "stripe diverged (n_log={n_log})");
 
             let chunks_per_block = K / 128;
-            let transpose = |row: &[flock_core::field::F128]| {
-                let mut out = vec![flock_core::field::F128::ZERO; row.len()];
+            let transpose = |row: &[F128]| {
+                let mut out = vec![F128::ZERO; row.len()];
                 for o in 0..1usize << n_log {
                     for c in 0..chunks_per_block {
                         out[(c << n_log) + o] = row[o * chunks_per_block + c];
@@ -1975,8 +1958,8 @@ mod tests {
         let mut rng = Rng::new(0xBA7C_9427);
         let inputs: Vec<Compression> = (0..n_total)
             .map(|_| {
-                let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-                let msg: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+                let msg: [u32; 16] = from_fn(|_| rng.next_u32());
                 let counter = ((rng.next_u32() as u64) << 32) | (rng.next_u32() as u64);
                 (cv, msg, counter, 64u32, 11u32)
             })
@@ -2032,8 +2015,8 @@ mod tests {
         let mut rng = Rng::new(0xBA7C_F013);
         let inputs: Vec<Compression> = (0..256)
             .map(|_| {
-                let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-                let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+                let m: [u32; 16] = from_fn(|_| rng.next_u32());
                 let counter = ((rng.next_u32() as u64) << 32) | (rng.next_u32() as u64);
                 (cv, m, counter, 64u32, 11u32)
             })
@@ -2127,8 +2110,8 @@ mod tests {
     #[test]
     fn witness_encodes_correct_output() {
         let mut rng = Rng::new(0x1234_5678);
-        let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-        let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+        let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+        let m: [u32; 16] = from_fn(|_| rng.next_u32());
         let counter = ((rng.next_u32() as u64) << 32) | (rng.next_u32() as u64);
         let block_len = 64;
         let flags = CHUNK_START | CHUNK_END | ROOT;
@@ -2160,8 +2143,8 @@ mod tests {
             let r1cs = build_block_r1cs(n_log);
             let blocks: Vec<Compression> = (0..n_blocks)
                 .map(|_| {
-                    let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-                    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                    let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+                    let m: [u32; 16] = from_fn(|_| rng.next_u32());
                     (cv, m, rng.next_u32() as u64, 64u32, 11u32)
                 })
                 .collect();
@@ -2177,8 +2160,8 @@ mod tests {
     #[test]
     fn mutated_witness_fails() {
         let mut rng = Rng::new(0xBEEF_F00D);
-        let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-        let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+        let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+        let m: [u32; 16] = from_fn(|_| rng.next_u32());
         let r1cs = build_block_r1cs(3);
         let blocks = vec![(cv, m, 0u64, 64u32, 11u32)];
         let mut z = generate_witness(&blocks, 3);
@@ -2203,8 +2186,8 @@ mod tests {
             let mut rng = Rng::new(0xABCD_5A55 + n_blocks as u64);
             let blocks: Vec<Compression> = (0..n_blocks)
                 .map(|_| {
-                    let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-                    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                    let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+                    let m: [u32; 16] = from_fn(|_| rng.next_u32());
                     (cv, m, rng.next_u32() as u64, 64u32, 11u32)
                 })
                 .collect();
@@ -2254,7 +2237,7 @@ mod tests {
         }
 
         // CSC gather (what prove_fast/verify actually use) matches too.
-        let csc = flock_core::lincheck::CscCircuit::from_matrices(&a_0, &b_0);
+        let csc = CscCircuit::from_matrices(&a_0, &b_0);
         let got_csc = csc.fold_alpha_batched(alpha, &eq_inner);
         assert_eq!(expected, got_csc, "CSC fold mismatch");
     }
@@ -2269,8 +2252,8 @@ mod tests {
             let mut rng = Rng::new(0xABCD_EF00 + n_blocks as u64);
             let blocks: Vec<Compression> = (0..n_blocks)
                 .map(|_| {
-                    let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-                    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                    let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+                    let m: [u32; 16] = from_fn(|_| rng.next_u32());
                     (cv, m, rng.next_u32() as u64, 64u32, 11u32)
                 })
                 .collect();
@@ -2302,8 +2285,8 @@ mod tests {
             let mut rng = Rng::new(0x9A11_0F11);
             (0..256)
                 .map(|_| {
-                    let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-                    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                    let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+                    let m: [u32; 16] = from_fn(|_| rng.next_u32());
                     (cv, m, 0u64, 64u32, 11u32)
                 })
                 .collect()
@@ -2344,8 +2327,8 @@ mod tests {
         let mut rng = Rng::new(0xb1a_3211e);
         let blocks: Vec<Compression> = (0..256)
             .map(|_| {
-                let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-                let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+                let m: [u32; 16] = from_fn(|_| rng.next_u32());
                 (cv, m, 0u64, 64u32, 11u32)
             })
             .collect();
@@ -2368,8 +2351,8 @@ mod tests {
         let mut rng = Rng::new(0xb1a_63112);
         let blocks: Vec<Compression> = (0..256)
             .map(|_| {
-                let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-                let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+                let m: [u32; 16] = from_fn(|_| rng.next_u32());
                 (cv, m, 0u64, 64u32, 11u32)
             })
             .collect();
@@ -2403,8 +2386,8 @@ mod tests {
         let mut rng = Rng::new(0x5EED_B1A3);
         let blocks: Vec<Compression> = (0..n)
             .map(|_| {
-                let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-                let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+                let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+                let m: [u32; 16] = from_fn(|_| rng.next_u32());
                 (cv, m, rng.next_u32() as u64, 64u32, 11u32)
             })
             .collect();
@@ -2420,16 +2403,13 @@ mod tests {
         let zeros: Vec<Compression> = vec![([0u32; 8], [0u32; 16], 0u64, 0u32, 0u32); n];
         let (mut z, mut a, mut b, mut zlc) =
             generate_witness_with_ab_packed_and_lincheck(&zeros, setup.n_blocks_log());
-        z.iter_mut()
-            .for_each(|v| *v = flock_core::field::F128::ZERO);
-        a.iter_mut()
-            .for_each(|v| *v = flock_core::field::F128::ZERO);
-        b.iter_mut()
-            .for_each(|v| *v = flock_core::field::F128::ZERO);
+        z.iter_mut().for_each(|v| *v = F128::ZERO);
+        a.iter_mut().for_each(|v| *v = F128::ZERO);
+        b.iter_mut().for_each(|v| *v = F128::ZERO);
         zlc.iter_mut().for_each(|v| *v = 0);
         let circuit = setup.r1cs.csc_lincheck_circuit();
         let mut ch_p = FsChallenger::new(b"poc");
-        let (proof, commitment, _) = crate::prover::prove_fast_ligerito_from_witness(
+        let (proof, commitment, _) = prove_fast_ligerito_from_witness(
             &setup.r1cs,
             &setup.pcs_params,
             z,
@@ -2443,7 +2423,7 @@ mod tests {
         let mut ch_v = FsChallenger::new(b"poc");
         let res = setup.verify(&commitment, &proof, &mut ch_v);
         assert!(
-            matches!(res, Err(flock_core::verifier::VerifyError::Lincheck(_))),
+            matches!(res, Err(VerifyError::Lincheck(_))),
             "all-zero witness must be rejected by the constant-wire pin; got {res:?}"
         );
     }

--- a/crates/flock-prover/src/r1cs_hashes/chain_common.rs
+++ b/crates/flock-prover/src/r1cs_hashes/chain_common.rs
@@ -17,14 +17,35 @@
 //! above. The two slots must be consecutive (slot 0 = input, slot 1 = output)
 //! so the chain claim's selector is a single bit-flip in the multilinear cube.
 
+use crate::chain::ChainClaims;
+use crate::chain::ChainError;
+use crate::chain::ChainShiftProof;
+use crate::chain::prove_chain_shift;
+use crate::chain::verify_chain_shift;
+use crate::prover::ProveCore;
+use crate::prover::prove_fast_core;
+use crate::prover::quirky_x_outer_full;
 use flock_core::challenger::Challenger;
 use flock_core::field::F128;
+use flock_core::lincheck::LincheckCircuit;
+use flock_core::lincheck::LincheckProof;
 use flock_core::lincheck::build_eq_table;
+use flock_core::pcs::BatchOpeningProofLigerito;
+use flock_core::pcs::VerifyError as PcsVerifyError;
+use flock_core::pcs::open_batch_mixed_ligerito_with_precomputed_s_hat_v;
+use flock_core::pcs::ring_switch::build_eq_sparse;
+use flock_core::pcs::verify_opening_batch_ligerito_mixed;
 use flock_core::pcs::{
     Commitment, DirectEqInd, LOG_PACKING, PackedDirectClaim, PackedDirectClaimRef, PcsParams,
 };
 use flock_core::r1cs::BlockR1cs;
+use flock_core::r1cs::WitnessLayout;
+use flock_core::verifier::VerifyError as VerifierVerifyError;
+use flock_core::verifier::verify_core;
+use flock_core::zerocheck::ZerocheckProof;
 use serde::{Deserialize, Serialize};
+use std::iter::repeat_n;
+use std::slice::from_ref;
 
 /// Geometry of one hash's input/output regions within a witness block. All
 /// fields are `const`-known per hash.
@@ -130,7 +151,7 @@ impl ChainFold {
 /// mul-adds (16 for keccak, 2 for blake3/sha2).
 pub fn fold_in_out(
     layout: &ChainLayout,
-    wl: flock_core::r1cs::WitnessLayout,
+    wl: WitnessLayout,
     packed: &[F128],
     fold: &ChainFold,
 ) -> (Vec<F128>, Vec<F128>) {
@@ -156,8 +177,8 @@ pub fn fold_in_out(
     // contiguous (`(w << n_log) + i`).
     let word_addr = move |i: usize, w: usize| -> usize {
         match wl {
-            flock_core::r1cs::WitnessLayout::RowMajor => i * block_packed + w,
-            flock_core::r1cs::WitnessLayout::BatchMajor => (w << n_log) + i,
+            WitnessLayout::RowMajor => i * block_packed + w,
+            WitnessLayout::BatchMajor => (w << n_log) + i,
         }
     };
 
@@ -195,12 +216,12 @@ pub fn fold_in_out(
 /// `build_eq_sparse` to skip the zero-coord halvings.
 pub fn assemble_chain_claim(
     layout: &ChainLayout,
-    wl: flock_core::r1cs::WitnessLayout,
+    wl: WitnessLayout,
     fold: &ChainFold,
-    claims: &crate::chain::ChainClaims,
+    claims: &ChainClaims,
 ) -> PackedDirectClaim {
     let point = build_chain_claim_point(layout, wl, fold, claims);
-    let sparse_eq = flock_core::pcs::ring_switch::build_eq_sparse(&point);
+    let sparse_eq = build_eq_sparse(&point);
     PackedDirectClaim {
         point,
         value: claims.value,
@@ -219,20 +240,20 @@ pub fn assemble_chain_claim(
 /// verifier evaluates `eq_eval(point, residual_challenges)` directly).
 fn build_chain_claim_point(
     layout: &ChainLayout,
-    wl: flock_core::r1cs::WitnessLayout,
+    wl: WitnessLayout,
     fold: &ChainFold,
-    claims: &crate::chain::ChainClaims,
+    claims: &ChainClaims,
 ) -> Vec<F128> {
     let high = layout.high_zeros();
     let point_len = fold.tau_pos.len() + 1 + high + claims.instance_point.len();
     let mut point = Vec::with_capacity(point_len);
-    if wl == flock_core::r1cs::WitnessLayout::BatchMajor {
+    if wl == WitnessLayout::BatchMajor {
         point.extend_from_slice(&claims.instance_point);
     }
     point.extend_from_slice(&fold.tau_pos);
     point.push(claims.sel0);
-    point.extend(std::iter::repeat_n(F128::ZERO, high));
-    if wl == flock_core::r1cs::WitnessLayout::RowMajor {
+    point.extend(repeat_n(F128::ZERO, high));
+    if wl == WitnessLayout::RowMajor {
         point.extend_from_slice(&claims.instance_point);
     }
     debug_assert_eq!(point.len(), point_len);
@@ -245,21 +266,21 @@ fn build_chain_claim_point(
 /// `[ab, c] (ring-switched) + [chain] (packed-direct)`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ChainProofLigerito {
-    pub zerocheck: flock_core::zerocheck::ZerocheckProof,
-    pub lincheck: flock_core::lincheck::LincheckProof,
-    pub shift: crate::chain::ChainShiftProof,
-    pub pcs_open: flock_core::pcs::BatchOpeningProofLigerito,
+    pub zerocheck: ZerocheckProof,
+    pub lincheck: LincheckProof,
+    pub shift: ChainShiftProof,
+    pub pcs_open: BatchOpeningProofLigerito,
 }
 
 /// Errors from chain verification.
 #[derive(Debug)]
 pub enum ChainVerifyError {
     /// Base R1CS (zerocheck/lincheck) replay failed.
-    R1cs(flock_core::verifier::VerifyError),
+    R1cs(VerifierVerifyError),
     /// The shift-sumcheck (glue + endpoints) check failed.
-    Shift(crate::chain::ChainError),
+    Shift(ChainError),
     /// The batched PCS opening failed.
-    Pcs(flock_core::pcs::VerifyError),
+    Pcs(PcsVerifyError),
 }
 
 /// Generic chain prover. The caller supplies the hash's already-generated
@@ -276,14 +297,14 @@ pub fn prove_chain_ligerito_generic<Ch: Challenger>(
     a_packed: Vec<F128>,
     b_packed: Vec<F128>,
     z_lincheck: Vec<u8>,
-    lincheck_circuit: &dyn flock_core::lincheck::LincheckCircuit,
+    lincheck_circuit: &dyn LincheckCircuit,
     challenger: &mut Ch,
 ) -> (ChainProofLigerito, Commitment) {
     let lig_config = pcs_params
         .ligerito_prover_config()
         .expect("Ligerito default config for chain prove; bump m for tiny instances");
 
-    let core = crate::prover::prove_fast_core(
+    let core = prove_fast_core(
         r1cs,
         pcs_params,
         z_packed,
@@ -298,15 +319,15 @@ pub fn prove_chain_ligerito_generic<Ch: Challenger>(
     let fold = ChainFold::new(layout, tau_pos);
     let (in_vals, out_vals) = fold_in_out(layout, r1cs.layout, &core.z_packed, &fold);
 
-    let (shift, claims) = crate::chain::prove_chain_shift(&in_vals, &out_vals, challenger);
+    let (shift, claims) = prove_chain_shift(&in_vals, &out_vals, challenger);
     let chain_claim = assemble_chain_claim(layout, r1cs.layout, &fold, &claims);
 
     let padding = r1cs.padding_spec();
-    let ab_x_outer = crate::prover::quirky_x_outer_full(&core.ab.point);
-    let c_x_outer = crate::prover::quirky_x_outer_full(&core.c.point);
+    let ab_x_outer = quirky_x_outer_full(&core.ab.point);
+    let c_x_outer = quirky_x_outer_full(&core.c.point);
     // Destructure core to move z_packed by value into the open (saves a 128 MB
     // clone at m=30 BLAKE3).
-    let crate::prover::ProveCore {
+    let ProveCore {
         zc_proof,
         lc_proof,
         commitment,
@@ -318,13 +339,13 @@ pub fn prove_chain_ligerito_generic<Ch: Challenger>(
     } = core;
     let pre_ab: Option<&[F128]> = s_hat_v_ab.as_deref();
     let pre_c: Option<&[F128]> = Some(s_hat_v_c.as_slice());
-    let pcs_open = flock_core::pcs::open_batch_mixed_ligerito_with_precomputed_s_hat_v(
+    let pcs_open = open_batch_mixed_ligerito_with_precomputed_s_hat_v(
         z_packed,
         &prover_data,
         &commitment,
         &[ab_x_outer.as_slice(), c_x_outer.as_slice()],
         &[pre_ab, pre_c],
-        std::slice::from_ref(&chain_claim),
+        from_ref(&chain_claim),
         &padding,
         &lig_config,
         challenger,
@@ -353,11 +374,11 @@ pub fn verify_chain_ligerito_generic<Ch: Challenger>(
     n_log: usize,
     x0_phys: &[bool],
     xlast_phys: &[bool],
-    lincheck_circuit: &dyn flock_core::lincheck::LincheckCircuit,
+    lincheck_circuit: &dyn LincheckCircuit,
     pcs_params: &PcsParams,
     challenger: &mut Ch,
 ) -> Result<(), ChainVerifyError> {
-    let (ab, c) = flock_core::verifier::verify_core(
+    let (ab, c) = verify_core(
         r1cs,
         &proof.zerocheck,
         &proof.lincheck,
@@ -372,12 +393,12 @@ pub fn verify_chain_ligerito_generic<Ch: Challenger>(
 
     let x0_r = fold.fold_public_phys(x0_phys);
     let xlast_r = fold.fold_public_phys(xlast_phys);
-    let claims = crate::chain::verify_chain_shift(&proof.shift, x0_r, xlast_r, n_log, challenger)
+    let claims = verify_chain_shift(&proof.shift, x0_r, xlast_r, n_log, challenger)
         .map_err(ChainVerifyError::Shift)?;
 
     let chain_point = build_chain_claim_point(layout, r1cs.layout, &fold, &claims);
-    let ab_x_outer = crate::prover::quirky_x_outer_full(&ab.point);
-    let c_x_outer = crate::prover::quirky_x_outer_full(&c.point);
+    let ab_x_outer = quirky_x_outer_full(&ab.point);
+    let c_x_outer = quirky_x_outer_full(&c.point);
     let pd_ref = PackedDirectClaimRef {
         point: &chain_point,
         value: claims.value,
@@ -387,12 +408,12 @@ pub fn verify_chain_ligerito_generic<Ch: Challenger>(
         .ligerito_verifier_config()
         .expect("Ligerito default verifier config for chain verify");
 
-    flock_core::pcs::verify_opening_batch_ligerito_mixed(
+    verify_opening_batch_ligerito_mixed(
         commitment,
         &[ab.value, c.value],
         &[ab.point.z_skip, c.point.z_skip],
         &[ab_x_outer.as_slice(), c_x_outer.as_slice()],
-        std::slice::from_ref(&pd_ref),
+        from_ref(&pd_ref),
         &proof.pcs_open,
         &lig_v_config,
         challenger,

--- a/crates/flock-prover/src/r1cs_hashes/common.rs
+++ b/crates/flock-prover/src/r1cs_hashes/common.rs
@@ -2,6 +2,12 @@
 //! modules (`sha2`, `blake3`, `keccak`). The shared `prove_fast`
 //! orchestration lives in [`crate::prover::prove_fast_from_witness`].
 
+use flock_core::scratch::take_f128;
+use flock_core::scratch::take_u8;
+use std::array::from_fn;
+use std::ptr::write_bytes;
+use std::slice::from_raw_parts;
+use std::slice::from_raw_parts_mut;
 use std::sync::OnceLock;
 
 use flock_core::bits::transpose_8_u64s_to_64_bytes;
@@ -79,9 +85,10 @@ impl<const NW: usize> BitRecord<NW> {
 /// mod-2³² carry-out; the carry slot is 31 bits wide).
 #[inline(always)]
 pub(crate) fn add_carry_parts(x: u32, y: u32) -> (u32, u32, u32, u32) {
+    const MASK_LO31: u32 = 0x7FFF_FFFF;
     let sum = x.wrapping_add(y);
     let cin = sum ^ x ^ y;
-    const MASK_LO31: u32 = 0x7FFF_FFFF;
+
     let left = (x ^ cin) & MASK_LO31;
     let right = (y ^ cin) & MASK_LO31;
     let carry_aux = left & right;
@@ -243,9 +250,9 @@ where
     // parallel build. The per-block builders OR 1-bits into pre-zeroed words,
     // so each group must be zeroed before its `per_block` calls. `z_lincheck`
     // stays `vec![0u8; _]` (lazy `alloc_zeroed`/mmap — no eager memset).
-    let mut z = flock_core::scratch::take_f128(total_f128);
-    let mut a = flock_core::scratch::take_f128(total_f128);
-    let mut b = flock_core::scratch::take_f128(total_f128);
+    let mut z = take_f128(total_f128);
+    let mut a = take_f128(total_f128);
+    let mut b = take_f128(total_f128);
     let mut z_lincheck = vec![0u8; (n_total / 8) * k];
 
     z.par_chunks_mut(8 * f128_per_block)
@@ -261,9 +268,9 @@ where
             // SAFETY: F128 is `Copy` (no Drop) and the all-zero bit pattern is
             // the valid `F128::ZERO`, so a byte memset is a correct init.
             unsafe {
-                std::ptr::write_bytes(z_grp.as_mut_ptr(), 0, z_grp.len());
-                std::ptr::write_bytes(a_grp.as_mut_ptr(), 0, a_grp.len());
-                std::ptr::write_bytes(b_grp.as_mut_ptr(), 0, b_grp.len());
+                write_bytes(z_grp.as_mut_ptr(), 0, z_grp.len());
+                write_bytes(a_grp.as_mut_ptr(), 0, a_grp.len());
+                write_bytes(b_grp.as_mut_ptr(), 0, b_grp.len());
             }
             for k_in in 0..8 {
                 let global_idx = 8 * g + k_in;
@@ -283,30 +290,20 @@ where
                 // SAFETY: F128 is `repr(C, align(16))` with two `u64` fields in
                 // LE order — same byte layout as a u64 pair.
                 let z_u64: &mut [u64] = unsafe {
-                    std::slice::from_raw_parts_mut(
-                        z_chunk.as_mut_ptr() as *mut u64,
-                        z_chunk.len() * 2,
-                    )
+                    from_raw_parts_mut(z_chunk.as_mut_ptr() as *mut u64, z_chunk.len() * 2)
                 };
                 let a_u64: &mut [u64] = unsafe {
-                    std::slice::from_raw_parts_mut(
-                        a_chunk.as_mut_ptr() as *mut u64,
-                        a_chunk.len() * 2,
-                    )
+                    from_raw_parts_mut(a_chunk.as_mut_ptr() as *mut u64, a_chunk.len() * 2)
                 };
                 let b_u64: &mut [u64] = unsafe {
-                    std::slice::from_raw_parts_mut(
-                        b_chunk.as_mut_ptr() as *mut u64,
-                        b_chunk.len() * 2,
-                    )
+                    from_raw_parts_mut(b_chunk.as_mut_ptr() as *mut u64, b_chunk.len() * 2)
                 };
                 per_block(init, z_u64, a_u64, b_u64);
             }
 
             // Bit-transpose 8 z chunks into the lincheck stripe.
-            let z_u64_all: &[u64] = unsafe {
-                std::slice::from_raw_parts(z_grp.as_ptr() as *const u64, z_grp.len() * 2)
-            };
+            let z_u64_all: &[u64] =
+                unsafe { from_raw_parts(z_grp.as_ptr() as *const u64, z_grp.len() * 2) };
             for i in 0..u64_per_block {
                 let lanes: [u64; 8] = [
                     z_u64_all[0 * u64_per_block + i],
@@ -472,7 +469,7 @@ pub(crate) unsafe fn stripe_from_rows(
 ) {
     let base = (o0 / 8) * u64_per_block * 64;
     for (w, row) in rows.iter().enumerate().take(useful_words) {
-        let out = unsafe { std::slice::from_raw_parts_mut(stripe.add(base + w * 64), 64) };
+        let out = unsafe { from_raw_parts_mut(stripe.add(base + w * 64), 64) };
         transpose_8_u64s_to_64_bytes(row, out);
     }
 }
@@ -525,9 +522,9 @@ where
     F: Fn([&S; BM_V], &mut [BmRow], &mut [BmRow], &mut [BmRow]) + Sync + Send,
 {
     let total_f128 = 1usize << (n_blocks_log + k_log - 7);
-    let mut z = flock_core::scratch::take_f128(total_f128);
-    let mut a = flock_core::scratch::take_f128(total_f128);
-    let mut b = flock_core::scratch::take_f128(total_f128);
+    let mut z = take_f128(total_f128);
+    let mut a = take_f128(total_f128);
+    let mut b = take_f128(total_f128);
     let stripe = drive_witness_batch_major_into(
         inputs,
         padding,
@@ -588,7 +585,7 @@ where
     // `[0, useful_words)` of every group — including fully-dummy groups, which
     // flush zeros — so only each group's TAIL rows need clearing, a few percent
     // of the buffer instead of faulting in all of it.
-    let mut stripe = flock_core::scratch::take_u8(n_total * u64_per_block * 8);
+    let mut stripe = take_u8(n_total * u64_per_block * 8);
     stripe
         .par_chunks_mut(u64_per_block * 64)
         .for_each(|g| g[useful_words * 64..].fill(0));
@@ -622,8 +619,7 @@ where
             ra[..useful_words].fill([0u64; BM_V]);
             rb[..useful_words].fill([0u64; BM_V]);
             let o0 = g * BM_V;
-            let group: [&S; BM_V] =
-                std::array::from_fn(|j| inputs_ref.get(o0 + j).unwrap_or(padding));
+            let group: [&S; BM_V] = from_fn(|j| inputs_ref.get(o0 + j).unwrap_or(padding));
             per_group(group, rz, ra, rb);
             // SAFETY: disjoint instance ranges per group; suffix pre-zeroed.
             unsafe {
@@ -671,9 +667,9 @@ where
     F: Fn([&S; BM_V], &mut [BmRow], &mut [BmRow], &mut [BmRow]) + Sync + Send,
 {
     let total_f128 = 1usize << (n_blocks_log + k_log - 7);
-    let mut z = flock_core::scratch::take_f128(total_f128);
-    let mut a = flock_core::scratch::take_f128(total_f128);
-    let mut b = flock_core::scratch::take_f128(total_f128);
+    let mut z = take_f128(total_f128);
+    let mut a = take_f128(total_f128);
+    let mut b = take_f128(total_f128);
     let stripe = drive_witness_batch_major_partial_into(
         inputs,
         n_blocks_log,
@@ -732,7 +728,7 @@ where
     // are count-proportional), and the padding suffix of z/a/b is skipped
     // outright (already zero, or dirty-but-unread, per the mode).
     let live_groups = inputs.len().div_ceil(BM_V);
-    let mut stripe = flock_core::scratch::take_u8(n_total * u64_per_block * 8);
+    let mut stripe = take_u8(n_total * u64_per_block * 8);
     let tail_groups = if elide_padding_writes {
         live_groups
     } else {
@@ -789,7 +785,7 @@ where
                 // placeholder — their rows are zeroed below, so the
                 // placeholder's data never reaches the buffers.
                 let group: [&S; BM_V] =
-                    std::array::from_fn(|j| inputs_ref.get(o0 + j).unwrap_or(&inputs_ref[o0]));
+                    from_fn(|j| inputs_ref.get(o0 + j).unwrap_or(&inputs_ref[o0]));
                 per_group(group, rz, ra, rb);
                 if live < BM_V {
                     for rows in [&mut *rz, &mut *ra, &mut *rb] {

--- a/crates/flock-prover/src/r1cs_hashes/keccak.rs
+++ b/crates/flock-prover/src/r1cs_hashes/keccak.rs
@@ -62,14 +62,27 @@
 //! the slow `prove` path will report "everything satisfied vacuously" for
 //! this encoding — only use `prove_fast`/`prove_chain`.
 
+use crate::prover::prove_fast_ligerito_from_witness;
+use crate::r1cs_hashes::chain_common::ChainProofLigerito;
+use crate::r1cs_hashes::chain_common::prove_chain_ligerito_generic;
+use crate::r1cs_hashes::chain_common::verify_chain_ligerito_generic;
 use crate::r1cs_hashes::chain_common::{ChainLayout, ChainVerifyError};
 use flock_core::challenger::Challenger;
 use flock_core::field::F128;
 use flock_core::lincheck::LincheckCircuit;
+use flock_core::pcs::ligerito::LigeritoProfile;
+use flock_core::pcs::prefault_codeword_during;
 use flock_core::pcs::{Commitment, PcsParams};
 use flock_core::proof::R1csClaim;
+use flock_core::proof::R1csProofLigerito;
 use flock_core::r1cs::BlockR1cs;
+use flock_core::r1cs::WitnessLayout;
+use flock_core::scratch::prewarm_prover;
+use flock_core::scratch::take_f128;
 use flock_core::verifier;
+#[cfg(test)]
+use flock_core::verifier::VerifyError;
+use std::array::from_fn;
 
 // ===========================================================================
 // Keccak-f[1600] primitives
@@ -874,32 +887,29 @@ impl KeccakSetup {
     pub fn with_log_inv_rate(n_keccaks: usize, log_inv_rate: usize) -> Self {
         // Rate keys the legacy profiles: 1 -> Fast, 2 -> Slim.
         let profile = match log_inv_rate {
-            1 => flock_core::pcs::ligerito::LigeritoProfile::Fast,
-            2 => flock_core::pcs::ligerito::LigeritoProfile::Slim,
-            _ => flock_core::pcs::ligerito::LigeritoProfile::Fast, // other rates default to Fast
+            1 => LigeritoProfile::Fast,
+            2 => LigeritoProfile::Slim,
+            _ => LigeritoProfile::Fast, // other rates default to Fast
         };
         Self::with_profile_and_rate(n_keccaks, profile, log_inv_rate)
     }
 
     /// Build a setup for a named Ligerito profile (fast/slim/secure);
     /// the PCS rate follows the profile.
-    pub fn with_profile(
-        n_keccaks: usize,
-        profile: flock_core::pcs::ligerito::LigeritoProfile,
-    ) -> Self {
+    pub fn with_profile(n_keccaks: usize, profile: LigeritoProfile) -> Self {
         Self::with_profile_and_rate(n_keccaks, profile, profile.log_inv_rate())
     }
 
     fn with_profile_and_rate(
         n_keccaks: usize,
-        profile: flock_core::pcs::ligerito::LigeritoProfile,
+        profile: LigeritoProfile,
         log_inv_rate: usize,
     ) -> Self {
         assert!(n_keccaks >= 1);
         let n_log = min_n_keccaks_log(n_keccaks);
         let r1cs = build_block_r1cs(n_log);
         // Pre-fault the prove-cycle scratch buffers — see scratch::prewarm_prover.
-        flock_core::scratch::prewarm_prover(r1cs.m);
+        prewarm_prover(r1cs.m);
         let pcs_params = PcsParams {
             m: r1cs.m,
             log_inv_rate,
@@ -923,7 +933,7 @@ impl KeccakSetup {
         let mut s = Self::new(n_keccaks);
         // Safe to set post-construction: the digest/csc caches are lazy and
         // untouched by `new`.
-        s.r1cs.layout = flock_core::r1cs::WitnessLayout::BatchMajor;
+        s.r1cs.layout = WitnessLayout::BatchMajor;
         s
     }
 
@@ -933,10 +943,10 @@ impl KeccakSetup {
         initial_states: &[State],
     ) -> (Vec<F128>, Vec<F128>, Vec<F128>, Vec<u8>) {
         match self.r1cs.layout {
-            flock_core::r1cs::WitnessLayout::RowMajor => {
+            WitnessLayout::RowMajor => {
                 generate_witness_with_ab_packed_and_lincheck(initial_states, self.n_keccaks_log())
             }
-            flock_core::r1cs::WitnessLayout::BatchMajor => {
+            WitnessLayout::BatchMajor => {
                 generate_witness_batch_major(initial_states, self.n_keccaks_log())
             }
         }
@@ -958,13 +968,11 @@ impl KeccakSetup {
         &self,
         initial_states: &[State],
         challenger: &mut Ch,
-    ) -> (flock_core::proof::R1csProofLigerito, Commitment, R1csClaim) {
+    ) -> (R1csProofLigerito, Commitment, R1csClaim) {
         assert_eq!(initial_states.len(), self.n_keccaks);
         let (codeword, (z_packed, a_packed_f128, b_packed_f128, z_packed_lincheck)) =
-            flock_core::pcs::prefault_codeword_during(&self.pcs_params, || {
-                self.generate_witness(initial_states)
-            });
-        crate::prover::prove_fast_ligerito_from_witness(
+            prefault_codeword_during(&self.pcs_params, || self.generate_witness(initial_states));
+        prove_fast_ligerito_from_witness(
             &self.r1cs,
             &self.pcs_params,
             z_packed,
@@ -981,7 +989,7 @@ impl KeccakSetup {
     pub fn verify<Ch: Challenger>(
         &self,
         commitment: &Commitment,
-        proof: &flock_core::proof::R1csProofLigerito,
+        proof: &R1csProofLigerito,
         challenger: &mut Ch,
     ) -> Result<R1csClaim, verifier::VerifyError> {
         verifier::verify_ligerito(
@@ -1002,14 +1010,11 @@ impl KeccakSetup {
         &self,
         initial_states: &[State],
         challenger: &mut Ch,
-    ) -> (
-        crate::r1cs_hashes::chain_common::ChainProofLigerito,
-        Commitment,
-    ) {
+    ) -> (ChainProofLigerito, Commitment) {
         assert_eq!(initial_states.len(), self.n_keccaks);
         assert_eq!(self.n_keccaks, self.n_keccak_slots());
         let (z_packed, a_packed, b_packed, z_lincheck) = self.generate_witness(initial_states);
-        crate::r1cs_hashes::chain_common::prove_chain_ligerito_generic(
+        prove_chain_ligerito_generic(
             &self.r1cs,
             &self.pcs_params,
             &CHAIN_LAYOUT,
@@ -1026,7 +1031,7 @@ impl KeccakSetup {
     pub fn verify_chain<Ch: Challenger>(
         &self,
         commitment: &Commitment,
-        proof: &crate::r1cs_hashes::chain_common::ChainProofLigerito,
+        proof: &ChainProofLigerito,
         x_0: &State,
         x_last: &State,
         challenger: &mut Ch,
@@ -1035,7 +1040,7 @@ impl KeccakSetup {
         let n_log = self.n_keccaks_log();
         let x0_phys = state_to_phys_bits(x_0);
         let xlast_phys = state_to_phys_bits(x_last);
-        crate::r1cs_hashes::chain_common::verify_chain_ligerito_generic(
+        verify_chain_ligerito_generic(
             &self.r1cs,
             &CHAIN_LAYOUT,
             commitment,
@@ -1334,9 +1339,9 @@ pub fn generate_witness_batch_major(
     let useful_chunks = USEFUL_BITS.div_ceil(128);
     let total_f128 = n_total * (U64_PER_BLOCK / 2);
 
-    let mut z = flock_core::scratch::take_f128(total_f128);
-    let mut a = flock_core::scratch::take_f128(total_f128);
-    let mut b = flock_core::scratch::take_f128(total_f128);
+    let mut z = take_f128(total_f128);
+    let mut a = take_f128(total_f128);
+    let mut b = take_f128(total_f128);
     let stripe = vec![0u8; n_total * U64_PER_BLOCK * 8];
     // Zero the padding suffix (contiguous chunk-columns >= useful_chunks);
     // the group builder fully rewrites the useful prefix every call.
@@ -1359,8 +1364,7 @@ pub fn generate_witness_batch_major(
 
     (0..n_total / BM_V).into_par_iter().for_each(move |g| {
         let o0 = g * BM_V;
-        let group: [&State; BM_V] =
-            std::array::from_fn(|j| states_ref.get(o0 + j).unwrap_or(padding_ref));
+        let group: [&State; BM_V] = from_fn(|j| states_ref.get(o0 + j).unwrap_or(padding_ref));
         // SAFETY: disjoint per-group ranges; suffix pre-zeroed above.
         unsafe {
             build_group_batch_major(
@@ -1765,7 +1769,7 @@ mod tests {
         b.iter_mut().for_each(|v| *v = F128::ZERO);
         zlc.iter_mut().for_each(|v| *v = 0);
         let mut ch_p = FsChallenger::new(b"poc");
-        let (proof, commitment, _) = crate::prover::prove_fast_ligerito_from_witness(
+        let (proof, commitment, _) = prove_fast_ligerito_from_witness(
             &setup.r1cs,
             &setup.pcs_params,
             z,
@@ -1779,7 +1783,7 @@ mod tests {
         let mut ch_v = FsChallenger::new(b"poc");
         let res = setup.verify(&commitment, &proof, &mut ch_v);
         assert!(
-            matches!(res, Err(flock_core::verifier::VerifyError::Lincheck(_))),
+            matches!(res, Err(VerifyError::Lincheck(_))),
             "all-zero witness must be rejected by the constant-wire pin; got {res:?}"
         );
     }
@@ -1804,18 +1808,8 @@ mod tests {
             })
             .collect();
         let fold = ChainFold::new(&CHAIN_LAYOUT, tau_pos);
-        let (in_r, out_r) = fold_in_out(
-            &CHAIN_LAYOUT,
-            flock_core::r1cs::WitnessLayout::RowMajor,
-            &z_r,
-            &fold,
-        );
-        let (in_b, out_b) = fold_in_out(
-            &CHAIN_LAYOUT,
-            flock_core::r1cs::WitnessLayout::BatchMajor,
-            &z_b,
-            &fold,
-        );
+        let (in_r, out_r) = fold_in_out(&CHAIN_LAYOUT, WitnessLayout::RowMajor, &z_r, &fold);
+        let (in_b, out_b) = fold_in_out(&CHAIN_LAYOUT, WitnessLayout::BatchMajor, &z_b, &fold);
         assert_eq!(in_b, in_r, "In fold diverged across layouts");
         assert_eq!(out_b, out_r, "Out fold diverged across layouts");
     }

--- a/crates/flock-prover/src/r1cs_hashes/keccak3.rs
+++ b/crates/flock-prover/src/r1cs_hashes/keccak3.rs
@@ -39,13 +39,22 @@
 //!   with `state_r` implicit via the φ substitution.
 //! - Padding: empty A, B.
 
+use crate::prover::ProvePhaseTimings;
+use crate::prover::prove_fast_ligerito_from_witness;
+use crate::prover::prove_fast_ligerito_timed;
 use flock_core::challenger::Challenger;
 use flock_core::field::F128;
 use flock_core::lincheck::LincheckCircuit;
+use flock_core::pcs::ligerito::LigeritoProfile;
+use flock_core::pcs::prefault_codeword_during;
 use flock_core::pcs::{Commitment, PcsParams};
 use flock_core::proof::R1csClaim;
+use flock_core::proof::R1csProofLigerito;
 use flock_core::r1cs::BlockR1cs;
 use flock_core::verifier;
+#[cfg(test)]
+use std::hint::black_box;
+use std::time::Instant;
 
 use super::keccak::{
     LANE_BITS, Lanes, N_LANES, N_ROUNDS, N_T, ROUND_CONSTANTS, STATE_BITS, STATE_SIZE_BITS, State,
@@ -297,6 +306,11 @@ pub fn generate_witness_with_ab_packed_and_lincheck(
 /// shared const self-loop, which [`KeccakLincheckCircuit::fold_alpha_batched`]
 /// adds once).
 fn accumulate_subkeccak(i: usize, alpha: F128, eq_inner: &[F128], comb: &mut [F128]) {
+    // ---- t-AND rows: per-round χ marginals on state_r positions.
+    // Rounds are independent (each writes only chi_*[r]); F128 addition is
+    // XOR (exactly associative/commutative), so the parallel reduction is
+    // bit-identical to the serial loop.
+    use rayon::prelude::*;
     // ---- state_0 input self-loops: A = [row], B = [Z_CONST].
     for j in 0..STATE_BITS {
         let row = z_pos_state(i, 0, j);
@@ -316,11 +330,6 @@ fn accumulate_subkeccak(i: usize, alpha: F128, eq_inner: &[F128], comb: &mut [F1
     }
     comb[Z_CONST] += sum_eq_pin; // B-side from pin's B = [Z_CONST]
 
-    // ---- t-AND rows: per-round χ marginals on state_r positions.
-    // Rounds are independent (each writes only chi_*[r]); F128 addition is
-    // XOR (exactly associative/commutative), so the parallel reduction is
-    // bit-identical to the serial loop.
-    use rayon::prelude::*;
     let chi: Vec<(Vec<F128>, Vec<F128>, F128)> = (0..N_T)
         .into_par_iter()
         .map(|r| {
@@ -502,25 +511,22 @@ impl KeccakSetup {
     pub fn with_log_inv_rate(n_keccaks: usize, log_inv_rate: usize) -> Self {
         // Rate keys the legacy profiles: 1 -> Fast, 2 -> Slim.
         let profile = match log_inv_rate {
-            1 => flock_core::pcs::ligerito::LigeritoProfile::Fast,
-            2 => flock_core::pcs::ligerito::LigeritoProfile::Slim,
-            _ => flock_core::pcs::ligerito::LigeritoProfile::Fast, // other rates default to Fast
+            1 => LigeritoProfile::Fast,
+            2 => LigeritoProfile::Slim,
+            _ => LigeritoProfile::Fast, // other rates default to Fast
         };
         Self::with_profile_and_rate(n_keccaks, profile, log_inv_rate)
     }
 
     /// Build a setup for a named Ligerito profile (fast/slim/secure);
     /// the PCS rate follows the profile.
-    pub fn with_profile(
-        n_keccaks: usize,
-        profile: flock_core::pcs::ligerito::LigeritoProfile,
-    ) -> Self {
+    pub fn with_profile(n_keccaks: usize, profile: LigeritoProfile) -> Self {
         Self::with_profile_and_rate(n_keccaks, profile, profile.log_inv_rate())
     }
 
     fn with_profile_and_rate(
         n_keccaks: usize,
-        profile: flock_core::pcs::ligerito::LigeritoProfile,
+        profile: LigeritoProfile,
         log_inv_rate: usize,
     ) -> Self {
         assert!(n_keccaks >= 1);
@@ -557,13 +563,13 @@ impl KeccakSetup {
         &self,
         initial_states: &[State],
         challenger: &mut Ch,
-    ) -> (flock_core::proof::R1csProofLigerito, Commitment, R1csClaim) {
+    ) -> (R1csProofLigerito, Commitment, R1csClaim) {
         assert_eq!(initial_states.len(), self.n_keccaks);
         let (codeword, (z_packed, a_packed_f128, b_packed_f128, z_packed_lincheck)) =
-            flock_core::pcs::prefault_codeword_during(&self.pcs_params, || {
+            prefault_codeword_during(&self.pcs_params, || {
                 generate_witness_with_ab_packed_and_lincheck(initial_states, self.n_blocks_log())
             });
-        crate::prover::prove_fast_ligerito_from_witness(
+        prove_fast_ligerito_from_witness(
             &self.r1cs,
             &self.pcs_params,
             z_packed,
@@ -579,7 +585,7 @@ impl KeccakSetup {
     pub fn verify<Ch: Challenger>(
         &self,
         commitment: &Commitment,
-        proof: &flock_core::proof::R1csProofLigerito,
+        proof: &R1csProofLigerito,
         challenger: &mut Ch,
     ) -> Result<R1csClaim, verifier::VerifyError> {
         verifier::verify_ligerito(
@@ -599,18 +605,13 @@ impl KeccakSetup {
         &self,
         initial_states: &[State],
         challenger: &mut Ch,
-    ) -> (
-        flock_core::proof::R1csProofLigerito,
-        Commitment,
-        R1csClaim,
-        crate::prover::ProvePhaseTimings,
-    ) {
+    ) -> (R1csProofLigerito, Commitment, R1csClaim, ProvePhaseTimings) {
         assert_eq!(initial_states.len(), self.n_keccaks);
-        let t0 = std::time::Instant::now();
+        let t0 = Instant::now();
         let (z_packed, a_packed_f128, b_packed_f128, z_packed_lincheck) =
             generate_witness_with_ab_packed_and_lincheck(initial_states, self.n_blocks_log());
         let witness_s = t0.elapsed().as_secs_f64();
-        let (proof, commitment, claim, mut timings) = crate::prover::prove_fast_ligerito_timed(
+        let (proof, commitment, claim, mut timings) = prove_fast_ligerito_timed(
             &self.r1cs,
             &self.pcs_params,
             z_packed,
@@ -822,13 +823,13 @@ mod tests {
         let mut ch = FsChallenger::new(b"pack-bench");
         let (p1, _, _) = s1.prove_fast(&inputs, &mut ch);
         let single = t.elapsed().as_secs_f64();
-        std::hint::black_box(&p1);
+        black_box(&p1);
 
         t = Instant::now();
         let mut ch = FsChallenger::new(b"pack-bench");
         let (p3, _, _) = s3.prove_fast(&inputs, &mut ch);
         let wide = t.elapsed().as_secs_f64();
-        std::hint::black_box(&p3);
+        black_box(&p3);
 
         println!(
             "prove_fast: single={:.1} ms  3-wide={:.1} ms  ({:.2}x)",
@@ -930,7 +931,7 @@ mod tests {
         zlc.iter_mut().for_each(|v| *v = 0);
 
         let mut ch_p = FsChallenger::new(b"poc");
-        let (proof, commitment, _claim) = crate::prover::prove_fast_ligerito_from_witness(
+        let (proof, commitment, _claim) = prove_fast_ligerito_from_witness(
             &setup.r1cs,
             &setup.pcs_params,
             z,

--- a/crates/flock-prover/src/r1cs_hashes/merkle_glue.rs
+++ b/crates/flock-prover/src/r1cs_hashes/merkle_glue.rs
@@ -45,6 +45,8 @@
 use flock_core::field::F128;
 use flock_core::r1cs::{BlockR1cs, SparseBinaryMatrix, WitnessLayout};
 use flock_core::schedule::IoWord;
+use flock_core::zerocheck::K_SKIP;
+use std::sync::OnceLock;
 
 use super::common::identity;
 use super::merkle_r1cs::SLOT_WORDS;
@@ -84,6 +86,7 @@ fn scatter_zab(
     useful_bits: usize,
     nu: usize,
 ) -> (Vec<F128>, Vec<F128>, Vec<F128>, Vec<u8>) {
+    use rayon::prelude::*;
     let n_total = 1usize << nu;
     assert!(
         n_total.is_multiple_of(8),
@@ -104,7 +107,6 @@ fn scatter_zab(
         }
     }
 
-    use rayon::prelude::*;
     let mut stripe = vec![0u8; (n_total / 8) * k];
     stripe.par_chunks_mut(k).enumerate().for_each(|(g, chunk)| {
         for r in 0..8 {
@@ -237,15 +239,15 @@ impl SwapTable {
         BlockR1cs {
             m: n_log + Self::K_LOG,
             k_log: Self::K_LOG,
-            k_skip: flock_core::zerocheck::K_SKIP,
+            k_skip: K_SKIP,
             useful_bits: Self::USEFUL_BITS,
             a_0,
             b_0,
             c_0: identity(Self::k()),
             layout: WitnessLayout::BatchMajor,
             const_pin: Some(Self::CONST),
-            digest_cache: std::sync::OnceLock::new(),
-            csc_cache: std::sync::OnceLock::new(),
+            digest_cache: OnceLock::new(),
+            csc_cache: OnceLock::new(),
         }
     }
 
@@ -430,15 +432,15 @@ impl BitSpreadTable {
         BlockR1cs {
             m: n_log + self.k_log(),
             k_log: self.k_log(),
-            k_skip: flock_core::zerocheck::K_SKIP,
+            k_skip: K_SKIP,
             useful_bits: self.useful_bits(),
             a_0,
             b_0,
             c_0: identity(self.k()),
             layout: WitnessLayout::BatchMajor,
             const_pin: Some(self.const_pos()),
-            digest_cache: std::sync::OnceLock::new(),
-            csc_cache: std::sync::OnceLock::new(),
+            digest_cache: OnceLock::new(),
+            csc_cache: OnceLock::new(),
         }
     }
 

--- a/crates/flock-prover/src/r1cs_hashes/merkle_path_common.rs
+++ b/crates/flock-prover/src/r1cs_hashes/merkle_path_common.rs
@@ -20,15 +20,37 @@
 //! coords, so its contents are invisible to the sumcheck but participate in
 //! the multilinear extension over the slot-selector dimensions.
 
+use crate::merkle_path::MerklePathClaims;
+use crate::merkle_path::MerklePathError;
+use crate::merkle_path::prove_merkle_path_shift;
+use crate::merkle_path::verify_merkle_path_shift;
 use crate::merkle_path::{MerklePathShiftProof, SlotLayout};
+use crate::prover::ProveCore;
+use crate::prover::prove_fast_core;
+use crate::prover::quirky_x_outer_full;
 use flock_core::challenger::Challenger;
 use flock_core::field::F128;
+use flock_core::lincheck::LincheckCircuit;
+use flock_core::lincheck::LincheckProof;
 use flock_core::lincheck::build_eq_table;
+use flock_core::pcs::BatchOpeningProofLigerito;
+use flock_core::pcs::VerifyError as PcsVerifyError;
+use flock_core::pcs::open_batch_mixed_ligerito_with_precomputed_s_hat_v;
+use flock_core::pcs::ring_switch::build_eq_sparse;
+use flock_core::pcs::verify_opening_batch_ligerito_mixed;
 use flock_core::pcs::{
     Commitment, DirectEqInd, LOG_PACKING, PackedDirectClaim, PackedDirectClaimRef, PcsParams,
 };
 use flock_core::r1cs::BlockR1cs;
+use flock_core::r1cs::WitnessLayout;
+use flock_core::verifier::VerifyError as VerifierVerifyError;
+use flock_core::verifier::verify_core;
+use flock_core::zerocheck::ZerocheckProof;
 use serde::{Deserialize, Serialize};
+use std::env::var;
+use std::iter::repeat_n;
+use std::slice::from_ref;
+use std::time::Instant;
 
 // ---------------------------------------------------------------------------
 // Layout
@@ -164,7 +186,7 @@ impl MerklePathFold {
 /// `s = sel_slot | (side << 1)`, matching the cube convention.
 pub fn fold_all_slots(
     layout: &MerkleLayout,
-    wl: flock_core::r1cs::WitnessLayout,
+    wl: WitnessLayout,
     packed: &[F128],
     fold: &MerklePathFold,
 ) -> [Vec<F128>; 4] {
@@ -188,8 +210,8 @@ pub fn fold_all_slots(
     // `chain_common::fold_in_out`).
     let word_addr = move |i: usize, w: usize| -> usize {
         match wl {
-            flock_core::r1cs::WitnessLayout::RowMajor => i * block_packed + w,
-            flock_core::r1cs::WitnessLayout::BatchMajor => (w << n_log) + i,
+            WitnessLayout::RowMajor => i * block_packed + w,
+            WitnessLayout::BatchMajor => (w << n_log) + i,
         }
     };
 
@@ -230,12 +252,12 @@ pub fn fold_all_slots(
 /// `eq_ind(point)` sparse with a `2^high_zeros ×` density reduction.
 pub fn assemble_merkle_path_claim(
     layout: &MerkleLayout,
-    wl: flock_core::r1cs::WitnessLayout,
+    wl: WitnessLayout,
     fold: &MerklePathFold,
-    claims: &crate::merkle_path::MerklePathClaims,
+    claims: &MerklePathClaims,
 ) -> PackedDirectClaim {
     let point = build_merkle_claim_point(layout, wl, fold, claims);
-    let sparse_eq = flock_core::pcs::ring_switch::build_eq_sparse(&point);
+    let sparse_eq = build_eq_sparse(&point);
     PackedDirectClaim {
         point,
         value: claims.value,
@@ -251,21 +273,21 @@ pub fn assemble_merkle_path_claim(
 /// BatchMajor `[instance…, τ_pos…, sel_slot, side, 0^high]`.
 fn build_merkle_claim_point(
     layout: &MerkleLayout,
-    wl: flock_core::r1cs::WitnessLayout,
+    wl: WitnessLayout,
     fold: &MerklePathFold,
-    claims: &crate::merkle_path::MerklePathClaims,
+    claims: &MerklePathClaims,
 ) -> Vec<F128> {
     let high = layout.high_zeros();
     let point_len = fold.tau_pos.len() + 2 + high + claims.instance_point.len();
     let mut point = Vec::with_capacity(point_len);
-    if wl == flock_core::r1cs::WitnessLayout::BatchMajor {
+    if wl == WitnessLayout::BatchMajor {
         point.extend_from_slice(&claims.instance_point);
     }
     point.extend_from_slice(&fold.tau_pos);
     point.push(claims.sel_slot);
     point.push(claims.side);
-    point.extend(std::iter::repeat_n(F128::ZERO, high));
-    if wl == flock_core::r1cs::WitnessLayout::RowMajor {
+    point.extend(repeat_n(F128::ZERO, high));
+    if wl == WitnessLayout::RowMajor {
         point.extend_from_slice(&claims.instance_point);
     }
     debug_assert_eq!(point.len(), point_len);
@@ -281,20 +303,20 @@ fn build_merkle_claim_point(
 /// sub-proof, and ONE batched Ligerito PCS open.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MerklePathProofLigerito {
-    pub zerocheck: flock_core::zerocheck::ZerocheckProof,
-    pub lincheck: flock_core::lincheck::LincheckProof,
+    pub zerocheck: ZerocheckProof,
+    pub lincheck: LincheckProof,
     pub shift: MerklePathShiftProof,
-    pub pcs_open: flock_core::pcs::BatchOpeningProofLigerito,
+    pub pcs_open: BatchOpeningProofLigerito,
 }
 
 #[derive(Debug)]
 pub enum MerklePathVerifyError {
     /// Base R1CS replay failed.
-    R1cs(flock_core::verifier::VerifyError),
+    R1cs(VerifierVerifyError),
     /// Merkle-path shift sumcheck check failed.
-    Shift(crate::merkle_path::MerklePathError),
+    Shift(MerklePathError),
     /// The batched PCS opening failed.
-    Pcs(flock_core::pcs::VerifyError),
+    Pcs(PcsVerifyError),
 }
 
 // ---------------------------------------------------------------------------
@@ -321,22 +343,18 @@ pub fn prove_merkle_paths_ligerito_generic<Ch: Challenger>(
     b_packed: Vec<F128>,
     z_lincheck: Vec<u8>,
     b_bits: &[bool],
-    lincheck_circuit: &dyn flock_core::lincheck::LincheckCircuit,
+    lincheck_circuit: &dyn LincheckCircuit,
     challenger: &mut Ch,
 ) -> (MerklePathProofLigerito, Commitment) {
-    let trace = std::env::var("MERKLE_TRACE").is_ok();
+    let trace = var("MERKLE_TRACE").is_ok();
 
     let lig_config = pcs_params
         .ligerito_prover_config()
         .expect("Ligerito config for merkle-path prove; bump m for tiny instances");
 
     // ---- Core: commit → zerocheck → lincheck.
-    let t = if trace {
-        Some(std::time::Instant::now())
-    } else {
-        None
-    };
-    let core = crate::prover::prove_fast_core(
+    let t = if trace { Some(Instant::now()) } else { None };
+    let core = prove_fast_core(
         r1cs,
         pcs_params,
         z_packed,
@@ -355,11 +373,7 @@ pub fn prove_merkle_paths_ligerito_generic<Ch: Challenger>(
     }
 
     // ---- Packed-pos fold.
-    let t = if trace {
-        Some(std::time::Instant::now())
-    } else {
-        None
-    };
+    let t = if trace { Some(Instant::now()) } else { None };
     let tau_pos = challenger.sample_f128_vec(layout.tau_pos_len());
     let fold = MerklePathFold::new(layout, tau_pos);
     let slot_vals = fold_all_slots(layout, r1cs.layout, &core.z_packed, &fold);
@@ -372,16 +386,12 @@ pub fn prove_merkle_paths_ligerito_generic<Ch: Challenger>(
     }
 
     // ---- Merkle-path shift sumcheck.
-    let t = if trace {
-        Some(std::time::Instant::now())
-    } else {
-        None
-    };
+    let t = if trace { Some(Instant::now()) } else { None };
     let x_l_vals = &slot_vals[layout.x_l_slot as usize];
     let x_r_vals = &slot_vals[layout.x_r_slot as usize];
     let z_vals = &slot_vals[layout.z_slot as usize];
     let iv_vals = &slot_vals[layout.other_slot() as usize];
-    let (shift, claims) = crate::merkle_path::prove_merkle_path_shift(
+    let (shift, claims) = prove_merkle_path_shift(
         path_log,
         x_l_vals,
         x_r_vals,
@@ -401,17 +411,13 @@ pub fn prove_merkle_paths_ligerito_generic<Ch: Challenger>(
     }
 
     // ---- Batched open: [ab, c] ring-switched + [merkle] packed-direct, via Ligerito.
-    let t = if trace {
-        Some(std::time::Instant::now())
-    } else {
-        None
-    };
+    let t = if trace { Some(Instant::now()) } else { None };
     let padding = r1cs.padding_spec();
-    let ab_x_outer = crate::prover::quirky_x_outer_full(&core.ab.point);
-    let c_x_outer = crate::prover::quirky_x_outer_full(&core.c.point);
+    let ab_x_outer = quirky_x_outer_full(&core.ab.point);
+    let c_x_outer = quirky_x_outer_full(&core.c.point);
     // Destructure core to move z_packed by value into the open (saves a large
     // clone at high m), mirroring `prove_chain_ligerito_generic`.
-    let crate::prover::ProveCore {
+    let ProveCore {
         zc_proof,
         lc_proof,
         commitment,
@@ -423,13 +429,13 @@ pub fn prove_merkle_paths_ligerito_generic<Ch: Challenger>(
     } = core;
     let pre_ab: Option<&[F128]> = s_hat_v_ab.as_deref();
     let pre_c: Option<&[F128]> = Some(s_hat_v_c.as_slice());
-    let pcs_open = flock_core::pcs::open_batch_mixed_ligerito_with_precomputed_s_hat_v(
+    let pcs_open = open_batch_mixed_ligerito_with_precomputed_s_hat_v(
         z_packed,
         &prover_data,
         &commitment,
         &[ab_x_outer.as_slice(), c_x_outer.as_slice()],
         &[pre_ab, pre_c],
-        std::slice::from_ref(&merkle_claim),
+        from_ref(&merkle_claim),
         &padding,
         &lig_config,
         challenger,
@@ -466,7 +472,7 @@ pub fn verify_merkle_paths_ligerito_generic<Ch: Challenger>(
     leaves_phys: &[&[bool]],
     root_phys: &[bool],
     b_bits: &[bool],
-    lincheck_circuit: &dyn flock_core::lincheck::LincheckCircuit,
+    lincheck_circuit: &dyn LincheckCircuit,
     pcs_params: &PcsParams,
     challenger: &mut Ch,
 ) -> Result<(), MerklePathVerifyError> {
@@ -478,7 +484,7 @@ pub fn verify_merkle_paths_ligerito_generic<Ch: Challenger>(
         "leaves_phys must have length 2^path_log"
     );
 
-    let (ab, c) = flock_core::verifier::verify_core(
+    let (ab, c) = verify_core(
         r1cs,
         &proof.zerocheck,
         &proof.lincheck,
@@ -497,7 +503,7 @@ pub fn verify_merkle_paths_ligerito_generic<Ch: Challenger>(
         .collect();
     let root_r = fold.fold_public_phys(root_phys);
 
-    let claims = crate::merkle_path::verify_merkle_path_shift(
+    let claims = verify_merkle_path_shift(
         path_log,
         &proof.shift,
         &leaf_evals,
@@ -510,8 +516,8 @@ pub fn verify_merkle_paths_ligerito_generic<Ch: Challenger>(
     .map_err(MerklePathVerifyError::Shift)?;
 
     let merkle_point = build_merkle_claim_point(layout, r1cs.layout, &fold, &claims);
-    let ab_x_outer = crate::prover::quirky_x_outer_full(&ab.point);
-    let c_x_outer = crate::prover::quirky_x_outer_full(&c.point);
+    let ab_x_outer = quirky_x_outer_full(&ab.point);
+    let c_x_outer = quirky_x_outer_full(&c.point);
     let pd_ref = PackedDirectClaimRef {
         point: &merkle_point,
         value: claims.value,
@@ -521,12 +527,12 @@ pub fn verify_merkle_paths_ligerito_generic<Ch: Challenger>(
         .ligerito_verifier_config()
         .expect("Ligerito verifier config for merkle-path verify");
 
-    flock_core::pcs::verify_opening_batch_ligerito_mixed(
+    verify_opening_batch_ligerito_mixed(
         commitment,
         &[ab.value, c.value],
         &[ab.point.z_skip, c.point.z_skip],
         &[ab_x_outer.as_slice(), c_x_outer.as_slice()],
-        std::slice::from_ref(&pd_ref),
+        from_ref(&pd_ref),
         &proof.pcs_open,
         &lig_v_config,
         challenger,

--- a/crates/flock-prover/src/r1cs_hashes/merkle_r1cs.rs
+++ b/crates/flock-prover/src/r1cs_hashes/merkle_r1cs.rs
@@ -106,7 +106,17 @@
 //! §8, §11).
 
 use flock_core::field::F128;
+use flock_core::lincheck::LincheckCircuit;
 use flock_core::r1cs::{BlockR1cs, SparseBinaryMatrix, WitnessLayout};
+use flock_core::schedule::IoWord;
+use flock_core::union::SlotWitnessDest;
+use flock_core::zerocheck::K_SKIP;
+use std::array::from_fn;
+use std::env::var;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::fmt::Result;
+use std::sync::OnceLock;
 
 use super::blake3;
 use super::common::{empty_matrix, identity};
@@ -324,7 +334,7 @@ fn blake3_node_group_ab(
     ra: &mut [[u64; 8]],
     rb: &mut [[u64; 8]],
 ) {
-    let blocks: [blake3::Compression; 8] = std::array::from_fn(|j| {
+    let blocks: [blake3::Compression; 8] = from_fn(|j| {
         (
             blake3::BLAKE3_IV,
             node_msg(&pairs[j].0, &pairs[j].1),
@@ -333,7 +343,7 @@ fn blake3_node_group_ab(
             BLAKE3_FLAG_PARENT,
         )
     });
-    let refs: [&blake3::Compression; 8] = std::array::from_fn(|j| &blocks[j]);
+    let refs: [&blake3::Compression; 8] = from_fn(|j| &blocks[j]);
     blake3::build_group_batch_major(refs, rz, ra, rb);
 }
 
@@ -345,7 +355,7 @@ fn blake3_raw_group_ab(
     ra: &mut [[u64; 8]],
     rb: &mut [[u64; 8]],
 ) {
-    let refs: [&blake3::Compression; 8] = std::array::from_fn(|j| &blocks[j]);
+    let refs: [&blake3::Compression; 8] = from_fn(|j| &blocks[j]);
     blake3::build_group_batch_major(refs, rz, ra, rb);
 }
 
@@ -639,7 +649,7 @@ impl MerkleTreeLayout {
     /// Everything that IS here has an outside claimant: the leaf data is read
     /// by whatever proves the opened values, the index binds to the
     /// Fiat–Shamir query, and the root binds to the committed root.
-    pub fn io_schema(&self) -> Vec<flock_core::schedule::IoWord> {
+    pub fn io_schema(&self) -> Vec<IoWord> {
         use flock_core::schedule::IoWord;
         assert!(
             self.leaf_blocks > 0,
@@ -961,15 +971,15 @@ impl MerkleTreeLayout {
         BlockR1cs {
             m: n_paths_log + self.k_log,
             k_log: self.k_log,
-            k_skip: flock_core::zerocheck::K_SKIP,
+            k_skip: K_SKIP,
             useful_bits: self.useful_bits,
             a_0,
             b_0,
             c_0: identity(self.k()),
             layout: WitnessLayout::BatchMajor,
             const_pin: Some(self.const_pos()),
-            digest_cache: std::sync::OnceLock::new(),
-            csc_cache: std::sync::OnceLock::new(),
+            digest_cache: OnceLock::new(),
+            csc_cache: OnceLock::new(),
         }
     }
 
@@ -1223,7 +1233,7 @@ impl MerkleTreeLayout {
         &self,
         paths: &[PathInput],
         nu: usize,
-        dst: flock_core::union::SlotWitnessDest<'_>,
+        dst: SlotWitnessDest<'_>,
     ) -> Vec<u8> {
         use super::common::{BM_V, BmRow, or_bit_row, or_u32_row};
 
@@ -1279,7 +1289,7 @@ impl MerkleTreeLayout {
             dst,
             move |group, rz, ra, rb| {
                 // Per-lane running digest: the leaf, then each level's output.
-                let mut prev: [[u32; SLOT_WORDS]; BM_V] = std::array::from_fn(|j| group[j].leaf);
+                let mut prev: [[u32; SLOT_WORDS]; BM_V] = from_fn(|j| group[j].leaf);
 
                 for l in 0..depth {
                     let w0 = l * words_per_level;
@@ -1305,14 +1315,14 @@ impl MerkleTreeLayout {
 
                     for w in 0..SLOT_WORDS {
                         // Sibling: a free column (z = a = S, b = 1).
-                        let sib: [u32; BM_V] = std::array::from_fn(|j| group[j].siblings[l][w]);
+                        let sib: [u32; BM_V] = from_fn(|j| group[j].siblings[l][w]);
                         or_u32_row(wz, sib_off + 32 * w, &sib);
                         or_u32_row(wa, sib_off + 32 * w, &sib);
                         or_u32_row(wb, sib_off + 32 * w, &[!0u32; BM_V]);
 
                         // t = b_l · (prev ⊕ S): A = [b_l], B = [prev, S].
-                        let xor: [u32; BM_V] = std::array::from_fn(|j| prev[j][w] ^ sib[j]);
-                        let t: [u32; BM_V] = std::array::from_fn(|j| mask[j] & xor[j]);
+                        let xor: [u32; BM_V] = from_fn(|j| prev[j][w] ^ sib[j]);
+                        let t: [u32; BM_V] = from_fn(|j| mask[j] & xor[j]);
                         or_u32_row(wz, t_off + 32 * w, &t);
                         or_u32_row(wa, t_off + 32 * w, &mask);
                         or_u32_row(wb, t_off + 32 * w, &xor);
@@ -1324,7 +1334,7 @@ impl MerkleTreeLayout {
                         or_bit_row(wa, const_off);
                         or_bit_row(wb, const_off);
                         for w in 0..SLOT_WORDS {
-                            let leaf: [u32; BM_V] = std::array::from_fn(|j| group[j].leaf[w]);
+                            let leaf: [u32; BM_V] = from_fn(|j| group[j].leaf[w]);
                             or_u32_row(wz, leaf_off + 32 * w, &leaf);
                             or_u32_row(wa, leaf_off + 32 * w, &leaf);
                             or_u32_row(wb, leaf_off + 32 * w, &[!0u32; BM_V]);
@@ -1334,8 +1344,7 @@ impl MerkleTreeLayout {
                         // are interior padding that empty rows force to zero,
                         // so a wider store would break the R1CS.
                         for i in 0..depth {
-                            let v: [u32; BM_V] =
-                                std::array::from_fn(|j| ((group[j].index >> i) & 1) as u32);
+                            let v: [u32; BM_V] = from_fn(|j| ((group[j].index >> i) & 1) as u32);
                             or_u32_row(wz, index_off + i, &v);
                             or_u32_row(wa, index_off + i, &v);
                             or_bit_row(wb, index_off + i);
@@ -1656,7 +1665,7 @@ impl MerkleTreeLayout {
         &self,
         paths: &[ChunkPathInput],
         nu: usize,
-        dst: flock_core::union::SlotWitnessDest<'_>,
+        dst: SlotWitnessDest<'_>,
     ) -> Vec<u8> {
         use super::common::{BM_V, BmRow, or_bit_row, or_u32_row};
 
@@ -1720,7 +1729,7 @@ impl MerkleTreeLayout {
                         f
                     };
                     let blocks: [([u32; SLOT_WORDS], [u32; 16], u64, u32, u32); BM_V] =
-                        std::array::from_fn(|j| {
+                        from_fn(|j| {
                             (
                                 prev[j],
                                 leaf_msg_words(&group[j].leaf_data, i),
@@ -1741,8 +1750,7 @@ impl MerkleTreeLayout {
                         // `depth` are read by no row; they carry whatever the
                         // wired Fiat-Shamir challenge put there.
                         for l in 0..128 {
-                            let v: [u32; BM_V] =
-                                std::array::from_fn(|j| ((group[j].index >> l) & 1) as u32);
+                            let v: [u32; BM_V] = from_fn(|j| ((group[j].index >> l) & 1) as u32);
                             or_u32_row(wz, index_off + l, &v);
                             or_u32_row(wa, index_off + l, &v);
                             or_bit_row(wb, index_off + l);
@@ -1777,13 +1785,13 @@ impl MerkleTreeLayout {
                     (spec.node_group_ab)(&pairs, wz, wa, wb);
 
                     for w in 0..SLOT_WORDS {
-                        let sib: [u32; BM_V] = std::array::from_fn(|j| group[j].siblings[l][w]);
+                        let sib: [u32; BM_V] = from_fn(|j| group[j].siblings[l][w]);
                         or_u32_row(wz, sib_off + 32 * w, &sib);
                         or_u32_row(wa, sib_off + 32 * w, &sib);
                         or_u32_row(wb, sib_off + 32 * w, &[!0u32; BM_V]);
 
-                        let xor: [u32; BM_V] = std::array::from_fn(|j| prev[j][w] ^ sib[j]);
-                        let t: [u32; BM_V] = std::array::from_fn(|j| mask[j] & xor[j]);
+                        let xor: [u32; BM_V] = from_fn(|j| prev[j][w] ^ sib[j]);
+                        let t: [u32; BM_V] = from_fn(|j| mask[j] & xor[j]);
                         or_u32_row(wz, t_off + 32 * w, &t);
                         or_u32_row(wa, t_off + 32 * w, &mask);
                         or_u32_row(wb, t_off + 32 * w, &xor);
@@ -1908,7 +1916,7 @@ pub struct ChunkPathInput {
 /// Chunk block `i`'s 16-word message: bytes `[64i, 64(i+1))` of the leaf
 /// data as little-endian words, per the BLAKE3 spec.
 fn leaf_msg_words(data: &[u8], block: usize) -> [u32; 16] {
-    std::array::from_fn(|w| {
+    from_fn(|w| {
         let o = block * 64 + 4 * w;
         u32::from_le_bytes(data[o..o + 4].try_into().unwrap())
     })
@@ -2060,8 +2068,8 @@ pub struct MerkleWalkerCircuit {
     const_pin: Option<usize>,
 }
 
-impl std::fmt::Debug for MerkleWalkerCircuit {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Debug for MerkleWalkerCircuit {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let (ba, bb) = self.base.nnz();
         let (xa, xb) = self.extras.nnz();
         f.debug_struct("MerkleWalkerCircuit")
@@ -2246,7 +2254,7 @@ impl MerkleWalkerCircuit {
     }
 }
 
-impl flock_core::lincheck::LincheckCircuit for MerkleWalkerCircuit {
+impl LincheckCircuit for MerkleWalkerCircuit {
     fn n_cols(&self) -> usize {
         self.n_cols
     }
@@ -2272,9 +2280,9 @@ impl flock_core::lincheck::LincheckCircuit for MerkleWalkerCircuit {
 /// factorization is verified before use — so one process can time both and
 /// cancel thermal drift. Same role as `lincheck::FOLD_IBLOCK`.
 fn force_per_level() -> bool {
-    static FORCE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    static FORCE: OnceLock<bool> = OnceLock::new();
     *FORCE.get_or_init(|| {
-        std::env::var("FLOCK_MERKLE_FOLD_PER_LEVEL")
+        var("FLOCK_MERKLE_FOLD_PER_LEVEL")
             .ok()
             .is_some_and(|v| v != "0" && !v.is_empty())
     })

--- a/crates/flock-prover/src/r1cs_hashes/sha2.rs
+++ b/crates/flock-prover/src/r1cs_hashes/sha2.rs
@@ -46,8 +46,29 @@
 //! - `H_out[w]` — the public output of the compression.
 
 use super::common::{BitRecord, add_carry_parts, or_bit_at, or_u32_at_bit};
+use crate::prover::ProvePhaseTimings;
+use crate::prover::prove_fast_ligerito_from_witness;
+use crate::prover::prove_fast_ligerito_timed;
+use crate::prover::prove_ligerito;
+use flock_core::challenger::Challenger;
 use flock_core::field::F128;
+#[cfg(test)]
+use flock_core::lincheck::CscCircuit;
+use flock_core::lincheck::LincheckCircuit;
+use flock_core::pcs::Commitment;
+use flock_core::pcs::PcsParams;
+use flock_core::pcs::ligerito::LigeritoProfile;
+use flock_core::pcs::prefault_codeword_during;
+use flock_core::proof::R1csClaim;
+use flock_core::proof::R1csProofLigerito;
+use flock_core::r1cs::WitnessLayout;
 use flock_core::r1cs::{BlockR1cs, SparseBinaryMatrix};
+use flock_core::scratch::prewarm_prover;
+use flock_core::union::SlotWitnessDest;
+use flock_core::verifier::VerifyError;
+use flock_core::verifier::verify_ligerito;
+use std::array::from_fn;
+use std::time::Instant;
 
 // ───────────────────────────────────────────────────────────────────────────
 // Compile-time slot layout
@@ -609,9 +630,7 @@ pub fn build_block_witness(h_in: &[u32; 8], m: &[u32; 16]) -> Vec<bool> {
 
 /// Read the 8-word post-compression hash out of a single block of witness.
 pub fn read_h_out(z: &[bool]) -> [u32; 8] {
-    std::array::from_fn(|w| {
-        (0..WORD_BITS).fold(0u32, |acc, b| acc | ((z[h_out_bit(w, b)] as u32) << b))
-    })
+    from_fn(|w| (0..WORD_BITS).fold(0u32, |acc, b| acc | ((z[h_out_bit(w, b)] as u32) << b)))
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -707,7 +726,7 @@ fn scatter_add32_alloc<F1: Fn(usize) -> usize, F2: Fn(usize) -> usize>(
 
 pub struct Sha2LincheckCircuit;
 
-impl flock_core::lincheck::LincheckCircuit for Sha2LincheckCircuit {
+impl LincheckCircuit for Sha2LincheckCircuit {
     fn n_cols(&self) -> usize {
         K
     }
@@ -959,9 +978,10 @@ fn add_inline_ab(
     b: &mut [u64],
     carry_base: usize,
 ) -> u32 {
+    const MASK_LO31: u32 = 0x7FFF_FFFF;
     let sum_word: u32 = x.wrapping_add(y);
     let cin: u32 = sum_word ^ x ^ y;
-    const MASK_LO31: u32 = 0x7FFF_FFFF;
+
     let left = (x ^ cin) & MASK_LO31;
     let right = (y ^ cin) & MASK_LO31;
     let carry_aux = left & right;
@@ -1000,6 +1020,9 @@ fn build_block_ab_packed_into(
     a: &mut [u64],
     b: &mut [u64],
 ) {
+    const SC0: usize = 0;
+    const SC1: usize = CARRIES_PER_ADD;
+    const SC2: usize = 2 * CARRIES_PER_ADD;
     const U64_PER_BLOCK: usize = K / 64;
     debug_assert_eq!(z.len(), U64_PER_BLOCK);
     debug_assert_eq!(a.len(), U64_PER_BLOCK);
@@ -1032,9 +1055,7 @@ fn build_block_ab_packed_into(
     // [`BitRecord`]).
     let mut w_sched = [0u32; 64];
     w_sched[..16].copy_from_slice(m);
-    const SC0: usize = 0;
-    const SC1: usize = CARRIES_PER_ADD;
-    const SC2: usize = 2 * CARRIES_PER_ADD;
+
     for t in 16..64 {
         let mut rz = BitRecord::<2>::new();
         let mut ra = BitRecord::<2>::new();
@@ -1080,6 +1101,15 @@ fn build_block_ab_packed_into(
         mut hh,
     ] = *h_in;
     for r in 0..N_ROUNDS {
+        // The 7 × 31-bit round carries are contiguous (217 bits at stride
+        // 217) — composed in a register record and flushed once per buffer.
+        const RC0: usize = 0;
+        const RC1: usize = CARRIES_PER_ADD;
+        const RC2: usize = 2 * CARRIES_PER_ADD;
+        const RC3: usize = 3 * CARRIES_PER_ADD;
+        const RC4: usize = 4 * CARRIES_PER_ADD;
+        const RC5: usize = 5 * CARRIES_PER_ADD;
+        const RC6: usize = 6 * CARRIES_PER_ADD;
         // ch_and AND row: (z, a, b) = (ch, e, f⊕g); c == z = ch.
         let f_xor_g = ff ^ gg;
         let ch_and_v = ee & f_xor_g;
@@ -1099,15 +1129,6 @@ fn build_block_ab_packed_into(
         or_u32_at_bit(b, off, c_xor_a);
         let maj_out = maj_and_v ^ aa;
 
-        // The 7 × 31-bit round carries are contiguous (217 bits at stride
-        // 217) — composed in a register record and flushed once per buffer.
-        const RC0: usize = 0;
-        const RC1: usize = CARRIES_PER_ADD;
-        const RC2: usize = 2 * CARRIES_PER_ADD;
-        const RC3: usize = 3 * CARRIES_PER_ADD;
-        const RC4: usize = 4 * CARRIES_PER_ADD;
-        const RC5: usize = 5 * CARRIES_PER_ADD;
-        const RC6: usize = 6 * CARRIES_PER_ADD;
         let mut rz = BitRecord::<4>::new();
         let mut ra = BitRecord::<4>::new();
         let mut rb = BitRecord::<4>::new();
@@ -1185,12 +1206,7 @@ fn build_block_ab_packed_into(
 pub fn generate_witness_with_ab_packed_and_lincheck(
     compressions: &[([u32; 8], [u32; 16])],
     n_blocks_log: usize,
-) -> (
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-    Vec<u8>,
-) {
+) -> (Vec<F128>, Vec<F128>, Vec<F128>, Vec<u8>) {
     // Constant-wire pin (docs/const-wire-pin.md): fill padding blocks with a
     // valid compression (of the all-zero input) so the constant cell is 1 in
     // every block. (The chain forbids padding, so this only affects the
@@ -1245,7 +1261,7 @@ pub fn generate_witness(compressions: &[([u32; 8], [u32; 16])], n_blocks_log: us
 pub struct Sha256HybridSetup {
     pub n_compressions: usize,
     pub r1cs: BlockR1cs,
-    pub pcs_params: flock_core::pcs::PcsParams,
+    pub pcs_params: PcsParams,
 }
 
 impl Sha256HybridSetup {
@@ -1258,7 +1274,7 @@ impl Sha256HybridSetup {
     /// chain/Merkle wrappers still require row-major.
     pub fn new_batch_major(n_compressions: usize) -> Self {
         let mut s = Self::new(n_compressions);
-        s.r1cs.layout = flock_core::r1cs::WitnessLayout::BatchMajor;
+        s.r1cs.layout = WitnessLayout::BatchMajor;
         s
     }
 
@@ -1266,17 +1282,12 @@ impl Sha256HybridSetup {
     fn generate_witness_ab(
         &self,
         compressions: &[([u32; 8], [u32; 16])],
-    ) -> (
-        Vec<flock_core::field::F128>,
-        Vec<flock_core::field::F128>,
-        Vec<flock_core::field::F128>,
-        Vec<u8>,
-    ) {
+    ) -> (Vec<F128>, Vec<F128>, Vec<F128>, Vec<u8>) {
         match self.r1cs.layout {
-            flock_core::r1cs::WitnessLayout::RowMajor => {
+            WitnessLayout::RowMajor => {
                 generate_witness_with_ab_packed_and_lincheck(compressions, self.n_blocks_log())
             }
-            flock_core::r1cs::WitnessLayout::BatchMajor => {
+            WitnessLayout::BatchMajor => {
                 generate_witness_batch_major(compressions, self.n_blocks_log())
             }
         }
@@ -1285,25 +1296,22 @@ impl Sha256HybridSetup {
     pub fn with_log_inv_rate(n_compressions: usize, log_inv_rate: usize) -> Self {
         // Rate keys the legacy profiles: 1 -> Fast, 2 -> Slim.
         let profile = match log_inv_rate {
-            1 => flock_core::pcs::ligerito::LigeritoProfile::Fast,
-            2 => flock_core::pcs::ligerito::LigeritoProfile::Slim,
-            _ => flock_core::pcs::ligerito::LigeritoProfile::Fast, // other rates default to Fast
+            1 => LigeritoProfile::Fast,
+            2 => LigeritoProfile::Slim,
+            _ => LigeritoProfile::Fast, // other rates default to Fast
         };
         Self::with_profile_and_rate(n_compressions, profile, log_inv_rate)
     }
 
     /// Build a setup for a named Ligerito profile (fast/slim/secure);
     /// the PCS rate follows the profile.
-    pub fn with_profile(
-        n_compressions: usize,
-        profile: flock_core::pcs::ligerito::LigeritoProfile,
-    ) -> Self {
+    pub fn with_profile(n_compressions: usize, profile: LigeritoProfile) -> Self {
         Self::with_profile_and_rate(n_compressions, profile, profile.log_inv_rate())
     }
 
     fn with_profile_and_rate(
         n_compressions: usize,
-        profile: flock_core::pcs::ligerito::LigeritoProfile,
+        profile: LigeritoProfile,
         log_inv_rate: usize,
     ) -> Self {
         assert!(n_compressions >= 1, "n_compressions must be ≥ 1");
@@ -1313,8 +1321,8 @@ impl Sha256HybridSetup {
         // first prove/verify, and pre-fault the prove-cycle scratch buffers
         // so even the first prove performs no page faults.
         r1cs.csc_lincheck_circuit();
-        flock_core::scratch::prewarm_prover(r1cs.m);
-        let pcs_params = flock_core::pcs::PcsParams {
+        prewarm_prover(r1cs.m);
+        let pcs_params = PcsParams {
             m: r1cs.m,
             log_inv_rate,
             log_batch_size: 6,
@@ -1348,10 +1356,7 @@ impl Sha256HybridSetup {
     /// per-circuit code they need. Implemented by reusing the fused builder
     /// (its a/b outputs are discarded): no separate packed-trace writer to
     /// maintain, and ~5× cheaper than the bool trace → `pack_witness` path.
-    pub fn generate_witness_packed(
-        &self,
-        compressions: &[([u32; 8], [u32; 16])],
-    ) -> Vec<flock_core::field::F128> {
+    pub fn generate_witness_packed(&self, compressions: &[([u32; 8], [u32; 16])]) -> Vec<F128> {
         let (z_packed, _a, _b, _stripe) = self.generate_witness_ab(compressions);
         z_packed
     }
@@ -1359,40 +1364,30 @@ impl Sha256HybridSetup {
     /// Generic (matrix-driven) prover. Same witness path (bool trace →
     /// pack) as the fused [`Self::prove_fast`]; produces a byte-identical
     /// proof, verifiable with [`Self::verify`].
-    pub fn prove_ligerito<Ch: flock_core::challenger::Challenger>(
+    pub fn prove_ligerito<Ch: Challenger>(
         &self,
         compressions: &[([u32; 8], [u32; 16])],
         challenger: &mut Ch,
-    ) -> (
-        flock_core::proof::R1csProofLigerito,
-        flock_core::pcs::Commitment,
-        flock_core::proof::R1csClaim,
-    ) {
+    ) -> (R1csProofLigerito, Commitment, R1csClaim) {
         let z_packed = self.generate_witness_packed(compressions);
-        crate::prover::prove_ligerito(&self.r1cs, z_packed, &self.pcs_params, challenger)
+        prove_ligerito(&self.r1cs, z_packed, &self.pcs_params, challenger)
     }
 
     /// Fast prover: skips `pack_witness`, `apply_{a,b,c}_packed`, and
     /// `pack_z_lincheck_from_packed` by emitting `(z, a, b, c, z_lincheck)`
     /// directly via the fused witness builder. Requires m ≥ ~21 (Ligerito).
-    pub fn prove_fast<Ch: flock_core::challenger::Challenger>(
+    pub fn prove_fast<Ch: Challenger>(
         &self,
         compressions: &[([u32; 8], [u32; 16])],
         challenger: &mut Ch,
-    ) -> (
-        flock_core::proof::R1csProofLigerito,
-        flock_core::pcs::Commitment,
-        flock_core::proof::R1csClaim,
-    ) {
+    ) -> (R1csProofLigerito, Commitment, R1csClaim) {
         assert_eq!(compressions.len(), self.n_compressions);
         // Pre-fault the commit codeword buffer on a background (E-core) thread
         // while witness generation runs on the perf cores; gated so
         // RAYON_NUM_THREADS=1 stays truly serial (no extra thread).
         let (codeword, (z_packed, a_packed_f128, b_packed_f128, z_packed_lincheck)) =
-            flock_core::pcs::prefault_codeword_during(&self.pcs_params, || {
-                self.generate_witness_ab(compressions)
-            });
-        crate::prover::prove_fast_ligerito_from_witness(
+            prefault_codeword_during(&self.pcs_params, || self.generate_witness_ab(compressions));
+        prove_fast_ligerito_from_witness(
             &self.r1cs,
             &self.pcs_params,
             z_packed,
@@ -1408,23 +1403,18 @@ impl Sha256HybridSetup {
     /// [`Self::prove_fast`] with a per-phase timing breakdown of the real
     /// Ligerito prover (witness gen + commit + zerocheck + lincheck + recursive
     /// open). Benchmark-only.
-    pub fn prove_fast_timed<Ch: flock_core::challenger::Challenger>(
+    pub fn prove_fast_timed<Ch: Challenger>(
         &self,
         compressions: &[([u32; 8], [u32; 16])],
         challenger: &mut Ch,
-    ) -> (
-        flock_core::proof::R1csProofLigerito,
-        flock_core::pcs::Commitment,
-        flock_core::proof::R1csClaim,
-        crate::prover::ProvePhaseTimings,
-    ) {
+    ) -> (R1csProofLigerito, Commitment, R1csClaim, ProvePhaseTimings) {
         assert_eq!(compressions.len(), self.n_compressions);
-        let t0 = std::time::Instant::now();
+        let t0 = Instant::now();
         let (z_packed, a_packed_f128, b_packed_f128, z_packed_lincheck) =
             self.generate_witness_ab(compressions);
         let witness_s = t0.elapsed().as_secs_f64();
         let lc_circuit = self.r1cs.csc_lincheck_circuit();
-        let (proof, commitment, claim, mut timings) = crate::prover::prove_fast_ligerito_timed(
+        let (proof, commitment, claim, mut timings) = prove_fast_ligerito_timed(
             &self.r1cs,
             &self.pcs_params,
             z_packed,
@@ -1439,13 +1429,13 @@ impl Sha256HybridSetup {
         (proof, commitment, claim, timings)
     }
 
-    pub fn verify<Ch: flock_core::challenger::Challenger>(
+    pub fn verify<Ch: Challenger>(
         &self,
-        commitment: &flock_core::pcs::Commitment,
-        proof: &flock_core::proof::R1csProofLigerito,
+        commitment: &Commitment,
+        proof: &R1csProofLigerito,
         challenger: &mut Ch,
-    ) -> Result<flock_core::proof::R1csClaim, flock_core::verifier::VerifyError> {
-        flock_core::verifier::verify_ligerito(
+    ) -> Result<R1csClaim, VerifyError> {
+        verify_ligerito(
             &self.r1cs,
             commitment,
             proof,
@@ -1555,14 +1545,11 @@ impl Sha256HybridSetup {
     /// The prover is **given the full sequence** of `Compression`s (one per
     /// instance) so trace-gen is parallel; for an honest chain the caller sets
     /// `blocks[i+1].0 = sha256_compress(&blocks[i].0, &blocks[i].1)`.
-    pub fn prove_chain<Ch: flock_core::challenger::Challenger>(
+    pub fn prove_chain<Ch: Challenger>(
         &self,
         compressions: &[Compression],
         challenger: &mut Ch,
-    ) -> (
-        super::chain_common::ChainProofLigerito,
-        flock_core::pcs::Commitment,
-    ) {
+    ) -> (super::chain_common::ChainProofLigerito, Commitment) {
         assert_eq!(compressions.len(), self.n_compressions);
         // The chain shift sumcheck enforces the relation across ALL witness
         // slots, including padding — require an exact fit.
@@ -1589,9 +1576,9 @@ impl Sha256HybridSetup {
         )
     }
 
-    pub fn verify_chain<Ch: flock_core::challenger::Challenger>(
+    pub fn verify_chain<Ch: Challenger>(
         &self,
-        commitment: &flock_core::pcs::Commitment,
+        commitment: &Commitment,
         proof: &super::chain_common::ChainProofLigerito,
         cv_0: &[u32; 8],
         cv_last: &[u32; 8],
@@ -1660,12 +1647,12 @@ impl Sha256HybridSetup {
     /// `compressions[i-1].1[H_out]` (i.e. the previous compression's digest,
     /// byte-equivalent). Requires a registered Ligerito security config for
     /// this `m` (m ≥ 22).
-    pub fn prove_merkle_path_ligerito<Ch: flock_core::challenger::Challenger>(
+    pub fn prove_merkle_path_ligerito<Ch: Challenger>(
         &self,
         compressions: &[Compression],
         b_bits: &[bool],
         challenger: &mut Ch,
-    ) -> (MerklePathProofLigerito, flock_core::pcs::Commitment) {
+    ) -> (MerklePathProofLigerito, Commitment) {
         assert_eq!(compressions.len(), self.n_compressions);
         assert_eq!(
             self.n_compressions,
@@ -1698,9 +1685,9 @@ impl Sha256HybridSetup {
     }
 
     /// Ligerito-backend mirror of [`Self::verify_merkle_path`].
-    pub fn verify_merkle_path_ligerito<Ch: flock_core::challenger::Challenger>(
+    pub fn verify_merkle_path_ligerito<Ch: Challenger>(
         &self,
-        commitment: &flock_core::pcs::Commitment,
+        commitment: &Commitment,
         proof: &MerklePathProofLigerito,
         leaf: &[u32; 8],
         root: &[u32; 8],
@@ -1738,13 +1725,13 @@ impl Sha256HybridSetup {
     }
 
     /// Ligerito-backend mirror of [`Self::prove_merkle_paths`].
-    pub fn prove_merkle_paths_ligerito<Ch: flock_core::challenger::Challenger>(
+    pub fn prove_merkle_paths_ligerito<Ch: Challenger>(
         &self,
         path_log: usize,
         compressions: &[Compression],
         b_bits: &[bool],
         challenger: &mut Ch,
-    ) -> (MerklePathProofLigerito, flock_core::pcs::Commitment) {
+    ) -> (MerklePathProofLigerito, Commitment) {
         assert_eq!(compressions.len(), self.n_compressions);
         assert_eq!(
             self.n_compressions,
@@ -1783,10 +1770,10 @@ impl Sha256HybridSetup {
     }
 
     /// Ligerito-backend mirror of [`Self::verify_merkle_paths`].
-    pub fn verify_merkle_paths_ligerito<Ch: flock_core::challenger::Challenger>(
+    pub fn verify_merkle_paths_ligerito<Ch: Challenger>(
         &self,
         path_log: usize,
-        commitment: &flock_core::pcs::Commitment,
+        commitment: &Commitment,
         proof: &MerklePathProofLigerito,
         leaves: &[[u32; 8]],
         root: &[u32; 8],
@@ -1845,15 +1832,15 @@ use super::common::{BM_V, BmRow, add_carry_parts_v, or_bit_row, or_u32_row};
 
 #[inline(always)]
 fn map_v(x: &[u32; BM_V], f: impl Fn(u32) -> u32) -> [u32; BM_V] {
-    std::array::from_fn(|j| f(x[j]))
+    from_fn(|j| f(x[j]))
 }
 #[inline(always)]
 fn xor_v(x: &[u32; BM_V], y: &[u32; BM_V]) -> [u32; BM_V] {
-    std::array::from_fn(|j| x[j] ^ y[j])
+    from_fn(|j| x[j] ^ y[j])
 }
 #[inline(always)]
 fn and_v(x: &[u32; BM_V], y: &[u32; BM_V]) -> [u32; BM_V] {
-    std::array::from_fn(|j| x[j] & y[j])
+    from_fn(|j| x[j] & y[j])
 }
 
 struct BmRows<'a> {
@@ -1899,8 +1886,8 @@ fn build_group_batch_major(
         a: ra,
         b: rb,
     };
-    let h_in: [[u32; BM_V]; 8] = std::array::from_fn(|w| std::array::from_fn(|j| inputs[j].0[w]));
-    let m: [[u32; BM_V]; 16] = std::array::from_fn(|i| std::array::from_fn(|j| inputs[j].1[i]));
+    let h_in: [[u32; BM_V]; 8] = from_fn(|w| from_fn(|j| inputs[j].0[w]));
+    let m: [[u32; BM_V]; 16] = from_fn(|i| from_fn(|j| inputs[j].1[i]));
 
     or_bit_row(rows.z, Z_CONST_POS);
     or_bit_row(rows.a, Z_CONST_POS);
@@ -2006,12 +1993,7 @@ fn build_group_batch_major(
 pub fn generate_witness_batch_major(
     compressions: &[([u32; 8], [u32; 16])],
     n_blocks_log: usize,
-) -> (
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-    Vec<u8>,
-) {
+) -> (Vec<F128>, Vec<F128>, Vec<F128>, Vec<u8>) {
     let padding: ([u32; 8], [u32; 16]) = ([0u32; 8], [0u32; 16]);
     super::common::drive_witness_batch_major(
         compressions,
@@ -2032,12 +2014,7 @@ pub fn generate_witness_batch_major(
 pub fn generate_witness_batch_major_partial(
     compressions: &[([u32; 8], [u32; 16])],
     n_blocks_log: usize,
-) -> (
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-    Vec<flock_core::field::F128>,
-    Vec<u8>,
-) {
+) -> (Vec<F128>, Vec<F128>, Vec<F128>, Vec<u8>) {
     super::common::drive_witness_batch_major_partial(
         compressions,
         n_blocks_log,
@@ -2053,7 +2030,7 @@ pub fn generate_witness_batch_major_partial(
 pub fn generate_witness_batch_major_into(
     compressions: &[([u32; 8], [u32; 16])],
     n_blocks_log: usize,
-    dst: flock_core::union::SlotWitnessDest<'_>,
+    dst: SlotWitnessDest<'_>,
 ) -> Vec<u8> {
     let padding: ([u32; 8], [u32; 16]) = ([0u32; 8], [0u32; 16]);
     super::common::drive_witness_batch_major_into(
@@ -2072,7 +2049,7 @@ pub fn generate_witness_batch_major_into(
 pub fn generate_witness_batch_major_partial_into(
     compressions: &[([u32; 8], [u32; 16])],
     n_blocks_log: usize,
-    dst: flock_core::union::SlotWitnessDest<'_>,
+    dst: SlotWitnessDest<'_>,
 ) -> Vec<u8> {
     super::common::drive_witness_batch_major_partial_into(
         compressions,
@@ -2102,7 +2079,7 @@ mod tests {
             (z ^ (z >> 31)) as u32
         }
         fn next_block(&mut self) -> [u32; 16] {
-            std::array::from_fn(|_| self.next_u32())
+            from_fn(|_| self.next_u32())
         }
     }
 
@@ -2113,7 +2090,7 @@ mod tests {
         for (n_inputs, n_log) in [(8usize, 3usize), (11, 4)] {
             let mut rng = Rng::new(0xBA7C_5A + n_log as u64);
             let inputs: Vec<([u32; 8], [u32; 16])> = (0..n_inputs)
-                .map(|_| (std::array::from_fn(|_| rng.next_u32()), rng.next_block()))
+                .map(|_| (from_fn(|_| rng.next_u32()), rng.next_block()))
                 .collect();
 
             let (z_r, a_r, b_r, stripe_r) =
@@ -2123,8 +2100,8 @@ mod tests {
             assert_eq!(stripe_b, stripe_r, "stripe diverged (n_log={n_log})");
 
             let chunks_per_block = K / 128;
-            let transpose = |row: &[flock_core::field::F128]| {
-                let mut out = vec![flock_core::field::F128::ZERO; row.len()];
+            let transpose = |row: &[F128]| {
+                let mut out = vec![F128::ZERO; row.len()];
                 for o in 0..1usize << n_log {
                     for c in 0..chunks_per_block {
                         out[(c << n_log) + o] = row[o * chunks_per_block + c];
@@ -2153,7 +2130,7 @@ mod tests {
         let m = K_LOG + n_log;
         let mut rng = Rng::new(0xBA7C_5427);
         let inputs: Vec<([u32; 8], [u32; 16])> = (0..n_total)
-            .map(|_| (std::array::from_fn(|_| rng.next_u32()), rng.next_block()))
+            .map(|_| (from_fn(|_| rng.next_u32()), rng.next_block()))
             .collect();
         let (z_f, a_f, b_f, _) = generate_witness_batch_major(&inputs, n_log);
 
@@ -2205,7 +2182,7 @@ mod tests {
         let setup = Sha256HybridSetup::new_batch_major(128);
         let mut rng = Rng::new(0xBA7C_F012);
         let inputs: Vec<([u32; 8], [u32; 16])> = (0..128)
-            .map(|_| (std::array::from_fn(|_| rng.next_u32()), rng.next_block()))
+            .map(|_| (from_fn(|_| rng.next_u32()), rng.next_block()))
             .collect();
 
         let mut ch_p = FsChallenger::new(b"flock-lig-batch-major-v0");
@@ -2292,7 +2269,7 @@ mod tests {
                 ],
             ),
             (SHA256_IV, rng.next_block()),
-            (std::array::from_fn(|_| rng.next_u32()), rng.next_block()),
+            (from_fn(|_| rng.next_u32()), rng.next_block()),
         ];
         for (h_in, m) in cases {
             let z = build_block_witness(&h_in, &m);
@@ -2342,7 +2319,7 @@ mod tests {
         }
 
         // CSC gather (what prove_fast/verify actually use) matches too.
-        let csc = flock_core::lincheck::CscCircuit::from_matrices(&a_0, &b_0);
+        let csc = CscCircuit::from_matrices(&a_0, &b_0);
         let got_csc = csc.fold_alpha_batched(alpha, &eq_inner);
         assert_eq!(expected, got_csc, "CSC fold mismatch");
     }
@@ -2377,12 +2354,7 @@ mod tests {
         let setup = Sha256HybridSetup::new(n);
         let mut rng = Rng::new(0x5A2_63112);
         let comps: Vec<Compression> = (0..n)
-            .map(|_| {
-                (
-                    std::array::from_fn(|_| rng.next_u32()),
-                    std::array::from_fn(|_| rng.next_u32()),
-                )
-            })
+            .map(|_| (from_fn(|_| rng.next_u32()), from_fn(|_| rng.next_u32())))
             .collect();
         let mut ch_f = FsChallenger::new(b"flock-sha2-gvf");
         let (proof_f, commit_f, claim_f) = setup.prove_fast(&comps, &mut ch_f);
@@ -2431,16 +2403,13 @@ mod tests {
         let zeros: Vec<([u32; 8], [u32; 16])> = vec![([0u32; 8], [0u32; 16]); n];
         let (mut z, mut a, mut b, mut zlc) =
             generate_witness_with_ab_packed_and_lincheck(&zeros, setup.n_blocks_log());
-        z.iter_mut()
-            .for_each(|v| *v = flock_core::field::F128::ZERO);
-        a.iter_mut()
-            .for_each(|v| *v = flock_core::field::F128::ZERO);
-        b.iter_mut()
-            .for_each(|v| *v = flock_core::field::F128::ZERO);
+        z.iter_mut().for_each(|v| *v = F128::ZERO);
+        a.iter_mut().for_each(|v| *v = F128::ZERO);
+        b.iter_mut().for_each(|v| *v = F128::ZERO);
         zlc.iter_mut().for_each(|v| *v = 0);
         let circuit = setup.r1cs.csc_lincheck_circuit();
         let mut ch_p = FsChallenger::new(b"poc");
-        let (proof, commit, _) = crate::prover::prove_fast_ligerito_from_witness(
+        let (proof, commit, _) = prove_fast_ligerito_from_witness(
             &setup.r1cs,
             &setup.pcs_params,
             z,
@@ -2454,7 +2423,7 @@ mod tests {
         let mut ch_v = FsChallenger::new(b"poc");
         let res = setup.verify(&commit, &proof, &mut ch_v);
         assert!(
-            matches!(res, Err(flock_core::verifier::VerifyError::Lincheck(_))),
+            matches!(res, Err(VerifyError::Lincheck(_))),
             "all-zero witness must be rejected by the constant-wire pin; got {res:?}"
         );
     }
@@ -2490,7 +2459,7 @@ mod tests {
     /// Returns `(blocks, cv_0, cv_last)`.
     fn honest_chain(n: usize, seed: u64) -> (Vec<Compression>, [u32; 8], [u32; 8]) {
         let mut rng = Rng::new(seed);
-        let mut cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
+        let mut cv: [u32; 8] = from_fn(|_| rng.next_u32());
         let cv0 = cv;
         let mut blocks = Vec::with_capacity(n);
         for _ in 0..n {
@@ -2558,7 +2527,7 @@ mod tests {
         seed: u64,
     ) -> (Vec<Compression>, [u32; 8], [u32; 8], Vec<bool>) {
         let mut rng = Rng::new(seed);
-        let leaf: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
+        let leaf: [u32; 8] = from_fn(|_| rng.next_u32());
         let mut b_bits = vec![false; n];
         for bit in b_bits.iter_mut().skip(1) {
             *bit = rng.next_u32() & 1 == 1;
@@ -2566,7 +2535,7 @@ mod tests {
         let mut blocks = Vec::with_capacity(n);
         let mut current = leaf;
         for i in 0..n {
-            let sibling: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
+            let sibling: [u32; 8] = from_fn(|_| rng.next_u32());
             let m: [u32; 16] = if !b_bits[i] {
                 // selected = left half of M = current; unselected = sibling
                 let mut m = [0u32; 16];

--- a/crates/flock-prover/tests/circuit_assist.rs
+++ b/crates/flock-prover/tests/circuit_assist.rs
@@ -15,6 +15,7 @@
 //! from the verifier it transcribes.
 
 use flock_core::circuit::builder::{GateType, ShapeBuilder, SlotWitness};
+use flock_core::element_r1cs::ElementTableType;
 use flock_core::field::F128;
 use flock_core::pcs::PcsParams;
 use flock_core::pcs::jagged::{STATE_INITIAL, STATE_SUCCESS, assist_sparse_transitions};
@@ -23,7 +24,9 @@ use flock_core::schedule::IoWord;
 use flock_core::verifier;
 use flock_prover::challenger::FsChallenger;
 use flock_prover::prover::{self, UnionElementSlotInput};
+use flock_prover::schedule::TableType;
 use flock_prover::union::UnionInstance;
+use std::sync::Arc;
 
 const DOMAIN: &[u8] = b"flock-circuit-assist-v0";
 
@@ -66,7 +69,7 @@ fn pb(z: &[F128], layer: usize) -> F128 {
 /// 53 columns — kappa 6. The sparse table is baked from
 /// [`assist_sparse_transitions`] at construction.
 struct AssistLayerGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
 }
 
 const AL_IN: usize = 9; // g0..g3, za, rb, rc, rd, one
@@ -117,16 +120,11 @@ impl AssistLayerGate {
         for s in 0..4 {
             b.linear(
                 AL_OUT0 + s,
-                &[
-                    (33 + s, one),
-                    (37 + s, one),
-                    (41 + s, one),
-                    (45 + s, one),
-                ],
+                &[(33 + s, one), (37 + s, one), (41 + s, one), (45 + s, one)],
             );
         }
         Self {
-            ty: std::sync::Arc::new(b.build().expect("assist layer gate is valid")),
+            ty: Arc::new(b.build().expect("assist layer gate is valid")),
         }
     }
 }
@@ -135,12 +133,12 @@ impl GateType for AssistLayerGate {
     type Row = Vec<F128>;
     type Hint = ();
 
-    fn table(&self) -> flock_prover::schedule::TableType {
+    fn table(&self) -> TableType {
         let mut schema: Vec<IoWord> = (0..AL_IN).map(IoWord::input).collect();
         for s in 0..4 {
             schema.push(IoWord::output(AL_OUT0 + s));
         }
-        flock_prover::schedule::TableType::element(self.ty.clone()).with_io_schema(schema)
+        TableType::element(self.ty.clone()).with_io_schema(schema)
     }
 
     fn eval(&self, inputs: &[F128], _hint: &()) -> (Vec<F128>, Self::Row) {
@@ -242,7 +240,12 @@ fn assist_layer_gate_chains_match_the_native_dp() {
         g[STATE_SUCCESS] = ow;
         for layer in (0..=m).rev() {
             let mut a_in = g.to_vec();
-            for v in [pb(zr, layer), pb(rho, layer), sigma[2 * layer], sigma[2 * layer + 1]] {
+            for v in [
+                pb(zr, layer),
+                pb(rho, layer),
+                sigma[2 * layer],
+                sigma[2 * layer + 1],
+            ] {
                 vals.push(v);
                 a_in.push(sb.public_input());
             }

--- a/crates/flock-prover/tests/circuit_builder.rs
+++ b/crates/flock-prover/tests/circuit_builder.rs
@@ -21,6 +21,7 @@
 //! work, so validating the SHA path would validate one we do not use.
 
 use flock_core::circuit::builder::{CircuitBuilder, GateType, SlotWitness, Wire};
+use flock_core::element_r1cs::ElementTableType;
 use flock_core::field::F128;
 use flock_core::hash::HashKind;
 use flock_core::pcs::PcsParams;
@@ -28,9 +29,14 @@ use flock_core::pcs::ligerito::LigeritoProfile;
 use flock_prover::challenger::FsChallenger;
 use flock_prover::prover::{self, UnionSlotProverInput};
 use flock_prover::r1cs_hashes::blake3;
+use flock_prover::r1cs_hashes::fs_chain::IV as FS_CHAIN_IV;
 use flock_prover::schedule::TableType;
 use flock_prover::union::UnionInstance;
 use flock_prover::verifier;
+use std::array::from_fn;
+use std::iter::once;
+use std::sync::Arc;
+use std::time::Instant;
 
 const DOMAIN: &[u8] = b"flock-circuit-builder-v0";
 
@@ -152,9 +158,7 @@ fn blake3_chunk_chain_through_the_builder() {
     let n_blocks = 16usize; // one 1 KiB chunk
     let mut rng = Rng(0xB1A3_0001);
 
-    let messages: Vec<[u32; 16]> = (0..n_blocks)
-        .map(|_| std::array::from_fn(|_| rng.next_u32()))
-        .collect();
+    let messages: Vec<[u32; 16]> = (0..n_blocks).map(|_| from_fn(|_| rng.next_u32())).collect();
 
     let mut b = CircuitBuilder::new(nu);
     let g = b.slot(Blake3Gate { nu });
@@ -318,7 +322,7 @@ fn fs_chain_circuit_derives_the_challenges() {
     let c2 = ch.sample_f128();
     let shape = ch.shape();
 
-    let values: Vec<F128> = std::iter::once(scalars[0])
+    let values: Vec<F128> = once(scalars[0])
         .chain(slice.iter().copied())
         .chain([scalars[1], scalars[2]])
         .collect();
@@ -367,7 +371,7 @@ fn fs_chain_circuit_derives_the_challenges() {
     // ---- build the circuit ----
     let mut b = CircuitBuilder::new(nu);
     let g = b.slot(Blake3Gate { nu });
-    let iv_w = pack8(&flock_prover::r1cs_hashes::fs_chain::IV);
+    let iv_w = pack8(&FS_CHAIN_IV);
     let iv = [b.public_value(iv_w[0]), b.public_value(iv_w[1])];
 
     // Stream words become public cells, EXCEPT squeezed ones, which are wired
@@ -525,12 +529,12 @@ fn fs_chain_circuit_derives_the_challenges() {
 #[test]
 #[ignore] // Heavy — run with `-- --ignored`.
 fn mvp_fs_chain_of_a_real_proof() {
+    use Arc;
     use flock_core::element_r1cs::{ElementTableBuilder, ElementTableType};
     use flock_core::transcript_record::{RecordingChallenger, TranscriptOp};
     use flock_prover::prover::UnionElementSlotInput;
     use flock_prover::r1cs_hashes::fs_chain::{CvSource, FsChain};
     use flock_prover::schedule::Registry;
-    use std::sync::Arc;
 
     const INNER: &[u8] = b"flock-union-element-v0";
     let (inner_nu, kappa, count) = (12usize, 3usize, 1usize << 12);
@@ -639,7 +643,7 @@ fn mvp_fs_chain_of_a_real_proof() {
     let nu = (trace.rows.len().next_power_of_two().trailing_zeros() as usize).max(1);
     let mut b = CircuitBuilder::new(nu);
     let g = b.slot(Blake3Gate { nu });
-    let iv_w = pack8(&flock_prover::r1cs_hashes::fs_chain::IV);
+    let iv_w = pack8(&FS_CHAIN_IV);
     let iv = [b.public_value(iv_w[0]), b.public_value(iv_w[1])];
     let mut word_wire: Vec<Option<Wire>> = vec![None; stream.words.len()];
     let mut outs: Vec<Vec<Wire>> = Vec::with_capacity(trace.rows.len());
@@ -724,7 +728,7 @@ fn mvp_fs_chain_of_a_real_proof() {
     let lc = r1cs.csc_lincheck_circuit();
     let rows = built.rows::<Blake3Gate>(g);
 
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut c = FsChallenger::new(DOMAIN);
     let (proof, commitment, _) = prover::prove_fast_ligerito_union_circuit(
         &outer,
@@ -740,7 +744,7 @@ fn mvp_fs_chain_of_a_real_proof() {
     );
     let prove_ms = t.elapsed().as_secs_f64() * 1e3;
 
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut c = FsChallenger::new(DOMAIN);
     verifier::verify_ligerito_union_circuit(
         &outer,
@@ -788,7 +792,7 @@ fn mvp_fs_chain_of_a_real_proof() {
 /// Every operation the round needs is one call: `x·y` is `(x+0)·(y+0)`,
 /// `(x+y)·z` is direct, and `x+y+z` is the sum output.
 struct ArithGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
 }
 
 impl ArithGate {
@@ -803,7 +807,7 @@ impl ArithGate {
             .mult_lin(4, &[(0, one), (1, one)], &[(2, one), (3, one)])
             .linear(5, &[(0, one), (1, one), (2, one), (3, one)]);
         Self {
-            ty: std::sync::Arc::new(b.build().expect("arith block")),
+            ty: Arc::new(b.build().expect("arith block")),
         }
     }
 }
@@ -911,7 +915,7 @@ fn mvp2_sumcheck_round_consumes_a_derived_challenge() {
     let arith = b.slot(ArithGate::new());
 
     let one = b.public_value(F128::ONE);
-    let iv_w = pack8(&flock_prover::r1cs_hashes::fs_chain::IV);
+    let iv_w = pack8(&FS_CHAIN_IV);
     let iv = [b.public_value(iv_w[0]), b.public_value(iv_w[1])];
     let mut outs: Vec<Vec<Wire>> = Vec::new();
     let mut inputs: Vec<[Wire; 7]> = Vec::new();
@@ -1125,6 +1129,12 @@ fn mvp2_sumcheck_round_consumes_a_derived_challenge() {
 #[test]
 #[ignore] // Heavier — run with `-- --ignored`.
 fn mvp2b_full_element_zerocheck_replayed() {
+    // Phase 2 continues on the SAME transcript — the recorder is a challenger,
+    // so the script just carries on. The round messages here are synthetic (a
+    // standalone lincheck would need the union's comb and g vectors); what is
+    // real is the round algebra and the transcript order.
+    const LC_LABEL: &[u8] = b"flock-element-union-lc-v0";
+    const LC_ROUNDS: usize = 3;
     use flock_core::challenger::Challenger as _;
     use flock_core::element_r1cs::{ElementTableBuilder, zerocheck};
     use flock_core::transcript_record::{RecordingChallenger, StreamWord};
@@ -1167,12 +1177,6 @@ fn mvp2b_full_element_zerocheck_replayed() {
     let mut rec = RecordingChallenger::new(FsChallenger::with_hash(D, HashKind::Blake3));
     zerocheck::verify_with_label(LABEL, m_words, &zc_proof, &mut rec).expect("zerocheck verifies");
 
-    // Phase 2 continues on the SAME transcript — the recorder is a challenger,
-    // so the script just carries on. The round messages here are synthetic (a
-    // standalone lincheck would need the union's comb and g vectors); what is
-    // real is the round algebra and the transcript order.
-    const LC_LABEL: &[u8] = b"flock-element-union-lc-v0";
-    const LC_ROUNDS: usize = 3;
     rec.observe_label(LC_LABEL);
     let alpha_v = rec.sample_f128();
     let lc_msgs: Vec<(F128, F128)> = (0..LC_ROUNDS).map(|_| (f(), f())).collect();
@@ -1215,7 +1219,7 @@ fn mvp2b_full_element_zerocheck_replayed() {
     let arith = b.slot(ArithGate::new());
     let zero = b.public_value(F128::ZERO);
     let one = b.public_value(F128::ONE);
-    let iv_w = pack8(&flock_prover::r1cs_hashes::fs_chain::IV);
+    let iv_w = pack8(&FS_CHAIN_IV);
     let iv = [b.public_value(iv_w[0]), b.public_value(iv_w[1])];
 
     let mut outs: Vec<Vec<Wire>> = Vec::new();
@@ -1418,7 +1422,7 @@ fn mvp2b_full_element_zerocheck_replayed() {
         SlotWitness::Element(z) => z.clone(),
         _ => unreachable!(),
     };
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut c = FsChallenger::new(DOMAIN);
     let (proof, commitment, _) = prover::prove_fast_ligerito_union_circuit(
         &outer,
@@ -1435,7 +1439,7 @@ fn mvp2b_full_element_zerocheck_replayed() {
         &mut c,
     );
     let prove_ms = t.elapsed().as_secs_f64() * 1e3;
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut c = FsChallenger::new(DOMAIN);
     verifier::verify_ligerito_union_circuit(
         &outer,

--- a/crates/flock-prover/tests/circuit_merkle.rs
+++ b/crates/flock-prover/tests/circuit_merkle.rs
@@ -35,20 +35,47 @@
 //! Small shapes where the geometry allows; `l0_shape_circuit_cost` runs the
 //! real one (218 openings, depth 13, 1 KiB leaves).
 
+use flock_core::challenger::pow_has_leading_zero_bits;
+use flock_core::circuit::builder::SlotId;
 use flock_core::circuit::builder::{CircuitBuilder, GateType, ShapeBuilder, SlotWitness, Wire};
+use flock_core::circuit::wire_cells;
+use flock_core::element_r1cs::ElementTableType;
 use flock_core::field::F128;
+use flock_core::lincheck::LincheckCircuit;
+#[cfg(test)]
+use flock_core::lincheck::build_eq_table;
 use flock_core::merkle::{self as core_merkle, HashKind};
 use flock_core::pcs::PcsParams;
+use flock_core::pcs::jagged::JaggedParams;
+use flock_core::pcs::jagged::assist_boundaries;
+use flock_core::pcs::jagged::assist_sparse_transitions;
 use flock_core::pcs::ligerito::LigeritoProfile;
+use flock_core::r1cs::BlockR1cs;
+use flock_core::transcript_record::Stream;
+use flock_core::transcript_record::StreamWord;
+use flock_core::transcript_record::TranscriptOp;
 use flock_core::verifier;
 use flock_prover::challenger::FsChallenger;
 use flock_prover::prover::{self, UnionSlotProverInput};
 use flock_prover::r1cs_hashes::blake3;
+use flock_prover::r1cs_hashes::fs_chain::FsChainTrace;
+use flock_prover::r1cs_hashes::fs_chain::IV as FS_CHAIN_IV;
 use flock_prover::r1cs_hashes::merkle_r1cs::{
     ChunkPathInput, MerkleTreeLayout, SLOT_WORDS, blake3_spec,
 };
+use flock_prover::schedule::Registry;
 use flock_prover::schedule::TableType;
 use flock_prover::union::UnionInstance;
+use std::any::Any;
+use std::array::from_fn;
+use std::env::var;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::fmt::Result;
+use std::hint::black_box;
+use std::iter::repeat_n;
+use std::sync::Arc;
+use std::time::Instant;
 
 const DOMAIN: &[u8] = b"flock-circuit-merkle-v0";
 
@@ -121,7 +148,7 @@ fn digest_words(d: &[u32; SLOT_WORDS]) -> [F128; 2] {
 }
 
 fn hash_to_digest(h: &[u8; 32]) -> [u32; SLOT_WORDS] {
-    std::array::from_fn(|w| u32::from_le_bytes(h[4 * w..4 * w + 4].try_into().unwrap()))
+    from_fn(|w| u32::from_le_bytes(h[4 * w..4 * w + 4].try_into().unwrap()))
 }
 
 struct Rng(u64);
@@ -389,7 +416,7 @@ fn merkle_index_wired_to_a_challenge() {
 
     // One compression over a public message: its `out_lo0` is the challenge.
     let iv = pack8(&IV);
-    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+    let m: [u32; 16] = from_fn(|_| rng.next_u32());
     let mut hash_in = vec![b.public_value(iv[0]), b.public_value(iv[1])];
     for j in 0..4 {
         hash_in.push(b.public_value(pack4(m[4 * j..4 * j + 4].try_into().unwrap())));
@@ -478,11 +505,10 @@ fn merkle_index_wired_to_a_challenge() {
         ),
     ];
     slots.sort_by_key(|(i, _)| *i);
-    let mut lcs: Vec<(usize, &dyn flock_core::lincheck::LincheckCircuit)> =
+    let mut lcs: Vec<(usize, &dyn LincheckCircuit)> =
         vec![(hash_slot, blake_lc), (merkle_slot, &walker)];
     lcs.sort_by_key(|(i, _)| *i);
-    let lcs: Vec<&dyn flock_core::lincheck::LincheckCircuit> =
-        lcs.into_iter().map(|(_, c)| c).collect();
+    let lcs: Vec<&dyn LincheckCircuit> = lcs.into_iter().map(|(_, c)| c).collect();
 
     let mut ch = FsChallenger::new(DOMAIN);
     let (proof, commitment, _) = prover::prove_fast_ligerito_union_circuit(
@@ -558,9 +584,9 @@ fn l0_shape_circuit_cost() {
 
     // How expensive is just materializing the TableType at k_log 19? It
     // carries a 2^19 identity `c_0`, and `finish` handles one per slot.
-    std::hint::black_box(MerklePathGate::new(depth, leaf_bytes, nu, 1 << depth).table());
+    black_box(MerklePathGate::new(depth, leaf_bytes, nu, 1 << depth).table());
     let t = Instant::now(); // second call: the first pays cold-allocator faults
-    std::hint::black_box(MerklePathGate::new(depth, leaf_bytes, nu, 1 << depth).table());
+    black_box(MerklePathGate::new(depth, leaf_bytes, nu, 1 << depth).table());
     let table_ms = t.elapsed().as_secs_f64() * 1e3;
 
     // ---- SETUP: no values, no field arithmetic, paid once ----
@@ -597,10 +623,9 @@ fn l0_shape_circuit_cost() {
         (vals, hints)
     };
     let (vals, hints) = gather();
-    let hint_refs: Vec<&dyn std::any::Any> =
-        hints.iter().map(|h| h as &dyn std::any::Any).collect();
+    let hint_refs: Vec<&dyn Any> = hints.iter().map(|h| h as &dyn Any).collect();
 
-    std::hint::black_box(shape.run(&vals, &hint_refs)); // warm
+    black_box(shape.run(&vals, &hint_refs)); // warm
     let t = Instant::now();
     let built = shape.run(&vals, &hint_refs);
     let online_ms = t.elapsed().as_secs_f64() * 1e3;
@@ -637,7 +662,7 @@ fn l0_shape_circuit_cost() {
     // and came out 20-40% high. `merkle_l0_opening` reports a median after
     // warm-up, so timing a cold single shot against it compares two different
     // statistics. Discard one round, then measure.
-    std::hint::black_box(prove(witgen()));
+    black_box(prove(witgen()));
 
     let t = Instant::now();
     let witness = witgen();
@@ -646,7 +671,7 @@ fn l0_shape_circuit_cost() {
     // How much of `build` is the gate re-executing BLAKE3 natively?
     let t = Instant::now();
     for row in rows {
-        std::hint::black_box(layout.root_chunk(row));
+        black_box(layout.root_chunk(row));
     }
     let eval_ms = t.elapsed().as_secs_f64() * 1e3;
 
@@ -654,7 +679,7 @@ fn l0_shape_circuit_cost() {
     let (proof, commitment, _) = prove(witness);
     let prove_ms = t.elapsed().as_secs_f64() * 1e3;
 
-    let lcs: Vec<&dyn flock_core::lincheck::LincheckCircuit> = vec![&walker];
+    let lcs: Vec<&dyn LincheckCircuit> = vec![&walker];
     // No thread-pool wrapper: `flock_core::verifier` pins its own 1-thread
     // `verifier_pool` around the verify cores, and the bench calls verify on
     // the default pool exactly like this. Wrapping would change the regime,
@@ -801,7 +826,7 @@ fn circuit_structure_does_not_depend_on_the_witness() {
 /// rows that grow to 127 terms at the last level. Left for later on purpose:
 /// this is the MVP.
 struct LeafEvalGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
     lay: LeafLayout,
 }
 
@@ -894,7 +919,7 @@ impl LeafEvalGate {
         b.mult(lay.t, lay.alpha, lay.y());
         b.linear(lay.acc, &[(lay.prev, one), (lay.t, one)]);
         Self {
-            ty: std::sync::Arc::new(b.build().expect("leaf-eval block is valid")),
+            ty: Arc::new(b.build().expect("leaf-eval block is valid")),
             lay,
         }
     }
@@ -959,6 +984,7 @@ impl GateType for LeafEvalGate {
 #[test]
 #[ignore] // Heavier — run with `-- --ignored`.
 fn leaf_arithmetic_joins_the_merkle_openings() {
+    #[cfg(test)]
     use flock_core::lincheck::build_eq_table;
     use flock_prover::prover::UnionElementSlotInput;
 
@@ -1017,8 +1043,7 @@ fn leaf_arithmetic_joins_the_merkle_openings() {
         vals.push(alpha[i]);
         hints.push(tree.siblings(pos));
     }
-    let hint_refs: Vec<&dyn std::any::Any> =
-        hints.iter().map(|h| h as &dyn std::any::Any).collect();
+    let hint_refs: Vec<&dyn Any> = hints.iter().map(|h| h as &dyn Any).collect();
     let built = shape.run(&vals, &hint_refs);
 
     // ---- the join is structural, not incidental ----
@@ -1035,7 +1060,7 @@ fn leaf_arithmetic_joins_the_merkle_openings() {
         iota_base(shape.registry_slot(merkle)),
         iota_base(shape.registry_slot(leafeval)),
     );
-    let joined = flock_core::circuit::wire_cells(&shape.circuit)
+    let joined = wire_cells(&shape.circuit)
         .iter()
         .filter(|cls| {
             let has = |lo: usize| cls.iter().any(|c| (lo..lo + LE_LANES).contains(&c.slot));
@@ -1130,7 +1155,7 @@ fn leaf_arithmetic_joins_the_merkle_openings() {
         &mut ch,
     );
 
-    let lcs: Vec<&dyn flock_core::lincheck::LincheckCircuit> = vec![&walker];
+    let lcs: Vec<&dyn LincheckCircuit> = vec![&walker];
     let mut ch = FsChallenger::new(DOMAIN);
     verifier::verify_ligerito_union_circuit(
         &union,
@@ -1217,6 +1242,7 @@ fn mvp4_l0_shape_cost() {
 
 fn mvp4_slice(depth: usize, n_queries: usize, nu: usize) {
     use flock_core::challenger::Challenger as _;
+    #[cfg(test)]
     use flock_core::lincheck::build_eq_table;
     use flock_core::transcript_record::{RecordingChallenger, TranscriptOp};
     use flock_prover::prover::UnionElementSlotInput;
@@ -1300,7 +1326,7 @@ fn mvp4_slice(depth: usize, n_queries: usize, nu: usize) {
     // index in the public segment — which the tamper check below relies on.
     let mut fs_values: Vec<F128> = Vec::new();
     let mut first_msg_pub: Option<usize> = None;
-    let iv_w = pack8(&flock_prover::r1cs_hashes::fs_chain::IV);
+    let iv_w = pack8(&FS_CHAIN_IV);
     fs_values.extend_from_slice(&iv_w);
 
     for (i, row) in trace.rows.iter().enumerate() {
@@ -1418,9 +1444,8 @@ fn mvp4_slice(depth: usize, n_queries: usize, nu: usize) {
         vals.push(alpha[k]);
         hints.push(tree.siblings(pos));
     }
-    let hint_refs: Vec<&dyn std::any::Any> =
-        hints.iter().map(|h| h as &dyn std::any::Any).collect();
-    std::hint::black_box(shape.run(&vals, &hint_refs)); // warm
+    let hint_refs: Vec<&dyn Any> = hints.iter().map(|h| h as &dyn Any).collect();
+    black_box(shape.run(&vals, &hint_refs)); // warm
     let t = Instant::now();
     let built = shape.run(&vals, &hint_refs);
     let online_ms = t.elapsed().as_secs_f64() * 1e3;
@@ -1441,7 +1466,7 @@ fn mvp4_slice(depth: usize, n_queries: usize, nu: usize) {
             iota(shape.registry_slot(merkle)),
             iota(shape.registry_slot(leafeval)),
         );
-        let classes = flock_core::circuit::wire_cells(&shape.circuit);
+        let classes = wire_cells(&shape.circuit);
         let spans = |lo_a: usize, n_a: usize, lo_b: usize, n_b: usize| {
             classes
                 .iter()
@@ -1546,13 +1571,12 @@ fn mvp4_slice(depth: usize, n_queries: usize, nu: usize) {
         ),
     ];
     bool_slots.sort_by_key(|(i, _)| *i);
-    let mut lcs_ord: Vec<(usize, &dyn flock_core::lincheck::LincheckCircuit)> = vec![
+    let mut lcs_ord: Vec<(usize, &dyn LincheckCircuit)> = vec![
         (shape.registry_slot(merkle), &walker),
         (shape.registry_slot(hash), b3_lc),
     ];
     lcs_ord.sort_by_key(|(i, _)| *i);
-    let lcs: Vec<&dyn flock_core::lincheck::LincheckCircuit> =
-        lcs_ord.into_iter().map(|(_, c)| c).collect();
+    let lcs: Vec<&dyn LincheckCircuit> = lcs_ord.into_iter().map(|(_, c)| c).collect();
 
     let t = Instant::now();
     let mut c = FsChallenger::new(DOMAIN);
@@ -1723,8 +1747,8 @@ struct Timing {
     max: f64,
 }
 
-impl std::fmt::Display for Timing {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for Timing {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{:.0} [{:.0}-{:.0}]", self.median, self.min, self.max)
     }
 }
@@ -1737,7 +1761,7 @@ fn timed<T>(reps: usize, mut f: impl FnMut() -> T) -> (T, Timing) {
     let mut out = f(); // warm-up, discarded
     let mut ms = Vec::with_capacity(reps);
     for _ in 0..reps {
-        let t = std::time::Instant::now();
+        let t = Instant::now();
         out = f();
         ms.push(t.elapsed().as_secs_f64() * 1e3);
     }
@@ -1790,6 +1814,7 @@ struct Level {
 #[ignore] // The full shape. `-- --ignored`.
 fn mvp5_all_levels_query_phase() {
     use flock_core::challenger::Challenger as _;
+    #[cfg(test)]
     use flock_core::lincheck::build_eq_table;
     use flock_core::transcript_record::{RecordingChallenger, TranscriptOp};
     use flock_prover::prover::UnionElementSlotInput;
@@ -1871,7 +1896,7 @@ fn mvp5_all_levels_query_phase() {
         .map(|l| sb.slot(MerklePathGate::new(l.depth, 16 * l.lanes, nu, 1 << l.depth)))
         .collect();
     // One leaf-eval slot per distinct lane count; L1..L3 share.
-    let mut leaf_slot: Vec<(usize, flock_core::circuit::builder::SlotId)> = Vec::new();
+    let mut leaf_slot: Vec<(usize, SlotId)> = Vec::new();
     let leafeval: Vec<_> = levels
         .iter()
         .map(|l| match leaf_slot.iter().find(|(n, _)| *n == l.lanes) {
@@ -1889,7 +1914,7 @@ fn mvp5_all_levels_query_phase() {
     let mut outs: Vec<Vec<Wire>> = Vec::with_capacity(trace.rows.len());
     let mut gate_in: Vec<[Wire; 7]> = Vec::with_capacity(trace.rows.len());
     let mut fs_values: Vec<F128> = Vec::new();
-    let iv_w = pack8(&flock_prover::r1cs_hashes::fs_chain::IV);
+    let iv_w = pack8(&FS_CHAIN_IV);
     fs_values.extend_from_slice(&iv_w);
 
     for (i, row) in trace.rows.iter().enumerate() {
@@ -2020,8 +2045,7 @@ fn mvp5_all_levels_query_phase() {
             hints.push(trees[li].siblings(pos));
         }
     }
-    let hint_refs: Vec<&dyn std::any::Any> =
-        hints.iter().map(|h| h as &dyn std::any::Any).collect();
+    let hint_refs: Vec<&dyn Any> = hints.iter().map(|h| h as &dyn Any).collect();
     let (built, online_t) = timed(REPS, || shape.run(&vals, &hint_refs));
 
     // Every level opened the queries its own squeeze determined, and every
@@ -2102,14 +2126,12 @@ fn mvp5_all_levels_query_phase() {
         })
         .collect();
 
-    let mut lcs_ord: Vec<(usize, &dyn flock_core::lincheck::LincheckCircuit)> =
-        vec![(shape.registry_slot(hash), b3_lc)];
+    let mut lcs_ord: Vec<(usize, &dyn LincheckCircuit)> = vec![(shape.registry_slot(hash), b3_lc)];
     for (li, _) in levels.iter().enumerate() {
         lcs_ord.push((shape.registry_slot(merkle[li]), &walkers[li]));
     }
     lcs_ord.sort_by_key(|(i, _)| *i);
-    let lcs: Vec<&dyn flock_core::lincheck::LincheckCircuit> =
-        lcs_ord.into_iter().map(|(_, c)| c).collect();
+    let lcs: Vec<&dyn LincheckCircuit> = lcs_ord.into_iter().map(|(_, c)| c).collect();
 
     let ((proof, commitment), prove_t) = timed(REPS, || {
         let mut bool_slots: Vec<(usize, UnionSlotProverInput)> = vec![(
@@ -2163,7 +2185,6 @@ fn mvp5_all_levels_query_phase() {
         .expect("the full query phase verifies")
     });
 
-
     // ---- what it cost ----
     let mut nnz_total = 0usize;
     let mut report = String::from("\nMVP-5 FULL QUERY PHASE (m=26 Fast ladder)\n");
@@ -2209,7 +2230,9 @@ fn mvp5_all_levels_query_phase() {
         union.m_bool(),
         union.m_total(),
         bincode::serialize(&proof).map(|b| b.len()).unwrap_or(0) as f64 / 1024.0,
-        bincode::serialize(&proof.pcs_open.frobenius).map(|b| b.len()).unwrap_or(0) as f64
+        bincode::serialize(&proof.pcs_open.frobenius)
+            .map(|b| b.len())
+            .unwrap_or(0) as f64
             / 1024.0,
         proof.pcs_open.merged_rounds.len(),
         shape.circuit.cells().num_gate_slots(),
@@ -2229,10 +2252,10 @@ fn mvp5_all_levels_query_phase() {
 /// block lives inline in `mvp6`; factored here for the real-transcript path.)
 fn emit_fs_chain(
     sb: &mut ShapeBuilder,
-    b3: flock_core::circuit::builder::SlotId,
+    b3: SlotId,
     iv: [Wire; 2],
-    trace: &flock_prover::r1cs_hashes::fs_chain::FsChainTrace,
-    stream: &flock_core::transcript_record::Stream,
+    trace: &FsChainTrace,
+    stream: &Stream,
     bytes: &[u8],
     vals: &mut Vec<F128>,
 ) -> (Vec<Vec<Wire>>, Vec<Option<Wire>>) {
@@ -2316,7 +2339,7 @@ fn emit_fs_chain(
 /// EVAL a held quad (beta = 0; only t' consumed), and INTRO-FOLD an OOD or
 /// enforced-sum claim (consume c', b', a', tr'; t' unwired).
 struct SpineGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
 }
 
 const SP_IN: usize = 9; // c b a tr u0 u2 y beta r
@@ -2346,7 +2369,7 @@ impl SpineGate {
             .mult(m2, r2, ao)
             .linear(to, &[(co, one), (m1, one), (m2, one)]);
         Self {
-            ty: std::sync::Arc::new(bld.build().expect("spine gate is valid")),
+            ty: Arc::new(bld.build().expect("spine gate is valid")),
         }
     }
 }
@@ -2411,7 +2434,7 @@ impl GateType for SpineGate {
 /// (already published) challenge word natively — same pattern as the cap
 /// select.
 struct ResidualGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
     sks_vks: Vec<F128>,
     acc_out: Vec<usize>,
     lmc: usize,
@@ -2505,7 +2528,7 @@ impl ResidualGate {
         }
         assert!(c <= 64, "residual gate spills kappa=6 ({c} cols)");
         Self {
-            ty: std::sync::Arc::new(b.build().expect("residual gate is valid")),
+            ty: Arc::new(b.build().expect("residual gate is valid")),
             sks_vks: sks_vks.to_vec(),
             acc_out,
             lmc,
@@ -2637,7 +2660,7 @@ fn sk_at_vks(log_n: usize) -> Vec<F128> {
 /// PartialCombineGate folds `beta * resid` into the running combined vector;
 /// FinalDotGate dots against the absorbed yr words.
 struct PrefixGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
     pl: usize,
     n_in: usize,
     k: usize,
@@ -2664,7 +2687,7 @@ impl PrefixGate {
         }
         assert!(c <= 64, "prefix gate spills ({c})");
         Self {
-            ty: std::sync::Arc::new(bl.build().expect("prefix gate")),
+            ty: Arc::new(bl.build().expect("prefix gate")),
             pl,
             n_in,
             k: c,
@@ -2707,7 +2730,7 @@ impl GateType for PrefixGate {
 }
 
 struct SuffixGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
     acc_out: Vec<usize>,
     yl: usize,
     n_in: usize,
@@ -2754,7 +2777,7 @@ impl SuffixGate {
         }
         assert!(c <= 64, "suffix gate spills ({c})");
         Self {
-            ty: std::sync::Arc::new(bl.build().expect("suffix gate")),
+            ty: Arc::new(bl.build().expect("suffix gate")),
             acc_out,
             yl,
             n_in,
@@ -2820,7 +2843,7 @@ impl GateType for SuffixGate {
 }
 
 struct PartialCombineGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
     acc_out: Vec<usize>,
     yr: usize,
     n_in: usize,
@@ -2847,7 +2870,7 @@ impl PartialCombineGate {
             c += 1;
         }
         Self {
-            ty: std::sync::Arc::new(bl.build().expect("partial combine")),
+            ty: Arc::new(bl.build().expect("partial combine")),
             acc_out,
             yr,
             n_in,
@@ -2894,7 +2917,7 @@ impl GateType for PartialCombineGate {
 }
 
 struct FinalDotGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
     yr: usize,
     n_in: usize,
     k: usize,
@@ -2920,7 +2943,7 @@ impl FinalDotGate {
         bl.linear(c, &terms);
         c += 1;
         Self {
-            ty: std::sync::Arc::new(bl.build().expect("final dot")),
+            ty: Arc::new(bl.build().expect("final dot")),
             yr,
             n_in,
             k: c,
@@ -2967,7 +2990,7 @@ impl GateType for FinalDotGate {
 /// from the absorbed stream, `r` from the chain squeeze; the chain of these
 /// binds rho and carries the outer gamma-combination down to `running`.
 struct MergedRoundGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
 }
 
 impl MergedRoundGate {
@@ -2984,7 +3007,7 @@ impl MergedRoundGate {
         b.mult(6, 5, 2); // gi r^2
         b.linear(7, &[(0, o), (1, o), (4, o), (6, o)]);
         Self {
-            ty: std::sync::Arc::new(b.build().expect("merged round gate")),
+            ty: Arc::new(b.build().expect("merged round gate")),
         }
     }
 }
@@ -3022,7 +3045,7 @@ impl GateType for MergedRoundGate {
 /// intake (gamma-power chains, the `T0`/`V` sums, and zero-delta joins:
 /// `mac(a, b, one) = a + b` is the char-2 equality delta).
 struct MacGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
 }
 
 impl MacGate {
@@ -3037,7 +3060,7 @@ impl MacGate {
         b.mult(3, 1, 2);
         b.linear(4, &[(0, o), (3, o)]);
         Self {
-            ty: std::sync::Arc::new(b.build().expect("mac gate")),
+            ty: Arc::new(b.build().expect("mac gate")),
         }
     }
 }
@@ -3073,7 +3096,7 @@ impl GateType for MacGate {
 /// oracle-tested standalone in `circuit_assist.rs` — this is the same gate,
 /// both sourcing the transition table from `flock_core::pcs::jagged`).
 struct AssistLayerGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
 }
 
 const AL_IN: usize = 9; // g0..g3, za, rb, rc, rd, one
@@ -3083,7 +3106,7 @@ impl AssistLayerGate {
     fn new() -> Self {
         use flock_core::element_r1cs::ElementTableBuilder;
         let one = F128::ONE;
-        let sparse = flock_core::pcs::jagged::assist_sparse_transitions();
+        let sparse = assist_sparse_transitions();
         let mut b = ElementTableBuilder::new(6);
         for w in 0..AL_IN {
             b.free_wire(w);
@@ -3121,7 +3144,7 @@ impl AssistLayerGate {
             );
         }
         Self {
-            ty: std::sync::Arc::new(b.build().expect("assist layer gate")),
+            ty: Arc::new(b.build().expect("assist layer gate")),
         }
     }
 }
@@ -3138,7 +3161,7 @@ impl GateType for AssistLayerGate {
         TableType::element(self.ty.clone()).with_io_schema(schema)
     }
     fn eval(&self, inputs: &[F128], _h: &()) -> (Vec<F128>, Self::Row) {
-        let sparse = flock_core::pcs::jagged::assist_sparse_transitions();
+        let sparse = assist_sparse_transitions();
         let mut z = vec![F128::ZERO; 53];
         z[..AL_IN].copy_from_slice(&inputs[..AL_IN]);
         let one = F128::ONE;
@@ -3187,7 +3210,7 @@ impl GateType for AssistLayerGate {
 ///   delta = g0 (1+t) + running + t g1          (must be 0)
 ///   running' = g0 (1+rho) + g1 rho + g_inf rho (1+rho)
 struct ZcRoundGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
 }
 
 impl ZcRoundGate {
@@ -3208,7 +3231,7 @@ impl ZcRoundGate {
         b.mult(13, 2, 12); // gi rho(1+rho)
         b.linear(14, &[(10, o), (11, o), (13, o)]);
         Self {
-            ty: std::sync::Arc::new(b.build().expect("zc round gate")),
+            ty: Arc::new(b.build().expect("zc round gate")),
         }
     }
 }
@@ -3253,7 +3276,7 @@ impl GateType for ZcRoundGate {
 /// likewise `vb` — the four eq-tensor weights over the last two zerocheck
 /// challenges, with the table's affine constants baked as weights.
 struct ZcJoinGate {
-    ty: std::sync::Arc<flock_core::element_r1cs::ElementTableType>,
+    ty: Arc<ElementTableType>,
     ac: Vec<F128>,
     bc: Vec<F128>,
 }
@@ -3289,7 +3312,7 @@ impl ZcJoinGate {
         b.linear(13, &ta); // va
         b.linear(14, &tb); // vb
         Self {
-            ty: std::sync::Arc::new(b.build().expect("zc join gate")),
+            ty: Arc::new(b.build().expect("zc join gate")),
             ac: a_const.to_vec(),
             bc: b_const.to_vec(),
         }
@@ -3316,16 +3339,10 @@ impl GateType for ZcJoinGate {
         z[10] = z[4] * (z[6] + z[5]);
         z[11] = (z[6] + z[4]) * z[5];
         z[12] = z[4] * z[5];
-        z[13] = z[1]
-            + z[9] * self.ac[0]
-            + z[10] * self.ac[1]
-            + z[11] * self.ac[2]
-            + z[12] * self.ac[3];
-        z[14] = z[2]
-            + z[9] * self.bc[0]
-            + z[10] * self.bc[1]
-            + z[11] * self.bc[2]
-            + z[12] * self.bc[3];
+        z[13] =
+            z[1] + z[9] * self.ac[0] + z[10] * self.ac[1] + z[11] * self.ac[2] + z[12] * self.ac[3];
+        z[14] =
+            z[2] + z[9] * self.bc[0] + z[10] * self.bc[1] + z[11] * self.bc[2] + z[12] * self.bc[3];
         (vec![z[8], z[13], z[14]], z)
     }
     fn witness(&self, rows: &[Self::Row], nu: usize) -> SlotWitness {
@@ -3436,7 +3453,7 @@ struct OpenLevel {
 /// not as a wrong wire.
 #[allow(clippy::type_complexity)]
 fn parse_open_levels(
-    ops: &[flock_core::transcript_record::TranscriptOp],
+    ops: &[TranscriptOp],
     cap0_bytes: usize,
     r: usize,
 ) -> (
@@ -3496,7 +3513,13 @@ fn parse_open_levels(
     // The merged intake absorbs, per packed-direct claim, [point slice,
     // value, gamma squeeze] right after the merged-open label — so the claim
     // POINTS are stream words (wireable), and each gamma is a scalar squeeze.
-    let mut cur = Cur { ops, i: 0, fin: 0, ch: 0, v: 0 };
+    let mut cur = Cur {
+        ops,
+        i: 0,
+        fin: 0,
+        ch: 0,
+        v: 0,
+    };
     let mut gammas: Vec<PdRec> = Vec::new();
     let mut rounds: Vec<RoundRec> = Vec::new();
     let mut mp: Option<MpRec> = None;
@@ -3517,7 +3540,11 @@ fn parse_open_levels(
                 cur.expect_obs_scalar();
                 cur.expect_obs_scalar();
                 assert!(matches!(ops[cur.i], Op::SqueezeScalar), "zc rho");
-                zc_rounds.push(RoundRec { g_v, fin: cur.fin, ch: cur.ch });
+                zc_rounds.push(RoundRec {
+                    g_v,
+                    fin: cur.fin,
+                    ch: cur.ch,
+                });
                 cur.bump();
             }
             let eab_v = cur.v;
@@ -3538,7 +3565,11 @@ fn parse_open_levels(
                 cur.expect_obs_scalar();
                 cur.expect_obs_scalar();
                 assert!(matches!(ops[cur.i], Op::SqueezeScalar), "lc rho");
-                lc_rounds.push(RoundRec { g_v, fin: cur.fin, ch: cur.ch });
+                lc_rounds.push(RoundRec {
+                    g_v,
+                    fin: cur.fin,
+                    ch: cur.ch,
+                });
                 cur.bump();
             }
             piop = Some(PiopRec {
@@ -3703,9 +3734,7 @@ fn parse_open_levels(
         let mut fold_msg_vs = Vec::new();
         loop {
             match cur.ops[cur.i] {
-                Op::Pow { .. }
-                    if matches!(cur.ops.get(cur.i + 1), Some(Op::SqueezeScalar)) =>
-                {
+                Op::Pow { .. } if matches!(cur.ops.get(cur.i + 1), Some(Op::SqueezeScalar)) => {
                     cur.bump()
                 }
                 Op::SqueezeScalar => {
@@ -3801,16 +3830,7 @@ fn parse_open_levels(
             a_count,
         });
     }
-    (
-        start_v,
-        piop,
-        gammas,
-        rounds,
-        mp,
-        inner_pd,
-        yr_v,
-        levels,
-    )
+    (start_v, piop, gammas, rounds, mp, inner_pd, yr_v, levels)
 }
 
 // ---------------------------------------------------------------------------
@@ -3868,13 +3888,34 @@ fn parse_open_levels(
 #[test]
 #[ignore] // Proves a real m=22 inner proof first. `-- --ignored`.
 fn mvp7_real_query_phase() {
+    // ---- PoW grinding ops, located on the tape ----
+    // Each Pow op finalizes the chain (the state digest — output wires the
+    // replay already computes) and absorbs one aligned 8-byte nonce word
+    // (a Bytes payload). Record (finalize ordinal, payload ordinal, bits).
+    struct PowRec {
+        fin: usize,
+        pay: usize,
+        bits: u32,
+    }
+    // Per level: q, c, path depth d-c, lanes — and the native cross-checks
+    // that pin every piece of the plumbing before the circuit exists: each
+    // opened row verifies against its cap under the recorded challenge, and
+    // the recorded weights reproduce `induce_sumcheck_enforced_sum`.
+    struct Lvl {
+        q: usize,
+        c: usize,
+        path: usize,
+        depth: usize,
+        lanes: usize,
+    }
+    use Arc;
     use flock_core::element_r1cs::ElementTableBuilder;
+    #[cfg(test)]
     use flock_core::lincheck::build_eq_table;
     use flock_core::transcript_record::RecordingChallenger;
     use flock_prover::prover::UnionElementSlotInput;
     use flock_prover::r1cs_hashes::fs_chain::FsChain;
     use flock_prover::schedule::Registry;
-    use std::sync::Arc;
     use std::time::Instant;
 
     const DOMAIN7: &[u8] = b"flock-mvp7-real-v0";
@@ -3913,7 +3954,11 @@ fn mvp7_real_query_phase() {
         z
     };
     let inner_union = UnionInstance::new(&registry, vec![n_rows]);
-    assert_eq!(inner_union.dense_m(), 22, "the inner commit is exactly m=22");
+    assert_eq!(
+        inner_union.dense_m(),
+        22,
+        "the inner commit is exactly m=22"
+    );
     let inner_params = PcsParams {
         m: inner_union.dense_m(),
         log_inv_rate: 1,
@@ -3958,7 +4003,11 @@ fn mvp7_real_query_phase() {
     let lig = &proof.pcs_open.inner.ligerito;
     assert_eq!(commitment.cap, lig.initial_cap, "commitment IS the L0 cap");
     let r = lig.recursive_caps.len();
-    assert_eq!(lig.recursive_proofs.len(), r - 1, "levels with opens = r + 1");
+    assert_eq!(
+        lig.recursive_proofs.len(),
+        r - 1,
+        "levels with opens = r + 1"
+    );
     let lvl_src: Vec<(&[[u8; 32]], &Vec<Vec<F128>>, &Vec<[u8; 32]>)> = (0..=r)
         .map(|li| {
             if li == 0 {
@@ -4002,7 +4051,11 @@ fn mvp7_real_query_phase() {
         }
         assert_eq!(mp.rounds.len(), fro.rounds.len(), "two-product round count");
         for (rr, want) in mp.rounds.iter().zip(&fro.rounds) {
-            assert_eq!((vals_rec[rr.g_v], vals_rec[rr.g_v + 1]), *want, "mp round msg");
+            assert_eq!(
+                (vals_rec[rr.g_v], vals_rec[rr.g_v + 1]),
+                *want,
+                "mp round msg"
+            );
         }
         assert_eq!(vals_rec[mp.anchor_v], fro.anchor.v, "anchor v stream word");
         assert_eq!(
@@ -4038,15 +4091,6 @@ fn mvp7_real_query_phase() {
         assert_eq!(t, fro.anchor.v, "T_m must equal the anchor's claimed v");
     }
 
-    // ---- PoW grinding ops, located on the tape ----
-    // Each Pow op finalizes the chain (the state digest — output wires the
-    // replay already computes) and absorbs one aligned 8-byte nonce word
-    // (a Bytes payload). Record (finalize ordinal, payload ordinal, bits).
-    struct PowRec {
-        fin: usize,
-        pay: usize,
-        bits: u32,
-    }
     let pows: Vec<PowRec> = {
         use flock_core::transcript_record::TranscriptOp as Op;
         let mut out = Vec::new();
@@ -4071,17 +4115,6 @@ fn mvp7_real_query_phase() {
     };
     assert!(!pows.is_empty(), "the Fast profile grinds");
 
-    // Per level: q, c, path depth d-c, lanes — and the native cross-checks
-    // that pin every piece of the plumbing before the circuit exists: each
-    // opened row verifies against its cap under the recorded challenge, and
-    // the recorded weights reproduce `induce_sumcheck_enforced_sum`.
-    struct Lvl {
-        q: usize,
-        c: usize,
-        path: usize,
-        depth: usize,
-        lanes: usize,
-    }
     let mut geo: Vec<Lvl> = Vec::new();
     let mut native_sums: Vec<F128> = Vec::new();
     for (li, lvl) in levels.iter().enumerate() {
@@ -4094,7 +4127,10 @@ fn mvp7_real_query_phase() {
         assert_eq!(paths.len(), q * path, "L{li}: flat paths divide evenly");
         let depth = path + c;
         let lanes = rows[0].len();
-        assert!(lanes.is_power_of_two() && lanes >= 4, "L{li}: lanes {lanes}");
+        assert!(
+            lanes.is_power_of_two() && lanes >= 4,
+            "L{li}: lanes {lanes}"
+        );
         assert_eq!(
             lanes,
             1 << lvl.fold_fins.len(),
@@ -4132,14 +4168,19 @@ fn mvp7_real_query_phase() {
             sum += aw[k] * dot;
         }
         native_sums.push(sum);
-        geo.push(Lvl { q, c, path, depth, lanes });
+        geo.push(Lvl {
+            q,
+            c,
+            path,
+            depth,
+            lanes,
+        });
     }
 
     // ---- the FS chain over the real byte stream ----
     let mut chain = FsChain::new();
     let mut at = 0usize;
-    let fin_ops: Vec<&flock_core::transcript_record::TranscriptOp> =
-        t_shape.ops().iter().filter(|o| o.finalizes()).collect();
+    let fin_ops: Vec<&TranscriptOp> = t_shape.ops().iter().filter(|o| o.finalizes()).collect();
     for (i, &upto) in stream.finalize_after.iter().enumerate() {
         chain.absorb(&bytes[at * 16..upto * 16]);
         at = upto;
@@ -4165,7 +4206,7 @@ fn mvp7_real_query_phase() {
             nu,
         }),
     };
-    let mut leaf_slot: Vec<(usize, flock_core::circuit::builder::SlotId)> = Vec::new();
+    let mut leaf_slot: Vec<(usize, SlotId)> = Vec::new();
     // ONE 8-lane leaf-eval type serves every level: a 64-lane leaf is 8
     // CHAINED rows, row h taking lanes [8h, 8h+8) with alpha input
     // `alpha_k·eq(v[3..], h)` — the same boundary-expanded-public pattern
@@ -4194,16 +4235,17 @@ fn mvp7_real_query_phase() {
     leaf_slot.push((0, spine));
 
     let mut vals: Vec<F128> = Vec::new();
-    let iv_w = pack8(&flock_prover::r1cs_hashes::fs_chain::IV);
+    let iv_w = pack8(&FS_CHAIN_IV);
     vals.extend_from_slice(&iv_w);
     let iv = [sb.public_input(), sb.public_input()];
-    let (outs, word_wire) = emit_fs_chain(&mut sb, slots.b3, iv, &trace, &stream, &bytes, &mut vals);
+    let (outs, word_wire) =
+        emit_fs_chain(&mut sb, slots.b3, iv, &trace, &stream, &bytes, &mut vals);
     // Observed-value index -> absorbed-stream word index, for wiring the
     // sumcheck messages (they are absorbed proof scalars, so their wires
     // already exist as the chain's block inputs).
     let mut vmap: Vec<Option<usize>> = Vec::new();
     for (wi, w) in stream.words.iter().enumerate() {
-        if let flock_core::transcript_record::StreamWord::Value(vi) = *w {
+        if let StreamWord::Value(vi) = *w {
             if vmap.len() <= vi {
                 vmap.resize(vi + 1, None);
             }
@@ -4348,14 +4390,29 @@ fn mvp7_real_query_phase() {
     for rr in &piop.lc_rounds {
         lr = sb.gate(
             mrslot,
-            &[lr, wv(rr.g_v), wv(rr.g_v + 1), chw(&outs, &trace.squeezes, rr.fin)],
+            &[
+                lr,
+                wv(rr.g_v),
+                wv(rr.g_v + 1),
+                chw(&outs, &trace.squeezes, rr.fin),
+            ],
         )[0];
     }
     let lc_target = lr;
     // ec join: the intake's first absorbed value == the zerocheck's ec.
     let ec_join = sb.gate(
         spine,
-        &[zw, zw, zw, wv(piop.eab_v + 2), zw, zw, wv(gammas[0].val_v), ow, zw],
+        &[
+            zw,
+            zw,
+            zw,
+            wv(piop.eab_v + 2),
+            zw,
+            zw,
+            wv(gammas[0].val_v),
+            ow,
+            zw,
+        ],
     )[3];
 
     // Outer target: SpineGate tr-rows accumulate gamma_k * value_k.
@@ -4375,7 +4432,10 @@ fn mvp7_real_query_phase() {
     let gpw = chw(&outs, &trace.squeezes, inner_pd.fin);
     let tw0 = sb.gate(spine, &[zw, zw, zw, zw, zw, zw, wv(inner_pd.q_v), gpw, zw]);
     let mut tw = tw0[3];
-    let st = sb.gate(spine, &[zw, zw, zw, zw, wv(start_v), wv(start_v + 1), tw, ow, zw]);
+    let st = sb.gate(
+        spine,
+        &[zw, zw, zw, zw, wv(start_v), wv(start_v + 1), tw, ow, zw],
+    );
     let (mut qc, mut qb, mut qa) = (st[0], st[1], st[2]);
     for (li, lvl) in levels.iter().enumerate() {
         for (j, &mv) in lvl.fold_msg_vs.iter().enumerate() {
@@ -4390,14 +4450,34 @@ fn mvp7_real_query_phase() {
                 let bw = chw(&outs, &trace.squeezes, od.beta_fin);
                 let f = sb.gate(
                     spine,
-                    &[qc, qb, qa, tw, wv(od.intro_v), wv(od.intro_v + 1), wv(od.y_v), bw, zw],
+                    &[
+                        qc,
+                        qb,
+                        qa,
+                        tw,
+                        wv(od.intro_v),
+                        wv(od.intro_v + 1),
+                        wv(od.y_v),
+                        bw,
+                        zw,
+                    ],
                 );
                 (qc, qb, qa, tw) = (f[0], f[1], f[2], f[3]);
             }
             let bw = chw(&outs, &trace.squeezes, lvl.beta_fin);
             let f = sb.gate(
                 spine,
-                &[qc, qb, qa, tw, wv(lvl.intro_v), wv(lvl.intro_v + 1), level_accs[li], bw, zw],
+                &[
+                    qc,
+                    qb,
+                    qa,
+                    tw,
+                    wv(lvl.intro_v),
+                    wv(lvl.intro_v + 1),
+                    level_accs[li],
+                    bw,
+                    zw,
+                ],
             );
             (qc, qb, qa, tw) = (f[0], f[1], f[2], f[3]);
         } else {
@@ -4430,7 +4510,7 @@ fn mvp7_real_query_phase() {
             .flat_map(|l| l.fold_fins.iter().map(|&f| chw(&outs, &trace.squeezes, f)))
             .collect();
         let alpha_vals: Vec<F128> = (0..lvl.a_count).map(|j| chals[lvl.a_ch + j]).collect();
-        let aw = flock_core::lincheck::build_eq_table(&alpha_vals);
+        let aw = build_eq_table(&alpha_vals);
         let mut accs: Vec<Wire> = (0..yr_len).map(|_| zw).collect();
         for k in 0..geo[li].q {
             let pos = (chals[lvl.q_ch + k].lo as usize) & ((1usize << geo[li].depth) - 1);
@@ -4458,101 +4538,111 @@ fn mvp7_real_query_phase() {
     assert_eq!(gammas.len(), pd_pts.len(), "one gamma per claim");
     for (k, pd) in gammas.iter().enumerate() {
         for j in 0..pd.pt_len {
-            assert_eq!(rec.values()[pd.pt_v + j], pd_pts[k][j], "pt {k}:{j} on tape");
+            assert_eq!(
+                rec.values()[pd.pt_v + j],
+                pd_pts[k][j],
+                "pt {k}:{j} on tape"
+            );
         }
     }
     let pl_full: usize = levels.iter().map(|l| l.fold_fins.len()).sum();
-    let inner_w = if !closeout { None } else {
-    let ris_full: Vec<Wire> = levels
-        .iter()
-        .flat_map(|l| l.fold_fins.iter().map(|&f| chw(&outs, &trace.squeezes, f)))
-        .collect();
-    let sxslot = sb.slot(SuffixGate::new(yr_log));
-    leaf_slot.push((300, sxslot));
-    // ONE prefix slot at pl_full serves every prefix length: shorter calls
-    // pad their (a, b) blocks with zero pairs — each padded factor is
-    // 1 + 0 + 0 = 1, so the wide gate is exact. (Was one slot per distinct
-    // pl: two extra kappa-6 types whose schemas alone were ~200K cells.)
-    let mut pf_slots: Vec<(usize, flock_core::circuit::builder::SlotId)> = Vec::new();
-    let mut pf_slot = |sb: &mut ShapeBuilder,
-                       leaf_slot: &mut Vec<(usize, flock_core::circuit::builder::SlotId)>,
-                       _pl: usize| {
-        match pf_slots.first() {
-            Some((_, sl)) => *sl,
-            None => {
-                let sl = sb.slot(PrefixGate::new(pl_full));
-                leaf_slot.push((310 + pl_full, sl));
-                pf_slots.push((pl_full, sl));
-                sl
+    let inner_w = if !closeout {
+        None
+    } else {
+        let ris_full: Vec<Wire> = levels
+            .iter()
+            .flat_map(|l| l.fold_fins.iter().map(|&f| chw(&outs, &trace.squeezes, f)))
+            .collect();
+        let sxslot = sb.slot(SuffixGate::new(yr_log));
+        leaf_slot.push((300, sxslot));
+        // ONE prefix slot at pl_full serves every prefix length: shorter calls
+        // pad their (a, b) blocks with zero pairs — each padded factor is
+        // 1 + 0 + 0 = 1, so the wide gate is exact. (Was one slot per distinct
+        // pl: two extra kappa-6 types whose schemas alone were ~200K cells.)
+        let mut pf_slots: Vec<(usize, SlotId)> = Vec::new();
+        let mut pf_slot = |sb: &mut ShapeBuilder,
+                           leaf_slot: &mut Vec<(usize, SlotId)>,
+                           _pl: usize| {
+            match pf_slots.first() {
+                Some((_, sl)) => *sl,
+                None => {
+                    let sl = sb.slot(PrefixGate::new(pl_full));
+                    leaf_slot.push((310 + pl_full, sl));
+                    pf_slots.push((pl_full, sl));
+                    sl
+                }
             }
-        }
-    };
-    let mut evb_accs: Vec<Wire> = (0..yr_len).map(|_| zw).collect();
-    // The ligerito layer sees ONE packed-direct claim: (rho, q_eval) with
-    // gamma'. rho's coords are the merged-round squeezes — chain wires.
-    {
-        assert_eq!(w_rounds.len(), pl_full + yr_log, "rho spans the dense domain");
-        let sl = pf_slot(&mut sb, &mut leaf_slot, pl_full);
-        let mut g_in = vec![chw(&outs, &trace.squeezes, inner_pd.fin)];
-        for rr in &w_rounds[..pl_full] {
-            g_in.push(chw(&outs, &trace.squeezes, rr.fin));
-        }
-        g_in.extend_from_slice(&ris_full);
-        g_in.push(ow);
-        let p = sb.gate(sl, &g_in)[0];
-        let mut s_in = vec![p];
-        for rr in &w_rounds[pl_full..] {
-            s_in.push(chw(&outs, &trace.squeezes, rr.fin));
-        }
-        s_in.push(ow);
-        s_in.extend_from_slice(&evb_accs);
-        evb_accs = sb.gate(sxslot, &s_in);
-    }
-    // OOD claims: same shape, seed = beta, point = the squeezed z.
-    for (li, lvl) in levels.iter().enumerate() {
-        for od in &lvl.ood {
-            let folded = od.z_len - yr_log;
-            let later: Vec<Wire> = levels[li + 1..]
-                .iter()
-                .flat_map(|l| l.fold_fins.iter().map(|&f| chw(&outs, &trace.squeezes, f)))
-                .collect();
-            assert_eq!(later.len(), folded, "OOD prefix = later folds");
-            let sl = pf_slot(&mut sb, &mut leaf_slot, folded);
-            let sq = &trace.squeezes[od.z_fin];
-            let mut g_in = vec![chw(&outs, &trace.squeezes, od.beta_fin)];
-            for j in 0..folded {
-                g_in.push(outs[sq[j / 4]][j % 4]);
+        };
+        let mut evb_accs: Vec<Wire> = (0..yr_len).map(|_| zw).collect();
+        // The ligerito layer sees ONE packed-direct claim: (rho, q_eval) with
+        // gamma'. rho's coords are the merged-round squeezes — chain wires.
+        {
+            assert_eq!(
+                w_rounds.len(),
+                pl_full + yr_log,
+                "rho spans the dense domain"
+            );
+            let sl = pf_slot(&mut sb, &mut leaf_slot, pl_full);
+            let mut g_in = vec![chw(&outs, &trace.squeezes, inner_pd.fin)];
+            for rr in &w_rounds[..pl_full] {
+                g_in.push(chw(&outs, &trace.squeezes, rr.fin));
             }
-            g_in.extend(std::iter::repeat_n(zw, pl_full - folded));
-            g_in.extend_from_slice(&later);
-            g_in.extend(std::iter::repeat_n(zw, pl_full - folded));
+            g_in.extend_from_slice(&ris_full);
             g_in.push(ow);
             let p = sb.gate(sl, &g_in)[0];
             let mut s_in = vec![p];
-            for j in 0..yr_log {
-                let jj = folded + j;
-                s_in.push(outs[sq[jj / 4]][jj % 4]);
+            for rr in &w_rounds[pl_full..] {
+                s_in.push(chw(&outs, &trace.squeezes, rr.fin));
             }
             s_in.push(ow);
             s_in.extend_from_slice(&evb_accs);
             evb_accs = sb.gate(sxslot, &s_in);
         }
-    }
-    // beta-weighted residuals fold in per level, then the yr dot.
-    let pcslot = sb.slot(PartialCombineGate::new(yr_log));
-    leaf_slot.push((301, pcslot));
-    let mut comb = evb_accs;
-    for (li, lvl) in levels.iter().enumerate() {
-        let mut g_in = vec![chw(&outs, &trace.squeezes, lvl.beta_fin)];
+        // OOD claims: same shape, seed = beta, point = the squeezed z.
+        for (li, lvl) in levels.iter().enumerate() {
+            for od in &lvl.ood {
+                let folded = od.z_len - yr_log;
+                let later: Vec<Wire> = levels[li + 1..]
+                    .iter()
+                    .flat_map(|l| l.fold_fins.iter().map(|&f| chw(&outs, &trace.squeezes, f)))
+                    .collect();
+                assert_eq!(later.len(), folded, "OOD prefix = later folds");
+                let sl = pf_slot(&mut sb, &mut leaf_slot, folded);
+                let sq = &trace.squeezes[od.z_fin];
+                let mut g_in = vec![chw(&outs, &trace.squeezes, od.beta_fin)];
+                for j in 0..folded {
+                    g_in.push(outs[sq[j / 4]][j % 4]);
+                }
+                g_in.extend(repeat_n(zw, pl_full - folded));
+                g_in.extend_from_slice(&later);
+                g_in.extend(repeat_n(zw, pl_full - folded));
+                g_in.push(ow);
+                let p = sb.gate(sl, &g_in)[0];
+                let mut s_in = vec![p];
+                for j in 0..yr_log {
+                    let jj = folded + j;
+                    s_in.push(outs[sq[jj / 4]][jj % 4]);
+                }
+                s_in.push(ow);
+                s_in.extend_from_slice(&evb_accs);
+                evb_accs = sb.gate(sxslot, &s_in);
+            }
+        }
+        // beta-weighted residuals fold in per level, then the yr dot.
+        let pcslot = sb.slot(PartialCombineGate::new(yr_log));
+        leaf_slot.push((301, pcslot));
+        let mut comb = evb_accs;
+        for (li, lvl) in levels.iter().enumerate() {
+            let mut g_in = vec![chw(&outs, &trace.squeezes, lvl.beta_fin)];
+            g_in.extend_from_slice(&comb);
+            g_in.extend_from_slice(&resid_pub[li]);
+            comb = sb.gate(pcslot, &g_in);
+        }
+        let fdslot = sb.slot(FinalDotGate::new(yr_log));
+        leaf_slot.push((302, fdslot));
+        let mut g_in: Vec<Wire> = (0..yr_len).map(|y| wv(yr_v + y)).collect();
         g_in.extend_from_slice(&comb);
-        g_in.extend_from_slice(&resid_pub[li]);
-        comb = sb.gate(pcslot, &g_in);
-    }
-    let fdslot = sb.slot(FinalDotGate::new(yr_log));
-    leaf_slot.push((302, fdslot));
-    let mut g_in: Vec<Wire> = (0..yr_len).map(|y| wv(yr_v + y)).collect();
-    g_in.extend_from_slice(&comb);
-    Some(sb.gate(fdslot, &g_in)[0])
+        Some(sb.gate(fdslot, &g_in)[0])
     };
 
     // ---- MVP-8 step 2: the multipoint intake in-circuit ----
@@ -4615,11 +4705,11 @@ fn mvp7_real_query_phase() {
             for (a, _) in chunk {
                 g_in.push(*a);
             }
-            g_in.extend(std::iter::repeat_n(zw, pl_full - chunk.len()));
+            g_in.extend(repeat_n(zw, pl_full - chunk.len()));
             for (_, b) in chunk {
                 g_in.push(*b);
             }
-            g_in.extend(std::iter::repeat_n(zw, pl_full - chunk.len()));
+            g_in.extend(repeat_n(zw, pl_full - chunk.len()));
             g_in.push(ow);
             seed = sb.gate(pfslot, &g_in)[0];
         }
@@ -4650,12 +4740,8 @@ fn mvp7_real_query_phase() {
         }
     }
     assert_eq!(groups_ix.len(), mp.val_vs.len(), "one dual value per group");
-    let params_i = flock_core::pcs::jagged::JaggedParams::from_heights(
-        &inner_union.jagged_heights(),
-        n_log_i,
-        m_mp,
-    );
-    let bounds = flock_core::pcs::jagged::assist_boundaries(&params_i);
+    let params_i = JaggedParams::from_heights(&inner_union.jagged_heights(), n_log_i, m_mp);
+    let bounds = assist_boundaries(&params_i);
     // Shape assumption: singleton used-column runs, plus AT MOST one
     // zero-height tail run (absent at full utilization — this inner).
     let n_runs = bounds.len();
@@ -4672,7 +4758,10 @@ fn mvp7_real_query_phase() {
             let mut factors = Vec::with_capacity(2 * (m_mp + 1));
             for l in 0..=m_mp {
                 factors.push((sig_w[2 * l], if (t_c >> l) & 1 == 1 { ow } else { zw }));
-                factors.push((sig_w[2 * l + 1], if (t_next >> l) & 1 == 1 { ow } else { zw }));
+                factors.push((
+                    sig_w[2 * l + 1],
+                    if (t_next >> l) & 1 == 1 { ow } else { zw },
+                ));
             }
             prefix_product(&mut sb, &factors)
         })
@@ -4747,7 +4836,7 @@ fn mvp7_real_query_phase() {
             let wi = stream
                 .words
                 .iter()
-                .position(|w| matches!(w, flock_core::transcript_record::StreamWord::Bytes { payload, .. } if *payload == pr.pay))
+                .position(|w| matches!(w, StreamWord::Bytes { payload, .. } if *payload == pr.pay))
                 .expect("pow nonce stream word");
             let nw = word_wire[wi].expect("pow nonce wired");
             [outs[sq[0]][0], outs[sq[0]][1], nw]
@@ -4813,8 +4902,7 @@ fn mvp7_real_query_phase() {
     let shape = sb.finish().expect("valid real-query circuit");
     let setup_ms = t.elapsed().as_secs_f64() * 1e3;
 
-    let hint_refs: Vec<&dyn std::any::Any> =
-        hints.iter().map(|h| h as &dyn std::any::Any).collect();
+    let hint_refs: Vec<&dyn Any> = hints.iter().map(|h| h as &dyn Any).collect();
     let (built, online_t) = timed(REPS, || shape.run(&vals, &hint_refs));
 
     // ---- the boundary checks ----
@@ -4840,7 +4928,11 @@ fn mvp7_real_query_phase() {
         // evals = (va, vb) are strip_constants derivations — validated
         // transitively by the lincheck target equality; z_eval is the
         // absorbed c-claim value.
-        assert_eq!(built.public[at + 2], vals_rec[gammas[0].val_v], "assertion z_eval");
+        assert_eq!(
+            built.public[at + 2],
+            vals_rec[gammas[0].val_v],
+            "assertion z_eval"
+        );
     }
     let pow_base = assert_base - 3 * pows.len();
     for (i, off) in [3, 2, 1].into_iter().enumerate() {
@@ -4864,12 +4956,7 @@ fn mvp7_real_query_phase() {
             assert_eq!(nn.lo, 0, "pow {i}: canonical zero nonce");
         } else {
             assert!(
-                flock_core::challenger::pow_has_leading_zero_bits(
-                    &digest,
-                    nn.lo,
-                    pr.bits,
-                    HashKind::Blake3,
-                ),
+                pow_has_leading_zero_bits(&digest, nn.lo, pr.bits, HashKind::Blake3,),
                 "pow {i}: grinding predicate on the published wires"
             );
         }
@@ -4882,7 +4969,8 @@ fn mvp7_real_query_phase() {
         + 3
         + 3 * pows.len()
         + n_assert;
-    let total_pub: usize = 1 + yr_pub
+    let total_pub: usize = 1
+        + yr_pub
         + levels
             .iter()
             .zip(&geo)
@@ -4926,12 +5014,20 @@ fn mvp7_real_query_phase() {
         if li < levels.len() - 1 {
             for od in &lvl.ood {
                 let b = chals[od.beta_ch];
-                let iq = quad(vals_rec[od.intro_v], vals_rec[od.intro_v + 1], vals_rec[od.y_v]);
+                let iq = quad(
+                    vals_rec[od.intro_v],
+                    vals_rec[od.intro_v + 1],
+                    vals_rec[od.y_v],
+                );
                 nq = (nq.0 + b * iq.0, nq.1 + b * iq.1, nq.2 + b * iq.2);
                 nt += b * vals_rec[od.y_v];
             }
             let b = chals[lvl.beta_ch];
-            let iq = quad(vals_rec[lvl.intro_v], vals_rec[lvl.intro_v + 1], native_sums[li]);
+            let iq = quad(
+                vals_rec[lvl.intro_v],
+                vals_rec[lvl.intro_v + 1],
+                native_sums[li],
+            );
             nq = (nq.0 + b * iq.0, nq.1 + b * iq.1, nq.2 + b * iq.2);
             nt += b * native_sums[li];
         } else {
@@ -5134,14 +5230,13 @@ fn mvp7_real_query_phase() {
         })
         .collect();
 
-    let mut lcs_ord: Vec<(usize, &dyn flock_core::lincheck::LincheckCircuit)> = vec![
+    let mut lcs_ord: Vec<(usize, &dyn LincheckCircuit)> = vec![
         (shape.registry_slot(slots.b3), b3_lc),
         (shape.registry_slot(slots.swap), swap_lc),
         (shape.registry_slot(slots.spread), spread_lc),
     ];
     lcs_ord.sort_by_key(|(i, _)| *i);
-    let lcs: Vec<&dyn flock_core::lincheck::LincheckCircuit> =
-        lcs_ord.into_iter().map(|(_, c)| c).collect();
+    let lcs: Vec<&dyn LincheckCircuit> = lcs_ord.into_iter().map(|(_, c)| c).collect();
 
     let ((cproof, ccommitment), prove_t) = timed(REPS, || {
         let mut bool_slots: Vec<(usize, UnionSlotProverInput)> = vec![
@@ -5291,9 +5386,9 @@ impl GateType for BitSpreadGate {
 /// The three slots a collapsed opening writes into.
 #[derive(Clone, Copy)]
 struct CollapsedSlots {
-    b3: flock_core::circuit::builder::SlotId,
-    swap: flock_core::circuit::builder::SlotId,
-    spread: flock_core::circuit::builder::SlotId,
+    b3: SlotId,
+    swap: SlotId,
+    spread: SlotId,
 }
 
 /// Emit one Merkle opening as rows of the shipped BLAKE3 table plus glue,
@@ -5450,8 +5545,7 @@ fn collapsed_opening_matches_the_composite() {
             }
             hints.extend(tree.siblings(pos));
         }
-        let hint_refs: Vec<&dyn std::any::Any> =
-            hints.iter().map(|h| h as &dyn std::any::Any).collect();
+        let hint_refs: Vec<&dyn Any> = hints.iter().map(|h| h as &dyn Any).collect();
         let built = shape.run(&vals, &hint_refs);
 
         // Every opening's root is the tree's — i.e. the collapsed rows fold
@@ -5514,6 +5608,7 @@ fn collapsed_opening_matches_the_composite() {
 #[ignore] // The full shape. `-- --ignored`.
 fn mvp6_all_levels_collapsed() {
     use flock_core::challenger::Challenger as _;
+    #[cfg(test)]
     use flock_core::lincheck::build_eq_table;
     use flock_core::transcript_record::{RecordingChallenger, TranscriptOp};
     use flock_prover::prover::UnionElementSlotInput;
@@ -5610,7 +5705,7 @@ fn mvp6_all_levels_collapsed() {
             nu,
         }),
     };
-    let mut leaf_slot: Vec<(usize, flock_core::circuit::builder::SlotId)> = Vec::new();
+    let mut leaf_slot: Vec<(usize, SlotId)> = Vec::new();
     let leafeval: Vec<_> = levels
         .iter()
         .map(|l| match leaf_slot.iter().find(|(n, _)| *n == l.lanes) {
@@ -5629,7 +5724,7 @@ fn mvp6_all_levels_collapsed() {
     leaf_slot.push((0, spine));
 
     let mut vals: Vec<F128> = Vec::new();
-    let iv_w = pack8(&flock_prover::r1cs_hashes::fs_chain::IV);
+    let iv_w = pack8(&FS_CHAIN_IV);
     vals.extend_from_slice(&iv_w);
     let iv = [sb.public_input(), sb.public_input()];
 
@@ -5768,8 +5863,7 @@ fn mvp6_all_levels_collapsed() {
     let setup_ms = t.elapsed().as_secs_f64() * 1e3;
 
     // ---- online ----
-    let hint_refs: Vec<&dyn std::any::Any> =
-        hints.iter().map(|h| h as &dyn std::any::Any).collect();
+    let hint_refs: Vec<&dyn Any> = hints.iter().map(|h| h as &dyn Any).collect();
     let (built, online_t) = timed(REPS, || shape.run(&vals, &hint_refs));
 
     // Every opening folds to its cap node, and the accumulator is
@@ -5840,14 +5934,13 @@ fn mvp6_all_levels_collapsed() {
         })
         .collect();
 
-    let mut lcs_ord: Vec<(usize, &dyn flock_core::lincheck::LincheckCircuit)> = vec![
+    let mut lcs_ord: Vec<(usize, &dyn LincheckCircuit)> = vec![
         (shape.registry_slot(slots.b3), b3_lc),
         (shape.registry_slot(slots.swap), swap_lc),
         (shape.registry_slot(slots.spread), spread_lc),
     ];
     lcs_ord.sort_by_key(|(i, _)| *i);
-    let lcs: Vec<&dyn flock_core::lincheck::LincheckCircuit> =
-        lcs_ord.into_iter().map(|(_, c)| c).collect();
+    let lcs: Vec<&dyn LincheckCircuit> = lcs_ord.into_iter().map(|(_, c)| c).collect();
 
     let ((proof, commitment), prove_t) = timed(REPS, || {
         let mut bool_slots: Vec<(usize, UnionSlotProverInput)> = vec![
@@ -5905,8 +5998,7 @@ fn mvp6_all_levels_collapsed() {
         .expect("the collapsed query phase verifies")
     });
 
-
-    let nnz = |r: &flock_core::r1cs::BlockR1cs| {
+    let nnz = |r: &BlockR1cs| {
         r.a_0.rows.iter().map(|x| x.len()).sum::<usize>()
             + r.b_0.rows.iter().map(|x| x.len()).sum::<usize>()
     };
@@ -5931,7 +6023,9 @@ fn mvp6_all_levels_collapsed() {
         union.m_bool(),
         shape.circuit.cells().mu(),
         bincode::serialize(&proof).map(|b| b.len()).unwrap_or(0) as f64 / 1024.0,
-        bincode::serialize(&proof.pcs_open.frobenius).map(|b| b.len()).unwrap_or(0) as f64
+        bincode::serialize(&proof.pcs_open.frobenius)
+            .map(|b| b.len())
+            .unwrap_or(0) as f64
             / 1024.0,
         proof.pcs_open.merged_rounds.len(),
         shape.circuit.cells().num_gate_slots(),
@@ -5977,14 +6071,14 @@ fn mvp9_boolean_leaf_tape() {
     let mut rng = Rng(0x4D50_9B00);
     let inputs: Vec<blake3::Compression> = (0..n_blocks)
         .map(|_| {
-            let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-            let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+            let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+            let m: [u32; 16] = from_fn(|_| rng.next_u32());
             let counter = ((rng.next_u32() as u64) << 32) | (rng.next_u32() as u64);
             (cv, m, counter, 64u32, 11u32)
         })
         .collect();
     let circuit = setup.r1cs.csc_lincheck_circuit();
-    let registry = flock_prover::schedule::Registry::new(
+    let registry = Registry::new(
         vec![TableType::from_block_r1cs(&setup.r1cs)],
         setup.r1cs.n_log(),
     );
@@ -5997,26 +6091,19 @@ fn mvp9_boolean_leaf_tape() {
     // opening gates and chain rows model blake3; the setup's defaults
     // (SHA-256 Merkle) diverge silently otherwise.
     let mut leaf_pcs = setup.pcs_params.clone();
-    leaf_pcs.merkle_hash = flock_core::merkle::HashKind::Blake3;
+    leaf_pcs.merkle_hash = HashKind::Blake3;
     let mut ch = FsChallenger::with_hash(DOMAIN, HashKind::Blake3);
     let (proof, commitment, _claim) =
         prover::prove_fast_ligerito_union(&union, &leaf_pcs, vec![slot], &mut ch);
 
     let mut rec = RecordingChallenger::new(FsChallenger::with_hash(DOMAIN, HashKind::Blake3));
-    verifier::verify_ligerito_union(
-        &union,
-        &[circuit],
-        &commitment,
-        &proof,
-        &leaf_pcs,
-        &mut rec,
-    )
-    .expect("the leaf workload proof verifies");
+    verifier::verify_ligerito_union(&union, &[circuit], &commitment, &proof, &leaf_pcs, &mut rec)
+        .expect("the leaf workload proof verifies");
     let t_shape = rec.shape();
     let chals: Vec<F128> = rec.challenges().to_vec();
     let vals_rec = rec.values();
 
-    if std::env::var("MVP9_DUMP").is_ok() {
+    if var("MVP9_DUMP").is_ok() {
         for (i, op) in t_shape.ops().iter().enumerate().take(160) {
             eprintln!("op {i:>3}: {op:?}");
         }
@@ -6060,8 +6147,16 @@ fn mvp9_boolean_leaf_tape() {
         assert!(matches!(ops[i], Op2::SqueezeScalar), "z_skip");
         bump(&ops[i], &mut v, &mut c);
         i += 1;
-        assert_eq!(&vals_rec[r1ab_v..r1ab_v + 64], &proof.zerocheck.round1_ab[..], "round1_ab words");
-        assert_eq!(&vals_rec[r1c_v..r1c_v + 64], &proof.zerocheck.round1_c[..], "round1_c words");
+        assert_eq!(
+            &vals_rec[r1ab_v..r1ab_v + 64],
+            &proof.zerocheck.round1_ab[..],
+            "round1_ab words"
+        );
+        assert_eq!(
+            &vals_rec[r1c_v..r1c_v + 64],
+            &proof.zerocheck.round1_c[..],
+            "round1_c words"
+        );
         let mut zc_rounds = Vec::new();
         loop {
             // rounds are [obs, obs, squeeze]; the finals are obs NOT
@@ -6079,7 +6174,11 @@ fn mvp9_boolean_leaf_tape() {
                 break;
             }
         }
-        assert_eq!(zc_rounds.len(), proof.zerocheck.multilinear_rounds.len(), "zc rounds");
+        assert_eq!(
+            zc_rounds.len(),
+            proof.zerocheck.multilinear_rounds.len(),
+            "zc rounds"
+        );
         for ((g_v, _), want) in zc_rounds.iter().zip(&proof.zerocheck.multilinear_rounds) {
             assert_eq!((vals_rec[*g_v], vals_rec[*g_v + 1]), *want, "zc round msg");
         }
@@ -6154,27 +6253,34 @@ fn mvp9_boolean_leaf_tape() {
             tail_scalars.is_empty(),
             "the lincheck tail carries only z_partial"
         );
-        assert!(!proof.lincheck.matrix_evals.is_empty(), "the deferred matrix work");
+        assert!(
+            !proof.lincheck.matrix_evals.is_empty(),
+            "the deferred matrix work"
+        );
     }
 
     // The leaf's opening shape: rs×2, pd = 0 — R = 2, P = 0.
     let fro = &proof.pcs_open.frobenius;
     assert_eq!(fro.values.len(), 2, "the boolean class contributes rs×2");
-    assert!(fro.values.iter().all(|v| v.len() == 128), "128 values per RS claim");
-    assert!(fro.group_values.is_empty(), "no packed-direct claims at the leaf");
+    assert!(
+        fro.values.iter().all(|v| v.len() == 128),
+        "128 values per RS claim"
+    );
+    assert!(
+        fro.group_values.is_empty(),
+        "no packed-direct claims at the leaf"
+    );
 
     // Locate the multipoint region with a minimal cursor (value/challenge
     // ordinals), exactly as parse_open_levels does for the element inner.
     let ops = t_shape.ops();
     let (mut v, mut c, mut i) = (0usize, 0usize, 0usize);
-    let bump = |op: &Op, v: &mut usize, c: &mut usize| {
-        match op {
-            Op::SqueezeScalar => *c += 1,
-            Op::SqueezeSlice(n) => *c += n,
-            Op::ObserveScalar => *v += 1,
-            Op::ObserveSlice(n) => *v += n,
-            _ => {}
-        }
+    let bump = |op: &Op, v: &mut usize, c: &mut usize| match op {
+        Op::SqueezeScalar => *c += 1,
+        Op::SqueezeSlice(n) => *c += n,
+        Op::ObserveScalar => *v += 1,
+        Op::ObserveSlice(n) => *v += n,
+        _ => {}
     };
     while !matches!(&ops[i], Op::Label(l) if l.as_slice() == b"flock-multipoint-twisted-v1") {
         bump(&ops[i], &mut v, &mut c);
@@ -6248,7 +6354,10 @@ fn mvp9_boolean_leaf_tape() {
         let g0 = t + g1;
         t = g0 + (g1 + g0 + gi) * r + gi * r * r;
     }
-    assert_eq!(t, fro.anchor.v, "T_m must equal the anchor's claimed v (R = 2)");
+    assert_eq!(
+        t, fro.anchor.v,
+        "T_m must equal the anchor's claimed v (R = 2)"
+    );
 
     // ---- phase 2b step 1: the ring-switch regions pinned, and the R = 2
     // merged boundary replayed from located pieces: the two s_hat_v slices
@@ -6307,7 +6416,9 @@ fn mvp9_boolean_leaf_tape() {
             let eq = build_eq(&rdp);
             target += gs[k] * rs::inner_product(&rs::tensor_algebra_transpose(shv), &eq);
             let scaled: Vec<F128> = eq.iter().map(|x| gs[k] * *x).collect();
-            coeffs.push(rs::linearized_coefficients(&rs::build_fold_byte_table(&scaled)));
+            coeffs.push(rs::linearized_coefficients(&rs::build_fold_byte_table(
+                &scaled,
+            )));
         }
         let mut running = target;
         while matches!(ops[i], Op::ObserveScalar)
@@ -6353,7 +6464,28 @@ fn mvp9_boolean_leaf_tape() {
     // published and checked against native replicas. The mvp7 machinery,
     // instantiated on the boolean leaf tape.
     {
+        struct Lvl {
+            q: usize,
+            c: usize,
+            path: usize,
+            depth: usize,
+            lanes: usize,
+        }
+        // The PoW grinding ops, located and bound (the mvp7 machinery).
+        struct PowRec {
+            fin: usize,
+            pay: usize,
+            bits: u32,
+        }
+        // Native seed + g0/running chain.
+        #[cfg(test)]
         use flock_core::lincheck::build_eq_table;
+        use flock_core::zerocheck::multilinear::{
+            interpolate_at_z_combined, interpolate_at_z_on_lambda,
+        };
+        use flock_core::zerocheck::univariate_skip_optimized::{
+            medium_challenges_ghash, small_challenges_ghash,
+        };
         use flock_prover::prover::UnionElementSlotInput;
         use flock_prover::r1cs_hashes::fs_chain::FsChain;
 
@@ -6389,13 +6521,6 @@ fn mvp9_boolean_leaf_tape() {
         assert!(gammas_o.is_empty(), "no packed-direct claims at the leaf");
         assert_eq!(levels.len(), r + 1);
 
-        struct Lvl {
-            q: usize,
-            c: usize,
-            path: usize,
-            depth: usize,
-            lanes: usize,
-        }
         let mut geo: Vec<Lvl> = Vec::new();
         let mut native_sums: Vec<F128> = Vec::new();
         for (li, lvl) in levels.iter().enumerate() {
@@ -6439,7 +6564,13 @@ fn mvp9_boolean_leaf_tape() {
                 sum += aw[k] * dot;
             }
             native_sums.push(sum);
-            geo.push(Lvl { q, c, path, depth, lanes });
+            geo.push(Lvl {
+                q,
+                c,
+                path,
+                depth,
+                lanes,
+            });
         }
 
         let stream = t_shape.stream_words(DOMAIN);
@@ -6447,7 +6578,11 @@ fn mvp9_boolean_leaf_tape() {
         let mut chain = FsChain::new();
         let mut at = 0usize;
         let fin_ops: Vec<_> = t_shape.ops().iter().filter(|o| o.finalizes()).collect();
-        assert_eq!(stream.finalize_after.len(), fin_ops.len(), "finalize alignment");
+        assert_eq!(
+            stream.finalize_after.len(),
+            fin_ops.len(),
+            "finalize alignment"
+        );
         for (k, &upto) in stream.finalize_after.iter().enumerate() {
             chain.absorb(&bytes[at * 16..upto * 16]);
             at = upto;
@@ -6456,7 +6591,10 @@ fn mvp9_boolean_leaf_tape() {
         chain.absorb(&bytes[at * 16..]);
         let trace = chain.finish();
         let b3_rows: usize = trace.rows.len()
-            + geo.iter().map(|g| (g.lanes / 4 + g.path) * g.q).sum::<usize>();
+            + geo
+                .iter()
+                .map(|g| (g.lanes / 4 + g.path) * g.q)
+                .sum::<usize>();
         let nu = (b3_rows.next_power_of_two().trailing_zeros() as usize).max(3);
         let max_path = geo.iter().map(|g| g.path).max().unwrap().max(1);
 
@@ -6469,7 +6607,7 @@ fn mvp9_boolean_leaf_tape() {
                 nu,
             }),
         };
-        let mut leaf_slot: Vec<(usize, flock_core::circuit::builder::SlotId)> = Vec::new();
+        let mut leaf_slot: Vec<(usize, SlotId)> = Vec::new();
         let leafeval: Vec<_> = geo
             .iter()
             .map(|g| {
@@ -6485,17 +6623,11 @@ fn mvp9_boolean_leaf_tape() {
             })
             .collect();
         let mut vals: Vec<F128> = Vec::new();
-        let iv_w = pack8(&flock_prover::r1cs_hashes::fs_chain::IV);
+        let iv_w = pack8(&FS_CHAIN_IV);
         vals.extend_from_slice(&iv_w);
         let iv = [sb.public_input(), sb.public_input()];
         let (outs, ww) = emit_fs_chain(&mut sb, slots.b3, iv, &trace, &stream, &bytes, &mut vals);
 
-        // The PoW grinding ops, located and bound (the mvp7 machinery).
-        struct PowRec {
-            fin: usize,
-            pay: usize,
-            bits: u32,
-        }
         let pows: Vec<PowRec> = {
             use flock_core::transcript_record::TranscriptOp as Op3;
             let mut out = Vec::new();
@@ -6526,7 +6658,9 @@ fn mvp9_boolean_leaf_tape() {
                 let wi = stream
                     .words
                     .iter()
-                    .position(|w| matches!(w, flock_core::transcript_record::StreamWord::Bytes { payload, .. } if *payload == pr.pay))
+                    .position(
+                        |w| matches!(w, StreamWord::Bytes { payload, .. } if *payload == pr.pay),
+                    )
                     .expect("pow nonce stream word");
                 let nw = ww[wi].expect("pow nonce wired");
                 [outs[sq[0]][0], outs[sq[0]][1], nw]
@@ -6564,7 +6698,11 @@ fn mvp9_boolean_leaf_tape() {
                 let cw = outs[sqq[k / 4]][k % 4];
                 let cv = emit_opening(&mut sb, slots, iv, &leaf_w, cw, g.depth, g.c, &mut vals);
                 opens.push((cw, cv));
-                hints.extend(paths[k * g.path..(k + 1) * g.path].iter().map(hash_to_digest));
+                hints.extend(
+                    paths[k * g.path..(k + 1) * g.path]
+                        .iter()
+                        .map(hash_to_digest),
+                );
                 let lanes = g.lanes.min(8);
                 for h in 0..le_groups {
                     let mut a_in: Vec<Wire> = leaf_w[lanes * h..lanes * (h + 1)].to_vec();
@@ -6586,7 +6724,7 @@ fn mvp9_boolean_leaf_tape() {
         // natively (the 2b replay above is the reference).
         let mut vmap: Vec<Option<usize>> = Vec::new();
         for (wi, w) in stream.words.iter().enumerate() {
-            if let flock_core::transcript_record::StreamWord::Value(vi) = *w {
+            if let StreamWord::Value(vi) = *w {
                 if vmap.len() <= vi {
                     vmap.resize(vi + 1, None);
                 }
@@ -6628,10 +6766,7 @@ fn mvp9_boolean_leaf_tape() {
                 let rw = outs[trace.squeezes[lvl.fold_fins[j]][0]][0];
                 let ev = sb.gate(spine, &[qc, qb, qa, zw, zw, zw, zw, zw, rw]);
                 tsp = ev[4];
-                let bld = sb.gate(
-                    spine,
-                    &[zw, zw, zw, zw, wv(mv), wv(mv + 1), tsp, ow, zw],
-                );
+                let bld = sb.gate(spine, &[zw, zw, zw, zw, wv(mv), wv(mv + 1), tsp, ow, zw]);
                 (qc, qb, qa) = (bld[0], bld[1], bld[2]);
             }
             if li < r {
@@ -6751,7 +6886,10 @@ fn mvp9_boolean_leaf_tape() {
             bump2(&ops2[i2], &mut v2, &mut c2, &mut f2);
             i2 += 1;
             let (beta_ch2, beta_fin2) = (c2, f2);
-            assert!(matches!(ops2[i2], Op4::SqueezeScalar), "lc beta (const pin)");
+            assert!(
+                matches!(ops2[i2], Op4::SqueezeScalar),
+                "lc beta (const pin)"
+            );
             bump2(&ops2[i2], &mut v2, &mut c2, &mut f2);
             i2 += 1;
             let mut lc_rounds2 = Vec::new();
@@ -6779,13 +6917,7 @@ fn mvp9_boolean_leaf_tape() {
         let (outer_ch, outer_fin, r1ab_v, r1c_v, z_ch) = zc0;
         let (alpha_ch2, alpha_fin2, beta_ch2, beta_fin2) = lc_chs;
         assert!(zc_finals_v.len() >= 2, "zc finals (v_a, v_b) on the tape");
-        // Native seed + g0/running chain.
-        use flock_core::zerocheck::multilinear::{
-            interpolate_at_z_combined, interpolate_at_z_on_lambda,
-        };
-        use flock_core::zerocheck::univariate_skip_optimized::{
-            medium_challenges_ghash, small_challenges_ghash,
-        };
+
         let zval = chals[z_ch];
         let c_eval = interpolate_at_z_on_lambda(&vals_rec[r1c_v..r1c_v + 64], 6, zval);
         let combined: Vec<F128> = vals_rec[r1ab_v..r1ab_v + 64]
@@ -6920,7 +7052,11 @@ fn mvp9_boolean_leaf_tape() {
         leaf_slot.push((310 + pl_full, pfslot2));
         let mut evb_accs: Vec<Wire> = (0..yr_len).map(|_| zw).collect();
         {
-            assert_eq!(w_rounds.len(), pl_full + yr_log, "rho spans the dense domain");
+            assert_eq!(
+                w_rounds.len(),
+                pl_full + yr_log,
+                "rho spans the dense domain"
+            );
             let mut g_in = vec![outs[trace.squeezes[inner_pd2.fin][0]][0]];
             for rr in &w_rounds[..pl_full] {
                 g_in.push(outs[trace.squeezes[rr.fin][0]][0]);
@@ -6949,9 +7085,9 @@ fn mvp9_boolean_leaf_tape() {
                 for j in 0..folded {
                     g_in.push(outs[sq[j / 4]][j % 4]);
                 }
-                g_in.extend(std::iter::repeat_n(zw, pl_full - folded));
+                g_in.extend(repeat_n(zw, pl_full - folded));
                 g_in.extend_from_slice(&later);
-                g_in.extend(std::iter::repeat_n(zw, pl_full - folded));
+                g_in.extend(repeat_n(zw, pl_full - folded));
                 g_in.push(ow);
                 let pw2 = sb.gate(pfslot2, &g_in)[0];
                 let mut s_in = vec![pw2];
@@ -7134,8 +7270,7 @@ fn mvp9_boolean_leaf_tape() {
             sb.publish(*w);
         }
         let shape = sb.finish().expect("valid leaf query-phase circuit");
-        let hint_refs: Vec<&dyn std::any::Any> =
-            hints.iter().map(|h| h as &dyn std::any::Any).collect();
+        let hint_refs: Vec<&dyn Any> = hints.iter().map(|h| h as &dyn Any).collect();
         let built = shape.run(&vals, &hint_refs);
 
         // ---- boundary checks: alphas, cap selects, and the enforced sums.
@@ -7158,7 +7293,11 @@ fn mvp9_boolean_leaf_tape() {
             let g = &geo[li];
             let (cap, _, _) = lvl_src[li];
             for j in 0..lvl.a_count {
-                assert_eq!(built.public[at2 + j], chals[lvl.a_ch + j], "L{li} alpha {j}");
+                assert_eq!(
+                    built.public[at2 + j],
+                    chals[lvl.a_ch + j],
+                    "L{li} alpha {j}"
+                );
             }
             at2 += lvl.a_count;
             for k in 0..g.q {
@@ -7196,14 +7335,13 @@ fn mvp9_boolean_leaf_tape() {
                     .iter()
                     .flat_map(|l| l.fold_chs.iter().map(|&i| chals[i]))
                     .collect();
-                let alpha_vals: Vec<F128> =
-                    (0..lvl.a_count).map(|j| chals[lvl.a_ch + j]).collect();
+                let alpha_vals: Vec<F128> = (0..lvl.a_count).map(|j| chals[lvl.a_ch + j]).collect();
                 let aw = build_eq_table(&alpha_vals);
                 for y in 0..yr_len {
                     let mut sum = F128::ZERO;
                     for k in 0..geo[li].q {
-                        let pos = (chals[lvl.q_ch + k].lo as usize)
-                            & ((1usize << geo[li].depth) - 1);
+                        let pos =
+                            (chals[lvl.q_ch + k].lo as usize) & ((1usize << geo[li].depth) - 1);
                         let mut sk = Vec::with_capacity(lmc);
                         if lmc > 0 {
                             sk.push(F128::new(pos as u64, 0));
@@ -7298,12 +7436,7 @@ fn mvp9_boolean_leaf_tape() {
                 assert_eq!(nn.lo, 0, "pow {k}: canonical zero nonce");
             } else {
                 assert!(
-                    flock_core::challenger::pow_has_leading_zero_bits(
-                        &digest,
-                        nn.lo,
-                        pr.bits,
-                        HashKind::Blake3,
-                    ),
+                    pow_has_leading_zero_bits(&digest, nn.lo, pr.bits, HashKind::Blake3,),
                     "pow {k}: grinding predicate on the published wires"
                 );
             }
@@ -7381,14 +7514,20 @@ fn mvp9_boolean_leaf_tape() {
                 if li < levels.len() - 1 {
                     for od in &lvl.ood {
                         let b = chals[od.beta_ch];
-                        let iq =
-                            quad(vals_rec[od.intro_v], vals_rec[od.intro_v + 1], vals_rec[od.y_v]);
+                        let iq = quad(
+                            vals_rec[od.intro_v],
+                            vals_rec[od.intro_v + 1],
+                            vals_rec[od.y_v],
+                        );
                         nq = (nq.0 + b * iq.0, nq.1 + b * iq.1, nq.2 + b * iq.2);
                         nt += b * vals_rec[od.y_v];
                     }
                     let b = chals[lvl.beta_ch];
-                    let iq =
-                        quad(vals_rec[lvl.intro_v], vals_rec[lvl.intro_v + 1], native_sums[li]);
+                    let iq = quad(
+                        vals_rec[lvl.intro_v],
+                        vals_rec[lvl.intro_v + 1],
+                        native_sums[li],
+                    );
                     nq = (nq.0 + b * iq.0, nq.1 + b * iq.1, nq.2 + b * iq.2);
                     nt += b * native_sums[li];
                 } else {
@@ -7432,14 +7571,13 @@ fn mvp9_boolean_leaf_tape() {
                 other => panic!("leaf-eval slot produced {other:?}"),
             })
             .collect();
-        let mut lcs_ord: Vec<(usize, &dyn flock_core::lincheck::LincheckCircuit)> = vec![
+        let mut lcs_ord: Vec<(usize, &dyn LincheckCircuit)> = vec![
             (shape.registry_slot(slots.b3), b3_lc),
             (shape.registry_slot(slots.swap), swap_lc),
             (shape.registry_slot(slots.spread), spread_lc),
         ];
         lcs_ord.sort_by_key(|(i, _)| *i);
-        let lcs: Vec<&dyn flock_core::lincheck::LincheckCircuit> =
-            lcs_ord.into_iter().map(|(_, cc)| cc).collect();
+        let lcs: Vec<&dyn LincheckCircuit> = lcs_ord.into_iter().map(|(_, cc)| cc).collect();
         let ((oproof, ocommit), prove_t) = timed(REPS, || {
             let mut bool_slots: Vec<(usize, UnionSlotProverInput)> = vec![
                 (

--- a/crates/flock-prover/tests/circuit_wiring.rs
+++ b/crates/flock-prover/tests/circuit_wiring.rs
@@ -36,20 +36,30 @@
 //! --ignored`. A DEBUG run needs `--test-threads=1` (the repo's known
 //! pre-existing rayon stack hazard in the Ligerito recursion).
 
+use flock_core::circuit::CellSlot;
+use flock_core::circuit::WiringProof;
+use flock_core::circuit::prove_wiring;
+use flock_core::circuit::verify_wiring;
 use flock_core::circuit::{Cell, Circuit, CircuitError, WiringError};
+use flock_core::element_r1cs::union::verify as verify_element;
 use flock_core::element_r1cs::{ElementTableBuilder, ElementTableType};
 use flock_core::field::F128;
+use flock_core::lincheck::LincheckCircuit;
 use flock_core::pcs::PcsParams;
 use flock_core::pcs::ligerito::LigeritoProfile;
 use flock_core::product_gkr;
 use flock_core::proof::R1csProofCircuitMerged;
+use flock_core::r1cs::BlockR1cs;
 use flock_prover::challenger::FsChallenger;
+use flock_prover::pcs::Commitment;
 use flock_prover::prover::{self, UnionElementSlotInput, UnionSlotProverInput};
 use flock_prover::r1cs_hashes::sha2;
 use flock_prover::schedule::{IoWord, Registry, TableType};
 use flock_prover::union::UnionInstance;
 use flock_prover::verifier::{self, VerifyError};
+use std::array::from_fn;
 use std::sync::Arc;
+use std::time::Instant;
 
 const DOMAIN: &[u8] = b"flock-circuit-wiring-v0";
 
@@ -163,7 +173,7 @@ fn build_tree(k_leaves: usize, nu: usize, rng: &mut Rng) -> Tree {
 
     // Leaves: public messages under the IV.
     for _ in 0..leaves {
-        let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+        let m: [u32; 16] = from_fn(|_| rng.next_u32());
         public.extend(pack_u32_words(&m));
         out.push(sha2::sha256_compress(&sha2::SHA256_IV, &m));
         compressions.push((sha2::SHA256_IV, m));
@@ -242,7 +252,7 @@ fn pub_cell(p: usize, nu: usize) -> Cell {
     Cell::new(PUB_SLOT + (p >> nu), p & ((1 << nu) - 1))
 }
 
-fn sha2_registry(nu: usize) -> (Registry, flock_core::r1cs::BlockR1cs) {
+fn sha2_registry(nu: usize) -> (Registry, BlockR1cs) {
     let r1cs = sha2::build_block_r1cs(nu);
     let registry = Registry::new(
         vec![TableType::from_block_r1cs(&r1cs).with_io_schema(sha2_schema())],
@@ -294,9 +304,7 @@ fn sha256_binary_tree_circuit() {
             &mut ch,
         )
     };
-    let verify = |public: &[F128],
-                  commitment: &flock_prover::pcs::Commitment,
-                  proof: &R1csProofCircuitMerged| {
+    let verify = |public: &[F128], commitment: &Commitment, proof: &R1csProofCircuitMerged| {
         let mut ch = FsChallenger::new(DOMAIN);
         verifier::verify_ligerito_union_circuit(
             &union,
@@ -541,13 +549,11 @@ fn g_side_forgery_is_rejected() {
     for (iota, slot) in cells.slots().iter().enumerate() {
         for row in 0..1usize << nu {
             w[(iota << nu) | row] = match *slot {
-                flock_core::circuit::CellSlot::Gate { .. } => {
-                    packed[cells.gate_word_addr(iota, row)]
-                }
-                flock_core::circuit::CellSlot::Public { s } => {
+                CellSlot::Gate { .. } => packed[cells.gate_word_addr(iota, row)],
+                CellSlot::Public { s } => {
                     public.get((s << nu) + row).copied().unwrap_or(F128::ZERO)
                 }
-                flock_core::circuit::CellSlot::Pad => F128::ZERO,
+                CellSlot::Pad => F128::ZERO,
             };
         }
     }
@@ -580,10 +586,10 @@ fn g_side_forgery_is_rejected() {
         })
         .collect();
 
-    let proof = flock_core::circuit::WiringProof { gkr, gather };
+    let proof = WiringProof { gkr, gather };
     let mut ch = FsChallenger::new(DOMAIN);
     assert_eq!(
-        flock_core::circuit::verify_wiring(&circuit, &public, &proof, &mut ch),
+        verify_wiring(&circuit, &public, &proof, &mut ch),
         Err(WiringError::GEvalMismatch),
         "the g-side check must be what stops this — the GKR and the \
          recombination both accept"
@@ -595,7 +601,7 @@ fn g_side_forgery_is_rejected() {
         let v = rng.f128();
         for &idx in class {
             let (iota, row) = (idx >> nu, idx & ((1 << nu) - 1));
-            if let flock_core::circuit::CellSlot::Gate { .. } = cells.slots()[iota] {
+            if let CellSlot::Gate { .. } = cells.slots()[iota] {
                 packed[cells.gate_word_addr(iota, row)] = v;
             }
         }
@@ -603,10 +609,9 @@ fn g_side_forgery_is_rejected() {
     // Public cells are not wired in this circuit, so the repair above is
     // complete.
     let mut ch = FsChallenger::new(DOMAIN);
-    let (proof, _) = flock_core::circuit::prove_wiring(&circuit, &packed, &public, &mut ch);
+    let (proof, _) = prove_wiring(&circuit, &packed, &public, &mut ch);
     let mut ch = FsChallenger::new(DOMAIN);
-    flock_core::circuit::verify_wiring(&circuit, &public, &proof, &mut ch)
-        .expect("the honest control must verify");
+    verify_wiring(&circuit, &public, &proof, &mut ch).expect("the honest control must verify");
 }
 
 /// **A fabricated witness**: the GKR run honestly on a DIFFERENT (but
@@ -663,7 +668,7 @@ fn fabricated_witness_fails_recombination() {
 
     // The forger's transcript: an honest wiring proof of the FAKE buffer.
     let mut ch = FsChallenger::new(DOMAIN);
-    let (fake_proof, _) = flock_core::circuit::prove_wiring(&circuit, fake, &public, &mut ch);
+    let (fake_proof, _) = prove_wiring(&circuit, fake, &public, &mut ch);
 
     // Recover ρ by replaying, then compute the REAL buffer's gather values —
     // the ones the PCS opening would accept — and splice them in.
@@ -687,13 +692,13 @@ fn fabricated_witness_fails_recombination() {
                 .fold(F128::ZERO, |a, b| a + b)
         })
         .collect();
-    let spliced = flock_core::circuit::WiringProof {
+    let spliced = WiringProof {
         gkr: fake_proof.gkr.clone(),
         gather: real_gather,
     };
     let mut ch = FsChallenger::new(DOMAIN);
     assert_eq!(
-        flock_core::circuit::verify_wiring(&circuit, &public, &spliced, &mut ch),
+        verify_wiring(&circuit, &public, &spliced, &mut ch),
         Err(WiringError::Recombination),
         "jointly consistent evals over a fabricated vector must fail the \
          recombination against the committed gather values"
@@ -702,7 +707,7 @@ fn fabricated_witness_fails_recombination() {
     // consistent (it is an honest proof — of the wrong witness), which is
     // precisely why the gather claims must ride the PCS opening.
     let mut ch = FsChallenger::new(DOMAIN);
-    flock_core::circuit::verify_wiring(&circuit, &public, &fake_proof, &mut ch)
+    verify_wiring(&circuit, &public, &fake_proof, &mut ch)
         .expect("the fabricated proof is self-consistent — the opening is what rejects it");
 }
 
@@ -754,6 +759,7 @@ fn chain_witness(ty: &ElementTableType, nu: usize, a: &[F128], seed: F128) -> (V
 #[test]
 #[ignore] // Heavier — run with `-- --ignored`.
 fn element_chain_circuit() {
+    const PUB: usize = 3;
     let (nu, kappa, n) = (12usize, 3usize, 20usize);
     let registry = element_registry(nu, kappa);
     assert_eq!(registry.m_total(), 22);
@@ -768,7 +774,7 @@ fn element_chain_circuit() {
     let mut public = vec![seed];
     public.extend_from_slice(&a);
     public.push(result);
-    const PUB: usize = 3; // 3 gate slots, then the public slot
+    // 3 gate slots, then the public slot
 
     let mut wires = vec![vec![Cell::new(PUB, 0), Cell::new(EL_B, 0)]];
     for i in 0..n {
@@ -840,6 +846,9 @@ fn element_chain_circuit() {
 #[test]
 #[ignore] // Heavier — run with `-- --ignored`.
 fn cross_class_hash_into_mult() {
+    // Cell-slots: 8 SHA-256 gate slots, then 3 element slots, then public.
+    const EL: usize = 8;
+    const PUB: usize = 11;
     let (nu, kappa) = (7usize, 2usize);
     let r1cs = sha2::build_block_r1cs(nu);
     let registry = Registry::new(
@@ -858,7 +867,7 @@ fn cross_class_hash_into_mult() {
     assert_eq!(registry.m_total(), 23);
 
     let mut rng = Rng::new(0xC205_0001);
-    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+    let m: [u32; 16] = from_fn(|_| rng.next_u32());
     let h_out = sha2::sha256_compress(&sha2::SHA256_IV, &m);
     let out_words = pack_u32_words(&h_out);
     let (o0, o1) = (out_words[0], out_words[1]);
@@ -868,9 +877,6 @@ fn cross_class_hash_into_mult() {
     public.extend(pack_u32_words(&m));
     public.push(o0 * o1);
 
-    // Cell-slots: 8 SHA-256 gate slots, then 3 element slots, then public.
-    const EL: usize = 8;
-    const PUB: usize = 11;
     let wires = vec![
         vec![Cell::new(PUB, 0), Cell::new(SHA_H0, 0)],
         vec![Cell::new(PUB, 1), Cell::new(SHA_H1, 0)],
@@ -1020,13 +1026,13 @@ fn gather_claims_are_bound_by_the_opening() {
     // the fabricated witness.
     let mut ch = FsChallenger::new(DOMAIN);
     union.bind_statement_circuit(&mut ch, &commitment, &circuit.digest(), &[]);
-    flock_core::element_r1cs::union::verify(
+    verify_element(
         &union,
         proof.element.as_ref().expect("element half"),
         &mut ch,
     )
     .expect("the honest element PIOP replays");
-    let (fake_wiring, _) = flock_core::circuit::prove_wiring(&circuit, &fake, &[], &mut ch);
+    let (fake_wiring, _) = prove_wiring(&circuit, &fake, &[], &mut ch);
 
     let mut spliced = proof.clone();
     spliced.wiring = fake_wiring;
@@ -1051,9 +1057,9 @@ fn oracle_accepts(circuit: &Circuit, z: &[F128], nu: usize, public: &[F128]) -> 
     // directly.
     let at = |slot: usize, row: usize| -> F128 {
         match cells.slots()[slot] {
-            flock_core::circuit::CellSlot::Gate { .. } => z[cells.gate_word_addr(slot, row)],
-            flock_core::circuit::CellSlot::Public { s } => public[(s << nu) + row],
-            flock_core::circuit::CellSlot::Pad => F128::ZERO,
+            CellSlot::Gate { .. } => z[cells.gate_word_addr(slot, row)],
+            CellSlot::Public { s } => public[(s << nu) + row],
+            CellSlot::Pad => F128::ZERO,
         }
     };
     circuit.wires().iter().all(|class| {
@@ -1070,12 +1076,13 @@ fn oracle_accepts(circuit: &Circuit, z: &[F128], nu: usize, public: &[F128]) -> 
 #[test]
 #[ignore] // Heavier — run with `-- --ignored`.
 fn randomized_wirings_agree_with_the_oracle() {
+    const PUB: usize = 3;
     let (nu, kappa, n) = (12usize, 3usize, 8usize);
     let registry = element_registry(nu, kappa);
     let ty = registry.types()[0].element_type().expect("element");
     let union = UnionInstance::new(&registry, vec![n]);
     let pcs_params = union_pcs_params(&union);
-    const PUB: usize = 3;
+
     let n_public = 6usize;
 
     let mut rng = Rng::new(0x0AC1_E000);
@@ -1237,12 +1244,11 @@ fn wiring_cost_probe() {
         z
     };
     let mut ch = FsChallenger::new(DOMAIN);
-    let t = std::time::Instant::now();
-    let (wiring, claims) =
-        flock_core::circuit::prove_wiring(&circuit, &z_packed, &tree.public, &mut ch);
+    let t = Instant::now();
+    let (wiring, claims) = prove_wiring(&circuit, &z_packed, &tree.public, &mut ch);
     let wiring_ms = t.elapsed().as_secs_f64() * 1e3;
 
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut ch = FsChallenger::new(DOMAIN);
     let (proof, commitment, _) = prover::prove_fast_ligerito_union_circuit(
         &union,
@@ -1258,7 +1264,7 @@ fn wiring_cost_probe() {
     );
     let prove_ms = t.elapsed().as_secs_f64() * 1e3;
 
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut ch = FsChallenger::new(DOMAIN);
     verifier::verify_ligerito_union_circuit(
         &union,
@@ -1462,7 +1468,7 @@ fn a_merge_node_folds_two_circuit_proofs() {
 
     // Its second job: fold both children's claims into ONE accumulator.
     let mats = [(&r1cs.a_0, &r1cs.b_0)];
-    let circs: Vec<&dyn flock_core::lincheck::LincheckCircuit> = vec![circuit_lc];
+    let circs: Vec<&dyn LincheckCircuit> = vec![circuit_lc];
     let mut chp = FsChallenger::new(b"merge");
     let (agg, acc) =
         aggregate::prove_aggregate(&registry, &mats, &circs, &assertions, None, &mut chp)

--- a/crates/flock-prover/tests/factored_basis.rs
+++ b/crates/flock-prover/tests/factored_basis.rs
@@ -21,6 +21,7 @@
 use flock_core::field::F128;
 use flock_core::lincheck::build_eq_table;
 use rayon::prelude::*;
+use std::hint::black_box;
 use std::time::Instant;
 
 /// Materialized reference: W over the whole dense domain.
@@ -153,7 +154,7 @@ fn factored_basis_cost() {
         for _ in 0..4 {
             let t = Instant::now();
             let v = f();
-            std::hint::black_box(v);
+            black_box(v);
             b = b.min(t.elapsed().as_secs_f64());
         }
         println!("  {label:<46} {:6.2} ms", b * 1e3);

--- a/crates/flock-prover/tests/jit_fold.rs
+++ b/crates/flock-prover/tests/jit_fold.rs
@@ -9,6 +9,7 @@
 use flock_core::field::F128;
 use flock_core::lincheck::build_eq_table;
 use rayon::prelude::*;
+use std::hint::black_box;
 use std::time::Instant;
 
 const JM: usize = 23;
@@ -21,7 +22,7 @@ fn bench(label: &str, f: &mut dyn FnMut() -> usize) -> f64 {
     f();
     for _ in 0..4 {
         let t = Instant::now();
-        std::hint::black_box(f());
+        black_box(f());
         b = b.min(t.elapsed().as_secs_f64());
     }
     println!("  {label:<52} {:6.2} ms", b * 1e3);

--- a/crates/flock-prover/tests/kappa7_probe.rs
+++ b/crates/flock-prover/tests/kappa7_probe.rs
@@ -11,6 +11,9 @@
 //! schema words at columns >= 64, the wired circuit path, and the
 //! cross-class crossing. All small shapes — they run un-ignored.
 
+use flock_core::element_r1cs::ElementTableType;
+use flock_core::pcs::ligerito::LigeritoProfile;
+use std::array::from_fn;
 use std::sync::Arc;
 
 use flock_core::circuit::{Cell, Circuit};
@@ -59,7 +62,7 @@ fn mult_ty(kappa: usize) -> TableType {
 
 /// A WIDE kappa=7 gate — `used` live columns (the residual gates' shape:
 /// c approaches the column budget), a running product down the row.
-fn wide_ty(kappa: usize, used: usize) -> Arc<flock_core::element_r1cs::ElementTableType> {
+fn wide_ty(kappa: usize, used: usize) -> Arc<ElementTableType> {
     assert!(used >= 3 && used <= 1 << kappa);
     let mut b = ElementTableBuilder::new(kappa);
     b.free_wire(0).free_wire(1);
@@ -90,14 +93,17 @@ fn kappa7_wide_gate_union() {
                 z[at(c, j)] = prev;
             }
         }
-        assert!(ty.satisfies(&z, nu, n), "wide witness must satisfy (used={used})");
+        assert!(
+            ty.satisfies(&z, nu, n),
+            "wide witness must satisfy (used={used})"
+        );
 
         let union = UnionInstance::new(&registry, vec![n]);
         let pcs_params = PcsParams {
             m: union.dense_m(),
             log_inv_rate: 1,
             log_batch_size: 6,
-            profile: flock_core::pcs::ligerito::LigeritoProfile::Fast,
+            profile: LigeritoProfile::Fast,
             num_lanes: union.commit_lanes(6),
             merkle_hash: Default::default(),
         };
@@ -129,6 +135,7 @@ fn kappa7_wide_gate_union() {
 /// in-slot word coordinate set), wired through the circuit path.
 #[test]
 fn kappa7_high_column_schema_circuit() {
+    const PUB: usize = 3;
     let (nu, n) = (8usize, 20usize);
     let (ca, cb, cc) = (80usize, 81, 100);
     let mut b = ElementTableBuilder::new(7);
@@ -160,7 +167,6 @@ fn kappa7_high_column_schema_circuit() {
     let mut public = vec![seed];
     public.extend_from_slice(&a);
     public.push(result);
-    const PUB: usize = 3;
 
     let mut wires = vec![vec![Cell::new(PUB, 0), Cell::new(EL_B, 0)]];
     for i in 0..n {
@@ -176,7 +182,7 @@ fn kappa7_high_column_schema_circuit() {
         m: union.dense_m(),
         log_inv_rate: 1,
         log_batch_size: 6,
-        profile: flock_core::pcs::ligerito::LigeritoProfile::Fast,
+        profile: LigeritoProfile::Fast,
         num_lanes: union.commit_lanes(6),
         merkle_hash: Default::default(),
     };
@@ -213,6 +219,8 @@ fn kappa7_high_column_schema_circuit() {
 /// gate, mirroring `cross_class_hash_into_mult` at the packed-word width.
 #[test]
 fn kappa7_cross_class_circuit() {
+    const EL: usize = 8;
+    const PUB: usize = 11;
     use flock_prover::prover::UnionSlotProverInput;
     use flock_prover::r1cs_hashes::sha2;
 
@@ -257,7 +265,7 @@ fn kappa7_cross_class_circuit() {
     assert!(registry.types()[1].is_element());
 
     let mut rng = Rng::new(0xC205_0007);
-    let m: [u32; 16] = std::array::from_fn(|_| rng.next_u64() as u32);
+    let m: [u32; 16] = from_fn(|_| rng.next_u64() as u32);
     let h_out = sha2::sha256_compress(&sha2::SHA256_IV, &m);
     let out_words = pack_u32_words(&h_out);
     let (o0, o1) = (out_words[0], out_words[1]);
@@ -266,8 +274,6 @@ fn kappa7_cross_class_circuit() {
     public.extend(pack_u32_words(&m));
     public.push(o0 * o1);
 
-    const EL: usize = 8;
-    const PUB: usize = 11;
     let wires = vec![
         vec![Cell::new(PUB, 0), Cell::new(SHA_H0, 0)],
         vec![Cell::new(PUB, 1), Cell::new(SHA_H1, 0)],
@@ -286,7 +292,7 @@ fn kappa7_cross_class_circuit() {
         m: union.dense_m(),
         log_inv_rate: 1,
         log_batch_size: 6,
-        profile: flock_core::pcs::ligerito::LigeritoProfile::Fast,
+        profile: LigeritoProfile::Fast,
         num_lanes: union.commit_lanes(6),
         merkle_hash: Default::default(),
     };
@@ -331,6 +337,7 @@ fn kappa7_cross_class_circuit() {
 
 #[test]
 fn kappa7_element_chain_circuit() {
+    const PUB: usize = 3;
     let (nu, kappa, n) = (8usize, 7usize, 20usize);
     let registry = Registry::new(vec![mult_ty(kappa)], nu);
     assert_eq!(registry.m_total(), 22);
@@ -354,7 +361,6 @@ fn kappa7_element_chain_circuit() {
     let mut public = vec![seed];
     public.extend_from_slice(&a);
     public.push(result);
-    const PUB: usize = 3;
 
     let mut wires = vec![vec![Cell::new(PUB, 0), Cell::new(EL_B, 0)]];
     for i in 0..n {
@@ -370,7 +376,7 @@ fn kappa7_element_chain_circuit() {
         m: union.dense_m(),
         log_inv_rate: 1,
         log_batch_size: 6,
-        profile: flock_core::pcs::ligerito::LigeritoProfile::Fast,
+        profile: LigeritoProfile::Fast,
         num_lanes: union.commit_lanes(6),
         merkle_hash: Default::default(),
     };

--- a/crates/flock-prover/tests/merkle_glue.rs
+++ b/crates/flock-prover/tests/merkle_glue.rs
@@ -8,11 +8,13 @@
 
 use flock_core::r1cs::BlockR1cs;
 use flock_prover::r1cs_hashes::blake3;
+use flock_prover::r1cs_hashes::blake3::build_matrices;
 use flock_prover::r1cs_hashes::merkle_glue::{BitSpreadTable, SwapInput, SwapTable};
 use flock_prover::r1cs_hashes::merkle_r1cs::{
     BLAKE3_FLAG_CHUNK_END, BLAKE3_FLAG_CHUNK_START, BLAKE3_FLAG_PARENT, ChunkPathInput,
     MerkleTreeLayout, NODE_BLOCK_LEN, NODE_COUNTER, SLOT_WORDS, blake3_spec,
 };
+use std::array::from_fn;
 
 /// One compression's output chaining value.
 fn cv(h: &[u32; 8], m: &[u32; 16], flags: u32) -> [u32; SLOT_WORDS] {
@@ -30,7 +32,7 @@ impl Rng {
         (z ^ (z >> 31)) as u32
     }
     fn digest(&mut self) -> [u32; SLOT_WORDS] {
-        std::array::from_fn(|_| self.next_u32())
+        from_fn(|_| self.next_u32())
     }
     fn word(&mut self) -> u128 {
         (0..4).fold(0u128, |a, _| (a << 32) | self.next_u32() as u128)
@@ -140,7 +142,7 @@ fn swap_matches_the_composite_fold() {
             let blocks = leaf_bytes / 64;
             let mut prev = blake3::BLAKE3_IV;
             for i in 0..blocks {
-                let m: [u32; 16] = std::array::from_fn(|w| {
+                let m: [u32; 16] = from_fn(|w| {
                     let o = i * 64 + 4 * w;
                     u32::from_le_bytes(input.leaf_data[o..o + 4].try_into().unwrap())
                 });
@@ -211,7 +213,7 @@ fn bit_spread_relocates_and_is_tight() {
 #[test]
 fn glue_is_negligible_against_blake3() {
     let b3 = {
-        let (a, b) = flock_prover::r1cs_hashes::blake3::build_matrices();
+        let (a, b) = build_matrices();
         a.rows.iter().map(|r| r.len()).sum::<usize>()
             + b.rows.iter().map(|r| r.len()).sum::<usize>()
     };

--- a/crates/flock-prover/tests/merkle_r1cs.rs
+++ b/crates/flock-prover/tests/merkle_r1cs.rs
@@ -10,6 +10,8 @@ use flock_core::zerocheck::K_SKIP;
 use flock_prover::r1cs_hashes::merkle_r1cs::{
     MerkleTreeLayout, PathInput, SLOT_WORDS, blake3_spec, reference_root,
 };
+use std::array::from_fn;
+use std::mem::size_of;
 
 struct Rng(u64);
 impl Rng {
@@ -24,7 +26,7 @@ impl Rng {
         (z ^ (z >> 31)) as u32
     }
     fn digest(&mut self) -> [u32; SLOT_WORDS] {
-        std::array::from_fn(|_| self.next_u32())
+        from_fn(|_| self.next_u32())
     }
 }
 
@@ -41,9 +43,11 @@ fn path(rng: &mut Rng, depth: usize, index: u64) -> PathInput {
 /// and the useful region ends after the last level's `t` block.
 #[test]
 fn layout_geometry() {
-    let spec = blake3_spec();
-    const U: usize = 15_409; // blake3 useful bits
+    const U: usize = 15_409;
+    // blake3 useful bits
     const STRIDE: usize = 1 << 14;
+    let spec = blake3_spec();
+
     for (depth, want_k_log) in [(1usize, 14usize), (2, 15), (3, 16), (26, 19)] {
         let layout = MerkleTreeLayout::new(depth, spec.clone());
         // Level 0 additionally carries const + leaf + index bits; every later
@@ -565,7 +569,7 @@ fn walker_is_compact_at_depth26() {
     let layout = MerkleTreeLayout::new(26, blake3_spec());
     let walker = layout.build_walker();
     let resident = walker.resident_bytes();
-    let materialized = walker.effective_nnz() * std::mem::size_of::<usize>();
+    let materialized = walker.effective_nnz() * size_of::<usize>();
     println!(
         "depth 26: walker resident {:.1} MB, effective nnz {} ({:.2} GB materialized), \
          ratio {:.0}x",
@@ -623,7 +627,7 @@ fn digest_to_hash(d: &[u32; SLOT_WORDS]) -> [u8; 32] {
 }
 
 fn hash_to_digest(h: &[u8; 32]) -> [u32; SLOT_WORDS] {
-    std::array::from_fn(|w| u32::from_le_bytes(h[4 * w..4 * w + 4].try_into().unwrap()))
+    from_fn(|w| u32::from_le_bytes(h[4 * w..4 * w + 4].try_into().unwrap()))
 }
 
 /// Geometry of the chunk-leaf layout: chunk blocks tile first, node levels
@@ -632,9 +636,10 @@ fn hash_to_digest(h: &[u8; 32]) -> [u32; SLOT_WORDS] {
 /// same width as the depth-26 digest table.
 #[test]
 fn chunk_layout_geometry() {
-    let spec = blake3_spec();
     const U: usize = 15_409;
     const STRIDE: usize = 1 << 14;
+    let spec = blake3_spec();
+
     for (depth, leaf_bytes, want_k_log) in
         [(1usize, 64usize, 15usize), (2, 128, 16), (13, 1024, 19)]
     {
@@ -807,7 +812,7 @@ fn chunk_root_matches_flock_core_blake3_tree() {
             siblings: (0..depth).map(|_| rng.digest()).collect(),
         };
         let z = layout.build_witness_chunk(&input);
-        let leaf_cv: [u32; SLOT_WORDS] = std::array::from_fn(|w| {
+        let leaf_cv: [u32; SLOT_WORDS] = from_fn(|w| {
             let base = layout.hash_bit(0, 0) - (1 << 14) + layout.spec.out_cv_base; // last chunk block
             let mut word = 0u32;
             for b in 0..32 {

--- a/crates/flock-prover/tests/merkle_union.rs
+++ b/crates/flock-prover/tests/merkle_union.rs
@@ -21,9 +21,12 @@ use flock_prover::challenger::FsChallenger;
 use flock_prover::mixed::{MerkleMixedCounts, MerkleMixedSetup, MixedRegistryId};
 use flock_prover::prover::{self, UnionSlotProverInput};
 use flock_prover::r1cs_hashes::blake3;
+use flock_prover::r1cs_hashes::merkle_r1cs::MerkleWalkerCircuit;
 use flock_prover::r1cs_hashes::merkle_r1cs::{
     MerkleTreeLayout, PathInput, SLOT_WORDS, blake3_spec, reference_root,
 };
+use std::array::from_fn;
+use std::time::Instant;
 
 const DOMAIN: &[u8] = b"flock-merkle-union-e2e-v0";
 const DEPTH: usize = 26;
@@ -42,7 +45,7 @@ impl Rng {
         (z ^ (z >> 31)) as u32
     }
     fn digest(&mut self) -> [u32; SLOT_WORDS] {
-        std::array::from_fn(|_| self.next_u32())
+        from_fn(|_| self.next_u32())
     }
     fn path(&mut self, depth: usize) -> PathInput {
         let index =
@@ -58,7 +61,7 @@ impl Rng {
 /// Everything a Merkle-table union proof needs, built once.
 struct Setup {
     layout: MerkleTreeLayout,
-    walker: flock_prover::r1cs_hashes::merkle_r1cs::MerkleWalkerCircuit,
+    walker: MerkleWalkerCircuit,
     registry: Registry,
 }
 
@@ -123,11 +126,11 @@ fn depth26_roundtrip() {
 
     let union = s.union(n_paths);
     let pcs_params = s.pcs_params(&union);
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let witness = s.layout.generate_witness_batch_major_partial(&paths, NU);
     let t_wit = t.elapsed();
 
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut ch_p = FsChallenger::new(DOMAIN);
     let (proof, commitment, claim) = prover::prove_fast_ligerito_union(
         &union,
@@ -137,7 +140,7 @@ fn depth26_roundtrip() {
     );
     let t_prove = t.elapsed();
 
-    let t = std::time::Instant::now();
+    let t = Instant::now();
     let mut ch_v = FsChallenger::new(DOMAIN);
     let claim_v = verifier::verify_ligerito_union(
         &union,
@@ -215,8 +218,8 @@ fn depth26_partial_counts_roundtrip() {
 fn random_blake3_inputs(rng: &mut Rng, n: usize) -> Vec<blake3::Compression> {
     (0..n)
         .map(|_| {
-            let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-            let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+            let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+            let m: [u32; 16] = from_fn(|_| rng.next_u32());
             let counter = ((rng.next_u32() as u64) << 32) | rng.next_u32() as u64;
             (cv, m, counter, 64u32, 11u32)
         })
@@ -239,13 +242,13 @@ fn merkle_blake3_mixed_roundtrip() {
             blake3: n_blake3,
         };
 
-        let t = std::time::Instant::now();
+        let t = Instant::now();
         let mut ch_p = FsChallenger::new(DOMAIN);
         let (proof, commitment, claim) =
             setup.prove(&paths, &blake3_inputs, LigeritoProfile::Fast, &mut ch_p);
         let t_prove = t.elapsed();
 
-        let t = std::time::Instant::now();
+        let t = Instant::now();
         let mut ch_v = FsChallenger::new(DOMAIN);
         let claim_v = setup
             .verify(counts, &commitment, &proof, &mut ch_v)

--- a/crates/flock-prover/tests/transcript_shape.rs
+++ b/crates/flock-prover/tests/transcript_shape.rs
@@ -28,6 +28,8 @@
 use flock_core::element_r1cs::{ElementTableBuilder, ElementTableType};
 use flock_core::field::F128;
 use flock_core::pcs::ligerito::LigeritoProfile;
+use flock_core::schedule::TableClass;
+use flock_core::transcript_record::TranscriptShape;
 use flock_core::transcript_record::{RecordingChallenger, TranscriptOp};
 use flock_prover::challenger::FsChallenger;
 use flock_prover::pcs::PcsParams;
@@ -35,6 +37,7 @@ use flock_prover::prover::{self, UnionElementSlotInput};
 use flock_prover::schedule::{Registry, TableType};
 use flock_prover::union::UnionInstance;
 use flock_prover::verifier;
+use std::env::var_os;
 use std::sync::Arc;
 
 const DOMAIN: &[u8] = b"flock-union-element-v0";
@@ -106,10 +109,7 @@ fn record_element_only(
     kappas: &[usize],
     counts: &[usize],
     seed: u64,
-) -> (
-    flock_core::transcript_record::TranscriptShape,
-    flock_core::transcript_record::TranscriptShape,
-) {
+) -> (TranscriptShape, TranscriptShape) {
     let mut rng = Rng::new(seed);
     let (w0, w1) = (F128::new(7, 0), F128::new(0, 3));
 
@@ -122,7 +122,7 @@ fn record_element_only(
         .element_types()
         .iter()
         .map(|t| match &t.class {
-            flock_core::schedule::TableClass::LargeField(e) => e.clone(),
+            TableClass::LargeField(e) => e.clone(),
             _ => unreachable!("element-only registry"),
         })
         .collect();
@@ -182,7 +182,7 @@ fn element_only_transcript_shape_is_data_independent() {
         (0, 0xA11CE_0004),
     ];
 
-    let mut reference: Option<flock_core::transcript_record::TranscriptShape> = None;
+    let mut reference: Option<TranscriptShape> = None;
     for (count, seed) in cases {
         let (shape_p, shape_v) = record_element_only(nu, &kappas, &[count], seed);
 
@@ -258,13 +258,13 @@ fn element_only_transcript_shape_is_data_independent() {
 #[test]
 #[ignore] // Heavier — run with `-- --ignored`.
 fn element_only_transcript_shape_is_pinned() {
-// Re-pinned 2026-08-02: multipoint-twisted assist (proof_io v8) — the
-// per-statement assist became 128K dual values + one product sumcheck +
-// one untwisted anchor; transcript + wire moved by design.
-// Re-pinned 2026-08-02: two-product multipoint grouping (proof_io v9) —
-// element-only claims are all packed-direct, so the values absorb shrinks
-// from 128·K to ONE word per merged-row group and the sumcheck is the
-// single untwisted product; multipoint label v1.
+    // Re-pinned 2026-08-02: multipoint-twisted assist (proof_io v8) — the
+    // per-statement assist became 128K dual values + one product sumcheck +
+    // one untwisted anchor; transcript + wire moved by design.
+    // Re-pinned 2026-08-02: two-product multipoint grouping (proof_io v9) —
+    // element-only claims are all packed-direct, so the values absorb shrinks
+    // from 128·K to ONE word per merged-row group and the sumcheck is the
+    // single untwisted product; multipoint label v1.
     const EXPECTED: &str = "25a137909e6f2bbd3c92b16010ce0b2ef07307994b828889e52ce2c641944261";
 
     let (_, shape) = record_element_only(12, &[3], &[1 << 12], 0xB0DD_1E01);
@@ -302,7 +302,7 @@ fn element_only_transcript_shape_is_pinned() {
         inv.finalize_parents,
     );
 
-    if std::env::var_os("TRANSCRIPT_SHAPE_PRINT").is_some() {
+    if var_os("TRANSCRIPT_SHAPE_PRINT").is_some() {
         println!("const EXPECTED: &str = \"{}\";", shape.digest_hex());
         return;
     }

--- a/crates/flock-prover/tests/union_element.rs
+++ b/crates/flock-prover/tests/union_element.rs
@@ -27,18 +27,34 @@
 //! are the closure of the standalone milestone's dummy-row gap, so each is
 //! checked in the profile where it is observable.
 
+use flock_core::element_r1cs::union::fill_slot;
+use flock_core::element_r1cs::union::prove;
 use flock_core::element_r1cs::{ElementTableBuilder, ElementTableType};
 use flock_core::field::F128;
-use flock_core::proof::R1csProofMixedClassMerged;
-use flock_prover::challenger::FsChallenger;
+use flock_core::merkle::HashKind;
 use flock_core::pcs::ligerito::LigeritoProfile;
+use flock_core::proof::R1csProofMixedClassMerged;
+use flock_core::proof::UnionClassClaims;
+use flock_core::r1cs::BlockR1cs;
+use flock_core::schedule::TableClass;
 use flock_prover::challenger::Challenger as _;
+use flock_prover::challenger::FsChallenger;
+use flock_prover::pcs::Commitment;
 use flock_prover::pcs::PcsParams;
 use flock_prover::prover::{self, UnionElementSlotInput, UnionSlotProverInput};
 use flock_prover::r1cs_hashes::blake3;
+use flock_prover::r1cs_hashes::sha2;
+use flock_prover::r1cs_hashes::sha2::Compression;
+use flock_prover::r1cs_hashes::sha2::build_block_r1cs;
 use flock_prover::schedule::{Registry, TableType};
 use flock_prover::union::UnionInstance;
 use flock_prover::verifier;
+use std::array::from_fn;
+use std::env::var_os;
+use std::panic::AssertUnwindSafe;
+use std::panic::catch_unwind;
+use std::panic::set_hook;
+use std::panic::take_hook;
 use std::sync::Arc;
 
 const DOMAIN: &[u8] = b"flock-union-element-v0";
@@ -119,8 +135,8 @@ fn union_pcs_params(union: &UnionInstance<'_>) -> PcsParams {
 fn random_blake3_inputs(rng: &mut Rng, n: usize) -> Vec<blake3::Compression> {
     (0..n)
         .map(|_| {
-            let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-            let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+            let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+            let m: [u32; 16] = from_fn(|_| rng.next_u32());
             let counter = ((rng.next_u32() as u64) << 32) | (rng.next_u32() as u64);
             (cv, m, counter, 64u32, 11u32)
         })
@@ -145,10 +161,10 @@ fn element_only_union_roundtrip() {
 
     // Shapes: (nu, kappas, counts). M = ceil(log2(Σ 2^{nu+κ_t+7})) must be ≥ 22.
     let shapes: Vec<(usize, Vec<usize>, Vec<usize>)> = vec![
-        (12, vec![3], vec![1 << 12]),  // M = 22, full utilization
-        (12, vec![3], vec![2731]),     // non-power-of-two count
-        (12, vec![3], vec![1]),        // one real row
-        (12, vec![3], vec![0]),        // empty table
+        (12, vec![3], vec![1 << 12]),       // M = 22, full utilization
+        (12, vec![3], vec![2731]),          // non-power-of-two count
+        (12, vec![3], vec![1]),             // one real row
+        (12, vec![3], vec![0]),             // empty table
         (11, vec![3, 3], vec![2048, 1365]), // two equal slots, M = 22
         (11, vec![4, 2], vec![1000, 2048]), // two slots of different widths
         (8, vec![7], vec![200]),            // kappa = 7: the packed-word width
@@ -163,7 +179,11 @@ fn element_only_union_roundtrip() {
         assert_eq!(registry.num_boolean(), 0);
         assert_eq!(registry.num_element(), kappas.len());
         assert_eq!(registry.m_bool(), 0, "no boolean region");
-        assert_eq!(registry.element_base(), 0, "the region IS the prefix subcube");
+        assert_eq!(
+            registry.element_base(),
+            0,
+            "the region IS the prefix subcube"
+        );
         assert!(
             registry.m_total() >= 22,
             "shape (nu={nu}, kappas={kappas:?}) commits below the Ligerito floor"
@@ -174,7 +194,7 @@ fn element_only_union_roundtrip() {
             .element_types()
             .iter()
             .map(|t| match &t.class {
-                flock_core::schedule::TableClass::LargeField(e) => e.clone(),
+                TableClass::LargeField(e) => e.clone(),
                 _ => unreachable!(),
             })
             .collect();
@@ -187,15 +207,11 @@ fn element_only_union_roundtrip() {
             // end-to-end (found the hard way — the raw `*_config_for` calls
             // silently dropped the hash and L0 verified against the wrong
             // leaf function).
-            pcs_params.merkle_hash = flock_core::merkle::HashKind::Blake3;
+            pcs_params.merkle_hash = HashKind::Blake3;
         }
 
         // Count-proportional committed area: Σ_t n_t · used_cols_t.
-        let expected_dense: usize = slot_tys
-            .iter()
-            .zip(&counts)
-            .map(|(t, &n)| t.k() * n)
-            .sum();
+        let expected_dense: usize = slot_tys.iter().zip(&counts).map(|(t, &n)| t.k() * n).sum();
         assert_eq!(
             union.dense_words(),
             expected_dense,
@@ -372,15 +388,6 @@ fn element_claims_are_bound_by_the_opening() {
 #[test]
 #[ignore] // Heavier — run with `-- --ignored`.
 fn element_only_agrees_with_the_standalone_proof() {
-    use flock_core::element_r1cs::{ElementStatement, self as el};
-
-    let (nu, kappa) = (12usize, 3usize);
-    let (w0, w1) = (F128::new(11, 0), F128::new(0, 5));
-    let ty = gate_block(kappa, w0, w1);
-    let registry = Registry::new(vec![TableType::element(ty.clone())], nu);
-    assert_eq!(registry.m_total(), nu + kappa + 7);
-
-    let mut rng = Rng::new(0x0E1E_D1FF);
     // Cases: honest at several counts, then five ways of breaking the witness.
     // `tamper` mutates the witness in place; `dirty_support` marks the tampers
     // that write a word the union's height-`n_t` transport DROPS (a dummy row,
@@ -390,6 +397,16 @@ fn element_only_agrees_with_the_standalone_proof() {
     // only the release arm yields a verdict. (The panic itself is asserted in
     // `dummy_row_is_structurally_invisible_under_the_union`.)
     type Tamper = fn(&mut Vec<F128>, usize, usize);
+    use flock_core::element_r1cs::{self as el, ElementStatement};
+
+    let (nu, kappa) = (12usize, 3usize);
+    let (w0, w1) = (F128::new(11, 0), F128::new(0, 5));
+    let ty = gate_block(kappa, w0, w1);
+    let registry = Registry::new(vec![TableType::element(ty.clone())], nu);
+    assert_eq!(registry.m_total(), nu + kappa + 7);
+
+    let mut rng = Rng::new(0x0E1E_D1FF);
+
     let cases: Vec<(&str, usize, Option<Tamper>, bool)> = vec![
         ("honest full", 1 << nu, None, false),
         ("honest partial", 2731, None, false),
@@ -473,10 +490,7 @@ fn element_only_agrees_with_the_standalone_proof() {
                 "the union must accept '{name}' — the dirty word is not part \
                  of its statement"
             );
-            assert!(
-                !standalone_ok,
-                "the standalone proof must reject '{name}'"
-            );
+            assert!(!standalone_ok, "the standalone proof must reject '{name}'");
         } else {
             assert_eq!(
                 union_ok, standalone_ok,
@@ -485,11 +499,7 @@ fn element_only_agrees_with_the_standalone_proof() {
             );
             // Every in-support tamper here is a RELATION violation, so both
             // provers' verdicts are also the expected ones.
-            assert_eq!(
-                union_ok,
-                tamper.is_none(),
-                "unexpected verdict on '{name}'"
-            );
+            assert_eq!(union_ok, tamper.is_none(), "unexpected verdict on '{name}'");
         }
     }
 }
@@ -556,12 +566,12 @@ fn dummy_row_is_structurally_invisible_under_the_union() {
     // (1b) DEBUG builds: the compaction's honest-witness assertion fires — the
     // prover refuses to build a stack whose dropped words are not zero.
     if cfg!(debug_assertions) {
-        let hook = std::panic::take_hook();
-        std::panic::set_hook(Box::new(|_| {}));
-        let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let hook = take_hook();
+        set_hook(Box::new(|_| {}));
+        let caught = catch_unwind(AssertUnwindSafe(|| {
             union.compact_witness(&z);
         }));
-        std::panic::set_hook(hook);
+        set_hook(hook);
         assert!(
             caught.is_err(),
             "compact_witness must reject a non-zero dropped word"
@@ -642,7 +652,7 @@ fn dummy_row_is_structurally_invisible_under_the_union() {
 /// `2^21` boolean region, a `2^17` element region based at `2^21`, `M = 22`.
 struct Mixed {
     registry: Registry,
-    blake3_r1cs: flock_core::r1cs::BlockR1cs,
+    blake3_r1cs: BlockR1cs,
     ty: Arc<ElementTableType>,
     w: (F128, F128),
 }
@@ -687,7 +697,10 @@ fn mixed_boolean_element_roundtrip_and_tamper() {
     let pcs_params = union_pcs_params(&union);
     // Region geometry the two PIOPs run over.
     assert_eq!(union.boolean_packed_len(), 1 << 14);
-    assert_eq!(union.element_word_range(), (1 << 14)..((1 << 14) + (1 << 10)));
+    assert_eq!(
+        union.element_word_range(),
+        (1 << 14)..((1 << 14) + (1 << 10))
+    );
     // Count-proportional dense area across BOTH classes.
     assert_eq!(
         union.dense_words(),
@@ -721,11 +734,16 @@ fn mixed_boolean_element_roundtrip_and_tamper() {
 
     let verify = |union: &UnionInstance<'_>,
                   params: &PcsParams,
-                  commitment: &flock_prover::pcs::Commitment,
+                  commitment: &Commitment,
                   proof: &R1csProofMixedClassMerged| {
         let mut ch = FsChallenger::new(DOMAIN);
         verifier::verify_ligerito_union_mixed_class(
-            union, &[circuit], commitment, proof, params, &mut ch,
+            union,
+            &[circuit],
+            commitment,
+            proof,
+            params,
+            &mut ch,
         )
     };
     let claims_v = verify(&union, &pcs_params, &commitment, &proof).expect("honest mixed proof");
@@ -878,8 +896,7 @@ fn mixed_boolean_element_roundtrip_and_tamper() {
     // (g) Truncated and bit-flipped proof bytes.
     {
         let bytes = bincode::serialize(&proof).expect("serialize");
-        let decoded: R1csProofMixedClassMerged =
-            bincode::deserialize(&bytes).expect("deserialize");
+        let decoded: R1csProofMixedClassMerged = bincode::deserialize(&bytes).expect("deserialize");
         assert_eq!(decoded, proof);
         assert!(verify(&union, &pcs_params, &commitment, &decoded).is_ok());
         for frac in [1usize, 2, 4, 8] {
@@ -1073,7 +1090,7 @@ fn boolean_only_mixed_class_matches_the_plain_entry() {
 // change with `ELEMENT_FIXTURES_PRINT=1 ... --nocapture`.
 // ---------------------------------------------------------------------------
 
-use sha2 as sha2_hash;
+use ::sha2 as sha2_hash;
 use sha2_hash::Digest as _;
 
 // Re-pinned 2026-08-02: multipoint-twisted assist (proof_io v8) — the
@@ -1084,7 +1101,7 @@ use sha2_hash::Digest as _;
 // merged-column scalar groups carrying ONE dual value each (128 -> 1 per
 // distinct row point); multipoint label v1.
 fn check(label: &str, expected: &str, got: String) {
-    if std::env::var_os("ELEMENT_FIXTURES_PRINT").is_some() {
+    if var_os("ELEMENT_FIXTURES_PRINT").is_some() {
         println!("(\"{label}\", \"{got}\"),");
         return;
     }
@@ -1097,8 +1114,8 @@ fn check(label: &str, expected: &str, got: String) {
 /// The MERGED mirror of [`bundle_digest`].
 fn bundle_digest_merged(
     proof: &R1csProofMixedClassMerged,
-    commitment: &flock_prover::pcs::Commitment,
-    claims: &flock_core::proof::UnionClassClaims,
+    commitment: &Commitment,
+    claims: &UnionClassClaims,
 ) -> String {
     let mut h = sha2_hash::Sha256::new();
     h.update(bincode::serialize(proof).expect("proof serializes"));
@@ -1138,15 +1155,43 @@ fn bundle_digest_merged(
 #[ignore] // Heavier — run with `-- --ignored`.
 fn mixed_class_merged_proof_bytes_pinned() {
     const ELEMENT_ONLY: [(&str, usize, &str); 3] = [
-        ("elem-merged-nu12-full", 1 << 12, "f8de0ecee28cb721807e8ee4e08d05ae5a1be6d8344106499c0148acb19514dc"),
-        ("elem-merged-nu12-2731", 2731, "742fda0fae0bb6cbc4f435dfb9e2dd5b3c0298dc395360d2b3102b07ed56fc94"),
-        ("elem-merged-nu12-0", 0, "7e67d3845c2293f9700df51b8ef0c2cc572ec6b4488caec93dc8c6575dc720f8"),
+        (
+            "elem-merged-nu12-full",
+            1 << 12,
+            "f8de0ecee28cb721807e8ee4e08d05ae5a1be6d8344106499c0148acb19514dc",
+        ),
+        (
+            "elem-merged-nu12-2731",
+            2731,
+            "742fda0fae0bb6cbc4f435dfb9e2dd5b3c0298dc395360d2b3102b07ed56fc94",
+        ),
+        (
+            "elem-merged-nu12-0",
+            0,
+            "7e67d3845c2293f9700df51b8ef0c2cc572ec6b4488caec93dc8c6575dc720f8",
+        ),
     ];
     const MIXED: [(&str, [usize; 2], &str); 4] = [
-        ("mix-merged-nu7-128-128", [128, 128], "f4454462c5453208c29f7b18ddf062a38760f49507208b282f2fec06de722b6d"),
-        ("mix-merged-nu7-100-90", [100, 90], "7ab07aaae81259e9bf50070eab3adbafa0bed5c4e6e36bcf068a09c234f2fd46"),
-        ("mix-merged-nu7-0-90", [0, 90], "18041290acbd4146f81ce8d8be37659586805ddc11d59a3ed72045badc2a838a"),
-        ("mix-merged-nu7-100-0", [100, 0], "a301490e89d165bf8a3f7cbd6c4596a0227b3b4883a0262ffe1c1baade0ec0ea"),
+        (
+            "mix-merged-nu7-128-128",
+            [128, 128],
+            "f4454462c5453208c29f7b18ddf062a38760f49507208b282f2fec06de722b6d",
+        ),
+        (
+            "mix-merged-nu7-100-90",
+            [100, 90],
+            "7ab07aaae81259e9bf50070eab3adbafa0bed5c4e6e36bcf068a09c234f2fd46",
+        ),
+        (
+            "mix-merged-nu7-0-90",
+            [0, 90],
+            "18041290acbd4146f81ce8d8be37659586805ddc11d59a3ed72045badc2a838a",
+        ),
+        (
+            "mix-merged-nu7-100-0",
+            [100, 0],
+            "a301490e89d165bf8a3f7cbd6c4596a0227b3b4883a0262ffe1c1baade0ec0ea",
+        ),
     ];
 
     let (w0, w1) = (F128::new(0x51F0, 0), F128::new(0, 0x2C7E));
@@ -1161,16 +1206,15 @@ fn mixed_class_merged_proof_bytes_pinned() {
         let mut rng = Rng::new(0xE1E_0000 ^ n as u64);
         let z = gate_witness(&ty, nu, n, w0, w1, &mut rng);
         let mut ch = FsChallenger::new(DOMAIN);
-        let (proof, commitment, claims) =
-            prover::prove_fast_ligerito_union_mixed_class(
-                &union,
-                &pcs_params,
-                Vec::new(),
-                vec![UnionElementSlotInput::new(move |dst: &mut [F128]| {
-                    dst.copy_from_slice(&z)
-                })],
-                &mut ch,
-            );
+        let (proof, commitment, claims) = prover::prove_fast_ligerito_union_mixed_class(
+            &union,
+            &pcs_params,
+            Vec::new(),
+            vec![UnionElementSlotInput::new(move |dst: &mut [F128]| {
+                dst.copy_from_slice(&z)
+            })],
+            &mut ch,
+        );
         check(
             label,
             expected,
@@ -1190,19 +1234,18 @@ fn mixed_class_merged_proof_bytes_pinned() {
         let inputs = random_blake3_inputs(&mut rng, n_bool);
         let z_elem = gate_witness(&m.ty, nu, n_elem, m.w.0, m.w.1, &mut rng);
         let mut ch = FsChallenger::new(DOMAIN);
-        let (proof, commitment, claims) =
-            prover::prove_fast_ligerito_union_mixed_class(
-                &union,
-                &pcs_params,
-                vec![UnionSlotProverInput::new(
-                    blake3::generate_witness_batch_major_partial(&inputs, nu),
-                    circuit,
-                )],
-                vec![UnionElementSlotInput::new(move |dst: &mut [F128]| {
-                    dst.copy_from_slice(&z_elem)
-                })],
-                &mut ch,
-            );
+        let (proof, commitment, claims) = prover::prove_fast_ligerito_union_mixed_class(
+            &union,
+            &pcs_params,
+            vec![UnionSlotProverInput::new(
+                blake3::generate_witness_batch_major_partial(&inputs, nu),
+                circuit,
+            )],
+            vec![UnionElementSlotInput::new(move |dst: &mut [F128]| {
+                dst.copy_from_slice(&z_elem)
+            })],
+            &mut ch,
+        );
         check(
             label,
             expected,
@@ -1323,9 +1366,7 @@ fn mixed_class_cost_probe() {
                     &u_bool,
                     &p_bool,
                     vec![UnionSlotProverInput::in_place(
-                        |dst| {
-                            blake3::generate_witness_batch_major_partial_into(&inputs, nu, dst)
-                        },
+                        |dst| blake3::generate_witness_batch_major_partial_into(&inputs, nu, dst),
                         circuit,
                     )],
                     Vec::new(),
@@ -1341,9 +1382,7 @@ fn mixed_class_cost_probe() {
                     &u_mixed,
                     &p_mixed,
                     vec![UnionSlotProverInput::in_place(
-                        |dst| {
-                            blake3::generate_witness_batch_major_partial_into(&inputs, nu, dst)
-                        },
+                        |dst| blake3::generate_witness_batch_major_partial_into(&inputs, nu, dst),
                         circuit,
                     )],
                     vec![UnionElementSlotInput::new(move |dst: &mut [F128]| {
@@ -1362,7 +1401,7 @@ fn mixed_class_cost_probe() {
                 let mut ar = vec![F128::ZERO; region_words];
                 let mut brr = vec![F128::ZERO; region_words];
                 let slot_words = ty.width() << nu;
-                flock_core::element_r1cs::union::fill_slot(
+                fill_slot(
                     &ty,
                     nu,
                     None,
@@ -1373,9 +1412,7 @@ fn mixed_class_cost_probe() {
                 );
                 let mut ch = FsChallenger::new(DOMAIN);
                 let t = Instant::now();
-                let _ = flock_core::element_r1cs::union::prove(
-                    &u_mixed, &zr, ar.clone(), brr.clone(), &mut ch,
-                );
+                let _ = prove(&u_mixed, &zr, ar.clone(), brr.clone(), &mut ch);
                 let ms_p = t.elapsed().as_secs_f64() * 1e3;
 
                 if rep > 0 {
@@ -1386,12 +1423,22 @@ fn mixed_class_cost_probe() {
                 // Correctness, every rep: both arms verify.
                 let mut ch = FsChallenger::new(DOMAIN);
                 verifier::verify_ligerito_union_mixed_class(
-                    &u_bool, &[circuit], &ca, &pa, &p_bool, &mut ch,
+                    &u_bool,
+                    &[circuit],
+                    &ca,
+                    &pa,
+                    &p_bool,
+                    &mut ch,
                 )
                 .expect("boolean-only arm verifies");
                 let mut ch = FsChallenger::new(DOMAIN);
                 verifier::verify_ligerito_union_mixed_class(
-                    &u_mixed, &[circuit], &cb, &pb, &p_mixed, &mut ch,
+                    &u_mixed,
+                    &[circuit],
+                    &cb,
+                    &pb,
+                    &p_mixed,
+                    &mut ch,
                 )
                 .expect("mixed arm verifies");
             }
@@ -1424,7 +1471,7 @@ element-PIOP {}",
     {
         let nu = 10usize;
         let reps = 5usize;
-        let sha2_r1cs = flock_prover::r1cs_hashes::sha2::build_block_r1cs(nu);
+        let sha2_r1cs = build_block_r1cs(nu);
         let blake3_r1cs = blake3::build_block_r1cs(nu);
         let two_hash = Registry::new(
             vec![
@@ -1442,11 +1489,7 @@ element-PIOP {}",
             nu,
         );
         // The hole, spelled out.
-        let s_bool: usize = two_hash
-            .slots()
-            .iter()
-            .map(|s| s.area())
-            .sum();
+        let s_bool: usize = two_hash.slots().iter().map(|s| s.area()).sum();
         assert_eq!(s_bool, 3 << 24);
         assert_eq!(two_hash.m_total(), 26);
         assert_eq!(plus_element.m_bool(), 26);
@@ -1463,13 +1506,8 @@ leaves a {} hole inside the 2^26 prefix subcube, but the element region \
         let n = 1usize << nu;
         let mut rng = Rng::new(0x0C05_2845);
         let b3_inputs = random_blake3_inputs(&mut rng, n);
-        let s2_inputs: Vec<flock_prover::r1cs_hashes::sha2::Compression> = (0..n)
-            .map(|_| {
-                (
-                    std::array::from_fn(|_| rng.next_u32()),
-                    std::array::from_fn(|_| rng.next_u32()),
-                )
-            })
+        let s2_inputs: Vec<Compression> = (0..n)
+            .map(|_| (from_fn(|_| rng.next_u32()), from_fn(|_| rng.next_u32())))
             .collect();
         let z_elem = gate_witness(&ty, nu, n, w0, w1, &mut rng);
         let s2_circuit = sha2_r1cs.csc_lincheck_circuit();
@@ -1485,10 +1523,7 @@ leaves a {} hole inside the 2^26 prefix subcube, but the element region \
             let bool_slots = || {
                 vec![
                     UnionSlotProverInput::in_place(
-                        |dst| {
-                            flock_prover::r1cs_hashes::sha2::
-                                generate_witness_batch_major_partial_into(&s2_inputs, nu, dst)
-                        },
+                        |dst| sha2::generate_witness_batch_major_partial_into(&s2_inputs, nu, dst),
                         s2_circuit,
                     ),
                     UnionSlotProverInput::in_place(
@@ -1599,14 +1634,13 @@ fn mixed_proofs_verify_over_the_merged_transport() {
 
     // Merged.
     let mut ch = FsChallenger::new(DOMAIN);
-    let (merged, commitment, claims_m) =
-        prover::prove_fast_ligerito_union_mixed_class(
-            &union,
-            &pcs_params,
-            vec![bool_slot()],
-            vec![elem_slot()],
-            &mut ch,
-        );
+    let (merged, commitment, claims_m) = prover::prove_fast_ligerito_union_mixed_class(
+        &union,
+        &pcs_params,
+        vec![bool_slot()],
+        vec![elem_slot()],
+        &mut ch,
+    );
     assert!(merged.boolean.is_some() && merged.element.is_some());
     let mut ch_v = FsChallenger::new(DOMAIN);
     let got = verifier::verify_ligerito_union_mixed_class(
@@ -1685,7 +1719,7 @@ fn element_only_proofs_verify_over_the_merged_transport() {
             .element_types()
             .iter()
             .map(|t| match &t.class {
-                flock_core::schedule::TableClass::LargeField(e) => e.clone(),
+                TableClass::LargeField(e) => e.clone(),
                 _ => unreachable!(),
             })
             .collect();
@@ -1699,22 +1733,19 @@ fn element_only_proofs_verify_over_the_merged_transport() {
         let element_slots = || -> Vec<UnionElementSlotInput<'_>> {
             witnesses
                 .iter()
-                .map(|w| {
-                    UnionElementSlotInput::new(move |dst: &mut [F128]| dst.copy_from_slice(w))
-                })
+                .map(|w| UnionElementSlotInput::new(move |dst: &mut [F128]| dst.copy_from_slice(w)))
                 .collect()
         };
 
         // Merged.
         let mut ch_p = FsChallenger::new(DOMAIN);
-        let (merged, commitment, claims_m) =
-            prover::prove_fast_ligerito_union_mixed_class(
-                &union,
-                &pcs_params,
-                Vec::new(),
-                element_slots(),
-                &mut ch_p,
-            );
+        let (merged, commitment, claims_m) = prover::prove_fast_ligerito_union_mixed_class(
+            &union,
+            &pcs_params,
+            Vec::new(),
+            element_slots(),
+            &mut ch_p,
+        );
         assert!(merged.boolean.is_none(), "no boolean class");
         assert!(
             merged.pcs_open.ring_switches.is_empty(),
@@ -1730,7 +1761,9 @@ fn element_only_proofs_verify_over_the_merged_transport() {
             &mut ch_v,
         )
         .unwrap_or_else(|e| {
-            panic!("merged rejected an honest element-only proof (nu={nu}, counts={counts:?}): {e:?}")
+            panic!(
+                "merged rejected an honest element-only proof (nu={nu}, counts={counts:?}): {e:?}"
+            )
         });
         assert_eq!(claims_v, claims_m);
     }

--- a/crates/flock-prover/tests/union_m6_fixtures.rs
+++ b/crates/flock-prover/tests/union_m6_fixtures.rs
@@ -32,6 +32,7 @@
 //! Re-pinned 2026-08-02: Merkle capping (proof_io v7): cap layers absorbed instead of roots (ObserveBytes 32 -> 32*2^c per commit absorb); octopus multi-proofs replaced by flat per-query capped paths.
 
 use ::sha2 as sha2_hash;
+use flock_core::pcs::ligerito::LigeritoProfile;
 use flock_core::proof::{R1csClaim, R1csProofMergedLigerito};
 use flock_prover::challenger::FsChallenger;
 use flock_prover::mixed::MixedRegistryId;
@@ -42,6 +43,8 @@ use flock_prover::r1cs_hashes::{blake3, sha2};
 use flock_prover::schedule::{Registry, TableType};
 use flock_prover::union::UnionInstance;
 use sha2_hash::Digest as _;
+use std::array::from_fn;
+use std::env::var_os;
 
 const DOMAIN: &[u8] = b"flock-m6-fixture-v0";
 
@@ -63,8 +66,8 @@ impl Rng {
 fn random_blake3_inputs(rng: &mut Rng, n: usize) -> Vec<blake3::Compression> {
     (0..n)
         .map(|_| {
-            let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-            let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+            let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+            let m: [u32; 16] = from_fn(|_| rng.next_u32());
             let counter = ((rng.next_u32() as u64) << 32) | (rng.next_u32() as u64);
             (cv, m, counter, 64u32, 11u32)
         })
@@ -73,12 +76,7 @@ fn random_blake3_inputs(rng: &mut Rng, n: usize) -> Vec<blake3::Compression> {
 
 fn random_sha2_inputs(rng: &mut Rng, n: usize) -> Vec<sha2::Compression> {
     (0..n)
-        .map(|_| {
-            (
-                std::array::from_fn(|_| rng.next_u32()),
-                std::array::from_fn(|_| rng.next_u32()),
-            )
-        })
+        .map(|_| (from_fn(|_| rng.next_u32()), from_fn(|_| rng.next_u32())))
         .collect()
 }
 
@@ -90,7 +88,7 @@ fn random_sha2_inputs(rng: &mut Rng, n: usize) -> Vec<sha2::Compression> {
 // dual value each); the multipoint label bumped to v1, so even the
 // boolean-only fixtures here (no packed-direct claims) move.
 fn check(label: &str, expected: &str, got: String) {
-    if std::env::var_os("M6_FIXTURES_PRINT").is_some() {
+    if var_os("M6_FIXTURES_PRINT").is_some() {
         println!("(\"{label}\", \"{got}\"),");
         return;
     }
@@ -172,7 +170,7 @@ fn m6_merged_union_proof_bytes_pinned() {
             m: union.dense_m(),
             log_inv_rate: 1,
             log_batch_size: 6,
-            profile: flock_core::pcs::ligerito::LigeritoProfile::Fast,
+            profile: LigeritoProfile::Fast,
             // The shipped union configuration (integer-lane commit).
             num_lanes: union.commit_lanes(6),
             merkle_hash: Default::default(),
@@ -241,12 +239,8 @@ fn m6_single_slot_merged_anchor_proof_bytes_pinned() {
             circuit,
         );
         let mut ch = FsChallenger::new(DOMAIN);
-        let (proof, commitment, claim) = prover::prove_fast_ligerito_union(
-            &union,
-            &setup.pcs_params,
-            vec![slot],
-            &mut ch,
-        );
+        let (proof, commitment, claim) =
+            prover::prove_fast_ligerito_union(&union, &setup.pcs_params, vec![slot], &mut ch);
         check(
             "merged-anchor-blake3-m22",
             EXPECTED,
@@ -273,12 +267,8 @@ fn m6_single_slot_merged_anchor_proof_bytes_pinned() {
             circuit,
         );
         let mut ch = FsChallenger::new(DOMAIN);
-        let (proof, commitment, claim) = prover::prove_fast_ligerito_union(
-            &union,
-            &setup.pcs_params,
-            vec![slot],
-            &mut ch,
-        );
+        let (proof, commitment, claim) =
+            prover::prove_fast_ligerito_union(&union, &setup.pcs_params, vec![slot], &mut ch);
         check(
             "merged-anchor-sha2-m22",
             EXPECTED,

--- a/crates/flock-prover/tests/union_mixed.rs
+++ b/crates/flock-prover/tests/union_mixed.rs
@@ -22,10 +22,17 @@
 
 use flock_core::field::F128;
 use flock_core::lincheck::LincheckCircuit;
+use flock_core::lincheck::VerifyError as LincheckVerifyError;
+use flock_core::pcs::commit;
+use flock_core::pcs::commit_lane_major;
 use flock_core::pcs::ligerito::LigeritoProfile;
 use flock_core::pcs::{PcsParams, VerifyErrorOpen};
 use flock_core::proof::R1csProofMergedLigerito;
 use flock_core::r1cs::BlockR1cs;
+use flock_core::scratch::give_f128;
+use flock_core::scratch::give_u8;
+use flock_core::scratch::prewarm_prover;
+use flock_core::scratch::prewarm_prover_union;
 use flock_core::union::SlotWitness;
 use flock_core::verifier::VerifyError;
 use flock_prover::challenger::FsChallenger;
@@ -34,6 +41,10 @@ use flock_prover::r1cs_hashes::{blake3, sha2};
 use flock_prover::schedule::{Registry, TableType};
 use flock_prover::union::UnionInstance;
 use flock_prover::verifier;
+use std::array::from_fn;
+use std::env::var;
+use std::sync::Mutex;
+use std::sync::MutexGuard;
 
 struct Rng(u64);
 impl Rng {
@@ -56,16 +67,16 @@ const DOMAIN: &[u8] = b"flock-mixed-e2e-v0";
 /// wall-clock reading (a single-shot arm measured 3x its quiet value) and
 /// occasionally trips the loose timing gates. Correctness tests stay
 /// parallel; only tests that assert or print wall times take this lock.
-fn timing_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+fn timing_lock() -> MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
     LOCK.lock().unwrap_or_else(|e| e.into_inner())
 }
 
 fn random_blake3_inputs(rng: &mut Rng, n: usize) -> Vec<blake3::Compression> {
     (0..n)
         .map(|_| {
-            let cv: [u32; 8] = std::array::from_fn(|_| rng.next_u32());
-            let m: [u32; 16] = std::array::from_fn(|_| rng.next_u32());
+            let cv: [u32; 8] = from_fn(|_| rng.next_u32());
+            let m: [u32; 16] = from_fn(|_| rng.next_u32());
             let counter = ((rng.next_u32() as u64) << 32) | (rng.next_u32() as u64);
             (cv, m, counter, 64u32, 11u32)
         })
@@ -74,12 +85,7 @@ fn random_blake3_inputs(rng: &mut Rng, n: usize) -> Vec<blake3::Compression> {
 
 fn random_sha2_inputs(rng: &mut Rng, n: usize) -> Vec<sha2::Compression> {
     (0..n)
-        .map(|_| {
-            (
-                std::array::from_fn(|_| rng.next_u32()),
-                std::array::from_fn(|_| rng.next_u32()),
-            )
-        })
+        .map(|_| (from_fn(|_| rng.next_u32()), from_fn(|_| rng.next_u32())))
         .collect()
 }
 
@@ -204,9 +210,9 @@ fn mixed_blake3_sha256_roundtrip_and_tamper() {
     // Mirrors the prover's dispatch: the integer-lane commit encodes only the
     // dense stack's nonzero high-bit lanes (`UnionInstance::commit_lanes`).
     let (comm_direct, _prover_data) = if pcs_params.num_lanes.is_some() {
-        flock_core::pcs::commit_lane_major(&q, &pcs_params)
+        commit_lane_major(&q, &pcs_params)
     } else {
-        flock_core::pcs::commit(&q, &pcs_params)
+        commit(&q, &pcs_params)
     };
     assert_eq!(
         commitment.cap, comm_direct.cap,
@@ -310,9 +316,7 @@ fn mixed_blake3_sha256_roundtrip_and_tamper() {
         let mut bad = proof.clone();
         bad.lincheck.rounds[0].0.lo ^= 1;
         match verify(&union, &bad) {
-            Err(VerifyError::Lincheck(flock_core::lincheck::VerifyError::ConsistencyFailed {
-                ..
-            })) => {}
+            Err(VerifyError::Lincheck(LincheckVerifyError::ConsistencyFailed { .. })) => {}
             other => panic!(
                 "tampered lincheck round: expected Lincheck(ConsistencyFailed), got {other:?}"
             ),
@@ -635,8 +639,8 @@ fn identity_compaction_roundtrips_over_the_merged_transport() {
 #[test]
 #[ignore] // Heavy + informational — run explicitly with --ignored --nocapture
 fn mixed_throughput_smoke() {
-    let _quiet = timing_lock();
     use std::time::Instant;
+    let _quiet = timing_lock();
 
     // ν = 10: 1024 invocations per type; mixed M = 26, singles at m = 24
     // (BLAKE3) / 25 (SHA-256).
@@ -663,12 +667,8 @@ fn mixed_throughput_smoke() {
             blake3::generate_witness_batch_major(&blake3_inputs, nu),
             b3_circuit,
         );
-        let _ = prover::prove_fast_ligerito_union(
-            &b3_union,
-            &b3_setup.pcs_params,
-            vec![slot],
-            &mut ch,
-        );
+        let _ =
+            prover::prove_fast_ligerito_union(&b3_union, &b3_setup.pcs_params, vec![slot], &mut ch);
         if timed {
             b3_ms = t.elapsed().as_secs_f64() * 1e3;
         }
@@ -687,12 +687,8 @@ fn mixed_throughput_smoke() {
             sha2::generate_witness_batch_major(&sha2_inputs, nu),
             s2_circuit,
         );
-        let _ = prover::prove_fast_ligerito_union(
-            &s2_union,
-            &s2_setup.pcs_params,
-            vec![slot],
-            &mut ch,
-        );
+        let _ =
+            prover::prove_fast_ligerito_union(&s2_union, &s2_setup.pcs_params, vec![slot], &mut ch);
         if timed {
             s2_ms = t.elapsed().as_secs_f64() * 1e3;
         }
@@ -702,7 +698,7 @@ fn mixed_throughput_smoke() {
     let (registry, sha2_r1cs, blake3_r1cs) = mixed_registry(nu);
     let union = UnionInstance::new(&registry, vec![n_per_type, n_per_type]);
     let pcs_params = union_pcs_params(&union);
-    flock_core::scratch::prewarm_prover(registry.m_total());
+    prewarm_prover(registry.m_total());
     let s2_mix_circuit = sha2_r1cs.csc_lincheck_circuit();
     let b3_mix_circuit = blake3_r1cs.csc_lincheck_circuit();
     let mut mixed_ms = 0.0;
@@ -754,15 +750,15 @@ fn mixed_throughput_smoke() {
 #[test]
 #[ignore] // Heavy + informational — run explicitly with --ignored --nocapture
 fn mixed_low_utilization_smoke() {
-    let _quiet = timing_lock();
     use std::time::Instant;
+    let _quiet = timing_lock();
 
     let nu = 10usize;
     let (registry, sha2_r1cs, blake3_r1cs) = mixed_registry(nu);
     let s2_circuit = sha2_r1cs.csc_lincheck_circuit();
     let b3_circuit = blake3_r1cs.csc_lincheck_circuit();
     let mut rng = Rng::new(0x05_31_77_77);
-    flock_core::scratch::prewarm_prover(registry.m_total());
+    prewarm_prover(registry.m_total());
 
     let mut results = Vec::new();
     for counts in [[8usize, 8usize], [1024, 1024]] {
@@ -904,10 +900,17 @@ fn capacity_sweep_m30_load() {
 }
 
 fn run_capacity_sweep(counts: [usize; 2], nus: &[usize]) {
+    // Per-config minima: [prove total, verify]. (The per-phase columns died
+    // with the jagged `_timed` entry; `PCS_TRACE=1` on the merged prover
+    // gives the per-phase attribution instead — see
+    // `merged_capacity_attribution`.)
+    const PROVE: usize = 0;
+    const VERIFY: usize = 1;
+    const PASSES: usize = 4;
     use std::time::Instant;
 
     let cfgs: Vec<_> = nus.iter().map(|&nu| mixed_registry(nu)).collect();
-    flock_core::scratch::prewarm_prover(cfgs.last().unwrap().0.m_total());
+    prewarm_prover(cfgs.last().unwrap().0.m_total());
 
     let mut rng = Rng::new(0xCA9A_C17F_5EED);
     let sha2_inputs = random_sha2_inputs(&mut rng, counts[0]);
@@ -932,15 +935,9 @@ fn run_capacity_sweep(counts: [usize; 2], nus: &[usize]) {
         }
     }
 
-    // Per-config minima: [prove total, verify]. (The per-phase columns died
-    // with the jagged `_timed` entry; `PCS_TRACE=1` on the merged prover
-    // gives the per-phase attribution instead — see
-    // `merged_capacity_attribution`.)
-    const PROVE: usize = 0;
-    const VERIFY: usize = 1;
     let mut mins = vec![[f64::INFINITY; 2]; nus.len()];
 
-    const PASSES: usize = 4; // pass 0 is an untimed warm-up
+    // pass 0 is an untimed warm-up
     for pass in 0..PASSES {
         let order: Vec<usize> = if pass % 2 == 0 {
             (0..nus.len()).collect()
@@ -1090,7 +1087,7 @@ fn merged_transport_roundtrip_and_tamper() {
         assert_eq!(claim_v, claim);
 
         // Tamper matrix over the transport's new pieces + one PIOP field.
-        let reject = |p: &flock_core::proof::R1csProofMergedLigerito, what: &str| {
+        let reject = |p: &R1csProofMergedLigerito, what: &str| {
             let mut ch_v = FsChallenger::new(DOMAIN);
             assert!(
                 verifier::verify_ligerito_union(
@@ -1239,13 +1236,13 @@ fn merged_transport_roundtrip_and_tamper() {
 #[test]
 #[ignore] // Heavy + informational — run explicitly with --ignored --nocapture
 fn merged_transport_m30_probe() {
-    let _quiet = timing_lock();
     use std::time::Instant;
     const COUNTS: [usize; 2] = [16384, 16384];
     const NUS: [usize; 3] = [14, 15, 16];
+    let _quiet = timing_lock();
 
     let cfgs: Vec<_> = NUS.iter().map(|&nu| mixed_registry(nu)).collect();
-    flock_core::scratch::prewarm_prover(cfgs.last().unwrap().0.m_total());
+    prewarm_prover(cfgs.last().unwrap().0.m_total());
     let mut rng = Rng::new(0x_4E_26_ED_30);
     let sha2_inputs = random_sha2_inputs(&mut rng, COUNTS[0]);
     let blake3_inputs = random_blake3_inputs(&mut rng, COUNTS[1]);
@@ -1264,7 +1261,9 @@ fn merged_transport_m30_probe() {
                     s2_circuit,
                 ),
                 UnionSlotProverInput::in_place(
-                    |dst| blake3::generate_witness_batch_major_partial_into(&blake3_inputs, nu, dst),
+                    |dst| {
+                        blake3::generate_witness_batch_major_partial_into(&blake3_inputs, nu, dst)
+                    },
                     b3_circuit,
                 ),
             ];
@@ -1294,7 +1293,11 @@ fn merged_transport_m30_probe() {
     }
     println!("merged m30 probe, counts {COUNTS:?} (min of 2, ms, prove incl. witgen):");
     for (i, &nu) in NUS.iter().enumerate() {
-        println!("  nu = {nu} (M = {}): merged {:.1}", cfgs[i].0.m_total(), mins[i]);
+        println!(
+            "  nu = {nu} (M = {}): merged {:.1}",
+            cfgs[i].0.m_total(),
+            mins[i]
+        );
     }
     // The capacity-free design claim, now as an ABSOLUTE flatness bound (the
     // jagged comparator is gone — its final A/B record, 2026-08-02 on this
@@ -1318,15 +1321,16 @@ fn merged_transport_m30_probe() {
 #[test]
 #[ignore] // Heavy + informational — run explicitly with --ignored --nocapture
 fn merged_capacity_attribution() {
-    let _quiet = timing_lock();
     use std::time::Instant;
     const COUNTS: [usize; 2] = [16384, 16384];
+    let _quiet = timing_lock();
+
     // Tier list, overridable so a tier can be measured in ISOLATION
     // (`FLOCK_PROBE_NUS=18`). Required above nu = 16: the later tiers touch
     // GBs, and both the heat and the mid-run pool prewarms they leave behind
     // read back as several ms on whatever runs after them in the same
     // process. Citable per-tier numbers come from separate invocations.
-    let nus: Vec<usize> = match std::env::var("FLOCK_PROBE_NUS") {
+    let nus: Vec<usize> = match var("FLOCK_PROBE_NUS") {
         Ok(s) => s
             .split(',')
             .map(|t| {
@@ -1359,12 +1363,12 @@ fn merged_capacity_attribution() {
         let s2_circuit = sha2_r1cs.csc_lincheck_circuit();
         let b3_circuit = blake3_r1cs.csc_lincheck_circuit();
         let union = UnionInstance::new(registry, COUNTS.to_vec());
-        match std::env::var("FLOCK_PROBE_PREWARM").as_deref() {
+        match var("FLOCK_PROBE_PREWARM").as_deref() {
             Ok("0") => {}
             // The old shape: whole set sized off the PADDED m. Kept behind the
             // knob as the A/B arm that shows why it is wrong above nu = 16.
-            Ok("m") => flock_core::scratch::prewarm_prover(registry.m_total()),
-            _ => flock_core::scratch::prewarm_prover_union(registry.m_total(), union.dense_m()),
+            Ok("m") => prewarm_prover(registry.m_total()),
+            _ => prewarm_prover_union(registry.m_total(), union.dense_m()),
         }
         let pcs_params = union_pcs_params(&union);
         // Timed passes, `FLOCK_PROBE_PASSES` (default 3; pass 0 is an untimed
@@ -1375,7 +1379,7 @@ fn merged_capacity_attribution() {
         // and more samples strictly help. Long inter-process cooldowns do not:
         // they were sized for a heat model that the gate disproved (it returns
         // to the cold band with zero cooldown).
-        let passes: usize = std::env::var("FLOCK_PROBE_PASSES")
+        let passes: usize = var("FLOCK_PROBE_PASSES")
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(3);
@@ -1397,12 +1401,8 @@ fn merged_capacity_attribution() {
             ];
             let mut ch = FsChallenger::new(DOMAIN);
             let t = Instant::now();
-            let (_p, _c, _cl) = prover::prove_fast_ligerito_union(
-                &union,
-                &pcs_params,
-                slots,
-                &mut ch,
-            );
+            let (_p, _c, _cl) =
+                prover::prove_fast_ligerito_union(&union, &pcs_params, slots, &mut ch);
             let ms = t.elapsed().as_secs_f64() * 1e3;
             if pass == 0 {
                 // The genuine ONE-SHOT cost: nothing resident, every buffer
@@ -1465,10 +1465,10 @@ fn merged_padding_unread_poison_pool() {
         let len = union.packed_len();
         let poison = F128::new(0xDEAD_BEEF_DEAD_BEEF, 0xDEAD_BEEF_DEAD_BEEF);
         for _ in 0..6 {
-            flock_core::scratch::give_f128(vec![poison; len]);
+            give_f128(vec![poison; len]);
         }
         for _ in 0..4 {
-            flock_core::scratch::give_u8(vec![0xAD; 1 << 20]);
+            give_u8(vec![0xAD; 1 << 20]);
         }
         let (p2, c2, cl2) = prove();
         assert_eq!(c1.cap, c2.cap, "commitment must ignore dropped words");
@@ -1476,15 +1476,8 @@ fn merged_padding_unread_poison_pool() {
         assert_eq!(cl1, cl2);
         let circuits: [&dyn LincheckCircuit; 2] = [s2_circuit, b3_circuit];
         let mut chv = FsChallenger::new(DOMAIN);
-        verifier::verify_ligerito_union(
-            &union,
-            &circuits,
-            &c2,
-            &p2,
-            &pcs_params,
-            &mut chv,
-        )
-        .expect("poison-pool proof verifies");
+        verifier::verify_ligerito_union(&union, &circuits, &c2, &p2, &pcs_params, &mut chv)
+            .expect("poison-pool proof verifies");
     }
 }
 
@@ -1590,10 +1583,11 @@ fn in_place_generation_matches_prebuilt_byte_identical() {
 #[test]
 #[ignore] // Heavy (M = 30, ~2 GB) + informational — run explicitly with --ignored --nocapture
 fn mixed_m30_throughput() {
-    let _quiet = timing_lock();
     use std::time::Instant;
+    const ITERS: usize = 2;
+    let _quiet = timing_lock();
 
-    const ITERS: usize = 2; // timed runs after one warm-up; best reported
+    // timed runs after one warm-up; best reported
     let nu = 14usize; // M = 30; full utilization = 16384 invocations per type
     let n_per_type = 1usize << nu;
     let mut rng = Rng::new(0x30_31_2B_B3);
@@ -1615,12 +1609,8 @@ fn mixed_m30_throughput() {
                 circuit,
             );
             let mut ch = FsChallenger::new(DOMAIN);
-            let _ = prover::prove_fast_ligerito_union(
-                &union,
-                &setup.pcs_params,
-                vec![slot],
-                &mut ch,
-            );
+            let _ =
+                prover::prove_fast_ligerito_union(&union, &setup.pcs_params, vec![slot], &mut ch);
         }
         let mut best = f64::INFINITY;
         for _ in 0..ITERS {
@@ -1630,12 +1620,8 @@ fn mixed_m30_throughput() {
                 blake3::generate_witness_batch_major(&blake3_inputs, nu),
                 circuit,
             );
-            let _ = prover::prove_fast_ligerito_union(
-                &union,
-                &setup.pcs_params,
-                vec![slot],
-                &mut ch,
-            );
+            let _ =
+                prover::prove_fast_ligerito_union(&union, &setup.pcs_params, vec![slot], &mut ch);
             best = best.min(t.elapsed().as_secs_f64() * 1e3);
         }
         (best, setup.m())
@@ -1655,12 +1641,8 @@ fn mixed_m30_throughput() {
                 circuit,
             );
             let mut ch = FsChallenger::new(DOMAIN);
-            let _ = prover::prove_fast_ligerito_union(
-                &union,
-                &setup.pcs_params,
-                vec![slot],
-                &mut ch,
-            );
+            let _ =
+                prover::prove_fast_ligerito_union(&union, &setup.pcs_params, vec![slot], &mut ch);
         }
         let mut best = f64::INFINITY;
         for _ in 0..ITERS {
@@ -1670,12 +1652,8 @@ fn mixed_m30_throughput() {
                 sha2::generate_witness_batch_major(&sha2_inputs, nu),
                 circuit,
             );
-            let _ = prover::prove_fast_ligerito_union(
-                &union,
-                &setup.pcs_params,
-                vec![slot],
-                &mut ch,
-            );
+            let _ =
+                prover::prove_fast_ligerito_union(&union, &setup.pcs_params, vec![slot], &mut ch);
             best = best.min(t.elapsed().as_secs_f64() * 1e3);
         }
         (best, setup.m())
@@ -1695,7 +1673,7 @@ fn mixed_m30_throughput() {
     assert_eq!(union.dense_m(), 30);
     assert_eq!(union.committed_words(), union.packed_len());
     assert_eq!(pcs_params.m, 30);
-    flock_core::scratch::prewarm_prover(registry.m_total());
+    prewarm_prover(registry.m_total());
     let s2_mix_circuit = sha2_r1cs.csc_lincheck_circuit();
     let b3_mix_circuit = blake3_r1cs.csc_lincheck_circuit();
     {
@@ -1813,10 +1791,11 @@ fn mixed_m30_throughput() {
 #[test]
 #[ignore] // Heavy (m = 30, ~2 GB) + informational — run explicitly with --ignored --nocapture
 fn two_blake3_tables_vs_direct() {
-    let _quiet = timing_lock();
     use std::time::Instant;
+    const ITERS: usize = 2;
+    let _quiet = timing_lock();
 
-    const ITERS: usize = 2; // timed runs after one warm-up; best reported
+    // timed runs after one warm-up; best reported
     let n_total = 1usize << 16; // 2N = 65536 total BLAKE3 compressions
 
     // Shared inputs: 65536 BLAKE3 compressions. The two-table row proves the
@@ -1914,7 +1893,7 @@ fn two_blake3_tables_vs_direct() {
         assert_eq!(union.dense_m(), 30);
         assert_eq!(pcs_params.m, 30);
         let circuit = b3_r1cs.csc_lincheck_circuit();
-        flock_core::scratch::prewarm_prover(registry.m_total());
+        prewarm_prover(registry.m_total());
         let (lo, hi) = blake3_inputs.split_at(n_per);
         // Untimed warm-up.
         {
@@ -1943,15 +1922,8 @@ fn two_blake3_tables_vs_direct() {
         let circuits: [&dyn LincheckCircuit; 2] = [circuit, circuit];
         let t = Instant::now();
         let mut ch = FsChallenger::new(DOMAIN);
-        verifier::verify_ligerito_union(
-            &union,
-            &circuits,
-            &comm,
-            &proof,
-            &pcs_params,
-            &mut ch,
-        )
-        .expect("union two-table verify rejected honest proof");
+        verifier::verify_ligerito_union(&union, &circuits, &comm, &proof, &pcs_params, &mut ch)
+            .expect("union two-table verify rejected honest proof");
         let v_ms = t.elapsed().as_secs_f64() * 1e3;
         (best, bytes, v_ms, union.committed_words())
     };
@@ -1969,7 +1941,7 @@ fn two_blake3_tables_vs_direct() {
         assert_eq!(union.dense_m(), 30);
         assert_eq!(pcs_params.m, 30);
         let circuit = b3_r1cs.csc_lincheck_circuit();
-        flock_core::scratch::prewarm_prover(registry.m_total());
+        prewarm_prover(registry.m_total());
         // Untimed warm-up.
         {
             let slots = vec![UnionSlotProverInput::new(
@@ -1997,22 +1969,14 @@ fn two_blake3_tables_vs_direct() {
         let circuits: [&dyn LincheckCircuit; 1] = [circuit];
         let t = Instant::now();
         let mut ch = FsChallenger::new(DOMAIN);
-        verifier::verify_ligerito_union(
-            &union,
-            &circuits,
-            &comm,
-            &proof,
-            &pcs_params,
-            &mut ch,
-        )
-        .expect("union single-table verify rejected honest proof");
+        verifier::verify_ligerito_union(&union, &circuits, &comm, &proof, &pcs_params, &mut ch)
+            .expect("union single-table verify rejected honest proof");
         let v_ms = t.elapsed().as_secs_f64() * 1e3;
         (best, bytes, v_ms, union.committed_words())
     };
 
     // ---- Report.
-    let committed_all_equal =
-        direct_committed == u2_committed && u2_committed == u1_committed;
+    let committed_all_equal = direct_committed == u2_committed && u2_committed == u1_committed;
     println!(
         "\ntwo-blake3-table control: 2N = {n_total} total invocations, \
          best-of-{ITERS} (prove incl. witgen)\n"

--- a/crates/flock-prover/tests/verifier_roundtrip.rs
+++ b/crates/flock-prover/tests/verifier_roundtrip.rs
@@ -9,6 +9,7 @@ use flock_prover::pcs::{self, PcsParams};
 use flock_prover::prover::prove_ligerito;
 use flock_prover::r1cs::{BlockR1cs, SparseBinaryMatrix, WitnessLayout};
 use flock_prover::verifier::{self, VerifyError};
+use std::sync::OnceLock;
 
 struct Rng(u64);
 impl Rng {
@@ -47,8 +48,8 @@ fn identity_r1cs(m: usize, k_log: usize, k_skip: usize, useful_bits: usize) -> B
         c_0: identity(1 << k_log),
         layout: WitnessLayout::RowMajor,
         const_pin: None,
-        digest_cache: std::sync::OnceLock::new(),
-        csc_cache: std::sync::OnceLock::new(),
+        digest_cache: OnceLock::new(),
+        csc_cache: OnceLock::new(),
     }
 }
 

--- a/crates/flock-prover/tests/wiring_scaling.rs
+++ b/crates/flock-prover/tests/wiring_scaling.rs
@@ -17,6 +17,8 @@
 //! Isolated on purpose — `prove_wiring` is timed on its own rather than
 //! inside a full prove, so nothing else moves.
 
+use flock_core::circuit::prove_wiring;
+use std::hint::black_box;
 use std::time::Instant;
 
 use flock_core::circuit::builder::{GateType, ShapeBuilder, SlotWitness};
@@ -106,18 +108,13 @@ fn wiring_cost_across_mu() {
         // Warm once — the first call pays pooled-buffer faults.
         {
             let mut ch = FsChallenger::new(b"wiring-scaling");
-            std::hint::black_box(flock_core::circuit::prove_wiring(
-                &shape.circuit,
-                &packed,
-                &public,
-                &mut ch,
-            ));
+            black_box(prove_wiring(&shape.circuit, &packed, &public, &mut ch));
         }
         let mut ch = FsChallenger::new(b"wiring-scaling");
         let t = Instant::now();
-        let out = flock_core::circuit::prove_wiring(&shape.circuit, &packed, &public, &mut ch);
+        let out = prove_wiring(&shape.circuit, &packed, &public, &mut ch);
         let ms = t.elapsed().as_secs_f64() * 1e3;
-        std::hint::black_box(out);
+        black_box(out);
 
         let factor = match prev {
             Some((pmu, pms)) if mu == pmu + 1 => format!("{:.2}", ms / pms),


### PR DESCRIPTION
## Summary

- Clean up import paths across the Flock crates.
- Update related tests, benchmarks, examples, and documentation.

## Testing

Not run (not requested)